### PR TITLE
PolicyInsights Breaking Change Notice

### DIFF
--- a/src/PolicyInsights/PolicyInsights/ChangeLog.md
+++ b/src/PolicyInsights/PolicyInsights/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Added Breaking Change notifications to many of the cmdlets in Az.PolicyInsights.
 
 ## Version 1.7.3
 * Updated Azure.Core from 1.47.3 to 1.50.0

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/GetAzureRmPolicyAttestation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/GetAzureRmPolicyAttestation.cs
@@ -12,29 +12,38 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Microsoft.Azure.Commands.Common.Exceptions;
 using Microsoft.Azure.Commands.PolicyInsights.Common;
+using Microsoft.Azure.Commands.PolicyInsights.Models;
+using Microsoft.Azure.Commands.PolicyInsights.Models.Attestations;
 using Microsoft.Azure.Commands.PolicyInsights.Models.Remediation;
+using Microsoft.Azure.Commands.PolicyInsights.Properties;
 using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Management.Internal.Resources.Models;
-using Microsoft.Azure.Management.PolicyInsights.Models;
 using Microsoft.Azure.Management.PolicyInsights;
+using Microsoft.Azure.Management.PolicyInsights.Models;
+using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation;
 using System.Text;
-using Microsoft.Azure.Commands.PolicyInsights.Properties;
-using Microsoft.Azure.Commands.PolicyInsights.Models;
-using System.Linq;
-using Microsoft.Azure.Commands.PolicyInsights.Models.Attestations;
-using Microsoft.Azure.Commands.Common.Exceptions;
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Attestations
 {
     /// <summary>
     /// Gets policy attestations.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSAttestation),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Attestation",
+        DeprecatedOutputProperties = new string[] { "SystemData" },
+        NewOutputProperties = new string[] { "ResourceGroupName", "SystemDataCreatedAt", "SystemDataCreatedBy", "SystemDataCreatedByType", "SystemDataLastModifiedAt", "SystemDataLastModifiedBy", "SystemDataLastModifiedByType" }
+    )]
     [Cmdlet(VerbsCommon.Get, AzureRMConstants.AzureRMPrefix + "PolicyAttestation", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PSAttestation))]
     public class GetAzureRmPolicyAttestation : AttestationCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/NewAzureRmPolicyAttestation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/NewAzureRmPolicyAttestation.cs
@@ -20,7 +20,7 @@ using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Management.PolicyInsights;
 using Microsoft.Azure.Management.PolicyInsights.Models;
-
+using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using System;
 using System.Globalization;
 using System.Linq;
@@ -31,6 +31,14 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Attestations
     /// <summary>
     /// Creates a new Policy Attestation
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSAttestation),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Attestation",
+        DeprecatedOutputProperties = new string[] { "SystemData" },
+        NewOutputProperties = new string[] { "ResourceGroupName", "SystemDataCreatedAt", "SystemDataCreatedBy", "SystemDataCreatedByType", "SystemDataLastModifiedAt", "SystemDataLastModifiedBy", "SystemDataLastModifiedByType" }
+    )]
     [Cmdlet(VerbsCommon.New, AzureRMConstants.AzureRMPrefix + "PolicyAttestation", DefaultParameterSetName = ParameterSetNames.ByName, SupportsShouldProcess = true), OutputType(typeof(PSAttestation))]
     public class NewAzureRmPolicyAttestation : AttestationCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/SetAzureRmPolicyAttestation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Attestations/SetAzureRmPolicyAttestation.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
 using Microsoft.Azure.Management.PolicyInsights;
 using Microsoft.Azure.Management.PolicyInsights.Models;
+using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System;
 using System.Collections.Generic;
@@ -34,6 +35,14 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Attestations
     /// <summary>
     /// Updates a policy attestation.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSAttestation),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Attestation",
+        DeprecatedOutputProperties = new string[] { "SystemData" },
+        NewOutputProperties = new string[] { "ResourceGroupName", "SystemDataCreatedAt", "SystemDataCreatedBy", "SystemDataCreatedByType", "SystemDataLastModifiedAt", "SystemDataLastModifiedBy", "SystemDataLastModifiedByType" }
+    )]
     [Cmdlet(verbName: VerbsCommon.Set, AzureRMConstants.AzureRMPrefix + "PolicyAttestation", DefaultParameterSetName = ParameterSetNames.ByName, SupportsShouldProcess = true), OutputType(typeof(PSAttestation))]
     public class SetAzureRmPolicyAttestation : AttestationCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzPolicyMetadata.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzPolicyMetadata.cs
@@ -14,19 +14,27 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets
 {
-    using System.Linq;
-    using System.Management.Automation;
-    using System.Threading;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common;
     using Microsoft.Azure.Management.PolicyInsights;
     using Microsoft.Azure.Management.PolicyInsights.Models;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
     using Microsoft.WindowsAzure.Commands.Utilities.Common;
+    using System.Linq;
+    using System.Management.Automation;
+    using System.Threading;
 
     /// <summary>
     /// Gets policy metadata.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSPolicyMetadata),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "PolicyMetadata",
+        NewOutputProperties = new string[] { "ResourceGroupName" }
+    )]
     [Cmdlet("Get", AzureRMConstants.AzureRMPrefix + "PolicyMetadata"), OutputType(typeof(PSPolicyMetadata))]
     public class GetAzPolicyMetadata : PolicyInsightsCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyEvent.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyEvent.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets
         deprecateByVersion: "2.0.0",
         DeprecatedOutputProperties = new string[] { "ResourceTags", "ManagementGroupIds" },
         NewOutputProperties = new string[] { "ResourceTag", "ManagementGroupId", "ComplianceState", "Component", "EffectiveParameter", "OdataContext", "OdataId",
-            "Keys", "Vales", "Count", "AdditionalProperties" }
+            "Keys", "Values", "Count", "AdditionalProperties" }
     )]
     [Cmdlet("Get", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "PolicyEvent", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PolicyEvent))]
     public class GetAzureRmPolicyEvent : PolicyInsightsCmdletBase

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyEvent.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyEvent.cs
@@ -14,19 +14,28 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Management.Automation;
     using RestApiModels = Microsoft.Azure.Management.PolicyInsights.Models;
 
     /// <summary>
     /// Gets policy events
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PolicyEvent),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        DeprecatedOutputProperties = new string[] { "ResourceTags", "ManagementGroupIds" },
+        NewOutputProperties = new string[] { "ResourceTag", "ManagementGroupId", "ComplianceState", "Component", "EffectiveParameter", "OdataContext", "OdataId",
+            "Keys", "Vales", "Count", "AdditionalProperties" }
+    )]
     [Cmdlet("Get", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "PolicyEvent", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PolicyEvent))]
     public class GetAzureRmPolicyEvent : PolicyInsightsCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyState.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyState.cs
@@ -14,19 +14,27 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Management.Automation;
     using RestApiModels = Microsoft.Azure.Management.PolicyInsights.Models;
 
     /// <summary>
     /// Gets policy states
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PolicyState),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        DeprecatedOutputProperties = new string[] { "ResourceTags", "ManagementGroupIds" },
+        NewOutputProperties = new string[] { "ResourceGroupName", "ResourceTag", "ManagementGroupId" }
+    )]
     [Cmdlet("Get", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "PolicyState", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PolicyState))]
     public class GetAzureRmPolicyState : PolicyInsightsCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyStateSummary.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/GetAzureRmPolicyStateSummary.cs
@@ -14,19 +14,28 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Management.Automation;
     using RestApiModels = Microsoft.Azure.Management.PolicyInsights.Models;
 
     /// <summary>
     /// Gets policy states
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PolicyStateSummary),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        DeprecatedOutputProperties = new string[] { "PolicyAssignments", "Results" },
+        NewOutputProperties = new string[] { "PolicyAssignment", "ResultCompliantResource", "ResultNonCompliantPolicy", "ResultNonCompliantResource", "ResultPolicyDetail",
+            "ResultPolicyGroupDetail", "ResultQueryResultsUri", "ResultResourceDetail", "OdataId", "OdataContext" }
+    )]
     [Cmdlet("Get", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "PolicyStateSummary", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PolicyStateSummary))]
     public class GetAzureRmPolicyStateSummary : PolicyInsightsCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/GetAzureRmPolicyRemediation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/GetAzureRmPolicyRemediation.cs
@@ -14,9 +14,6 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models.Remediation;
     using Microsoft.Azure.Commands.PolicyInsights.Properties;
@@ -24,11 +21,24 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
     using Microsoft.Azure.Management.PolicyInsights.Models;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
     using Microsoft.WindowsAzure.Commands.Utilities.Common;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Management.Automation;
 
     /// <summary>
     /// Gets policy remediations.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSRemediation),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Remediation",
+        DeprecatedOutputProperties = new string[] { "Filters", "DeploymentSummary", "FailureThreshold", "ParallelDeployments" },
+        NewOutputProperties = new string[] { "FilterLocation", "FilterResourceId", "DeploymentStatusFailedDeployment", "DeploymentStatusSuccessfulDeployment", "DeploymentStatusTotalDeployment", "FailureThresholdPercentage", "ParallelDeployment",
+            "ResourceGroupName", "SystemDataCreatedAt", "SystemDataCreatedBy", "SystemDataCreatedByType", "SystemDataLastModifiedAt", "SystemDataLastModifiedBy", "SystemDataLastModifiedByType" }
+    )]
     [Cmdlet("Get", AzureRMConstants.AzureRMPrefix + "PolicyRemediation", DefaultParameterSetName = ParameterSetNames.SubscriptionScope), OutputType(typeof(PSRemediation))]
     public class GetAzureRmPolicyRemediation : RemediationCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StartAzureRmPolicyRemediation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StartAzureRmPolicyRemediation.cs
@@ -14,9 +14,6 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
 {
-    using System.Globalization;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models.Remediation;
     using Microsoft.Azure.Commands.PolicyInsights.Properties;
@@ -24,10 +21,24 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
     using Microsoft.Azure.Management.PolicyInsights.Models;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+    using System.Globalization;
+    using System.Linq;
+    using System.Management.Automation;
 
     /// <summary>
     /// Creates and starts a policy remediation.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(PSRemediation),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Remediation",
+        DeprecatedOutputProperties = new string[] { "Filters", "DeploymentSummary", "FailureThreshold", "ParallelDeployments" },
+        NewOutputProperties = new string[] { "FilterLocation", "FilterResourceId", "DeploymentStatusFailedDeployment", "DeploymentStatusSuccessfulDeployment", "DeploymentStatusTotalDeployment", "FailureThresholdPercentage", "ParallelDeployment",
+            "ResourceGroupName", "SystemDataCreatedAt", "SystemDataCreatedBy", "SystemDataCreatedByType", "SystemDataLastModifiedAt", "SystemDataLastModifiedBy", "SystemDataLastModifiedByType" },
+        ChangeDescription = "Start-AzPolicyRemediation will now return when the Remediation reaches a terminal state unless you use the new NoWait parameter."
+    )]
     [Cmdlet("Start", AzureRMConstants.AzureRMPrefix + "PolicyRemediation", DefaultParameterSetName = ParameterSetNames.ByName, SupportsShouldProcess = true), OutputType(typeof(PSRemediation))]
     public class StartAzureRmPolicyRemediation : RemediationCmdletBase
     {

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StopAzureRmPolicyRemediation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StopAzureRmPolicyRemediation.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
         deprecateByAzVersion: "16.0.0",
         deprecateByVersion: "2.0.0",
         ReplacementCmdletOutputTypeName = "Remediation",
-        ChangeDescription = "Stop-AzPolicyRemediation will now have a NoWait switch parameter."
+        ChangeDescription = "Stop-AzPolicyRemediation will now have a NoWait switch parameter as well as returning the Remediation object instead of just a boolean."
     )]
     [Cmdlet("Stop", AzureRMConstants.AzureRMPrefix + "PolicyRemediation", DefaultParameterSetName = ParameterSetNames.ByName, SupportsShouldProcess = true), OutputType(typeof(bool))]
     public class StopAzureRmPolicyRemediation : RemediationCmdletBase

--- a/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StopAzureRmPolicyRemediation.cs
+++ b/src/PolicyInsights/PolicyInsights/Cmdlets/Remediation/StopAzureRmPolicyRemediation.cs
@@ -14,19 +14,27 @@
 
 namespace Microsoft.Azure.Commands.PolicyInsights.Cmdlets.Remediation
 {
-    using System.Globalization;
-    using System.Linq;
-    using System.Management.Automation;
     using Microsoft.Azure.Commands.PolicyInsights.Common;
     using Microsoft.Azure.Commands.PolicyInsights.Models.Remediation;
     using Microsoft.Azure.Commands.PolicyInsights.Properties;
     using Microsoft.Azure.Commands.ResourceManager.Common;
     using Microsoft.Azure.Commands.ResourceManager.Common.ArgumentCompleters;
     using Microsoft.Azure.Management.PolicyInsights;
+    using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+    using System.Globalization;
+    using System.Linq;
+    using System.Management.Automation;
 
     /// <summary>
     /// Cancels a policy remediation.
     /// </summary>
+    [CmdletOutputBreakingChangeWithVersion(
+        typeof(bool),
+        deprecateByAzVersion: "16.0.0",
+        deprecateByVersion: "2.0.0",
+        ReplacementCmdletOutputTypeName = "Remediation",
+        ChangeDescription = "Stop-AzPolicyRemediation will now have a NoWait switch parameter."
+    )]
     [Cmdlet("Stop", AzureRMConstants.AzureRMPrefix + "PolicyRemediation", DefaultParameterSetName = ParameterSetNames.ByName, SupportsShouldProcess = true), OutputType(typeof(bool))]
     public class StopAzureRmPolicyRemediation : RemediationCmdletBase
     {


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Adding a breaking change notice for the PolicyInsights cmdlets. 

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
