### PR TITLE
Add per-principal support to New-AzDenyAssignment

### DIFF
--- a/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.cs
+++ b/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Commands.Resources.Test.ScenarioTests
 {
     /// <summary>
     /// Tests for New-AzDenyAssignment and Remove-AzDenyAssignment cmdlets.
-    /// PP1 model: principals = Everyone (SystemDefined), excludePrincipals required.
+    /// Covers both Everyone mode and per-principal (User/ServicePrincipal) mode.
     /// </summary>
     public class DenyAssignmentCrudTests : ResourcesTestRunner
     {
@@ -79,6 +79,52 @@ namespace Microsoft.Azure.Commands.Resources.Test.ScenarioTests
         public void NewDaWithCustomId()
         {
             TestRunner.RunTestScript("Test-NewDaWithCustomId");
+        }
+
+        // =============================================
+        // Per-Principal deny assignment tests
+        // =============================================
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaWithUserPrincipal()
+        {
+            TestRunner.RunTestScript("Test-NewDaWithUserPrincipal");
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaWithServicePrincipal()
+        {
+            TestRunner.RunTestScript("Test-NewDaWithServicePrincipal");
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaPerPrincipalNoExcludes()
+        {
+            TestRunner.RunTestScript("Test-NewDaPerPrincipalNoExcludes");
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaPerPrincipalWithExcludes()
+        {
+            TestRunner.RunTestScript("Test-NewDaPerPrincipalWithExcludes");
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaPerPrincipalGroupRejected()
+        {
+            TestRunner.RunTestScript("Test-NewDaPerPrincipalGroupRejected");
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.LiveOnly)]
+        public void NewDaPerPrincipalFromInputFile()
+        {
+            TestRunner.RunTestScript("Test-NewDaPerPrincipalFromInputFile");
         }
 
         // =============================================

--- a/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.ps1
+++ b/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.ps1
@@ -14,7 +14,7 @@
 
 # Scenario tests for New-AzDenyAssignment and Remove-AzDenyAssignment
 
-# Helper: Get a valid user principal ID for the exclude list.
+# Helper: Get a valid user principal ID for the exclude list / per-principal tests.
 # In Record mode with SP auth, Graph API calls (Get-AzADUser) may fail
 # due to insufficient permissions. Use the known tenant admin user ID.
 function Get-TestExcludePrincipalId
@@ -31,9 +31,10 @@ function Get-TestExcludePrincipalId
     }
 }
 #
-# PP1 API model:
-#   - Principals must be Everyone (SystemDefined with Guid.Empty)
-#   - ExcludePrincipals is required (at least one)
+# UADA API model:
+#   - Principals can be Everyone (SystemDefined with Guid.Empty) or a specific User/ServicePrincipal
+#   - ExcludePrincipals is required for Everyone mode; optional for per-principal mode
+#   - Group type principals are not supported
 #   - DataActions not supported
 #   - DoNotApplyToChildScopes not supported
 #   - Read actions cannot be denied; only write/delete/action
@@ -396,4 +397,223 @@ function Test-NewAndRemoveDaEndToEnd
     # 4. Verify gone
     $gone = Get-AzDenyAssignment -Id $da.Id -ErrorAction SilentlyContinue
     Assert-Null $gone
+}
+
+# =============================================
+# Per-Principal deny assignment tests
+# =============================================
+
+# Helper: Get a test service principal ID
+function Get-TestServicePrincipalId
+{
+    if ($env:TEST_SERVICE_PRINCIPAL_ID) {
+        return $env:TEST_SERVICE_PRINCIPAL_ID
+    }
+    return "c090fe3f-66fa-4e18-8142-107d8f4cd0e4"  # DenyAssignmentTestApp
+}
+
+<#
+.SYNOPSIS
+Creates a deny assignment targeting a specific user principal.
+#>
+function Test-NewDaWithUserPrincipal
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $userId = Get-TestExcludePrincipalId
+    $daName = "Test-DA-UserPrincipal-" + [Guid]::NewGuid().ToString().Substring(0, 8)
+
+    try
+    {
+        $da = New-AzDenyAssignment `
+            -DenyAssignmentName $daName `
+            -Description "Test deny assignment targeting a specific user" `
+            -Scope $subscriptionScope `
+            -Action "Microsoft.Storage/storageAccounts/write" `
+            -PrincipalId $userId `
+            -PrincipalType "User"
+
+        Assert-NotNull $da
+        Assert-AreEqual $daName $da.DenyAssignmentName
+        Assert-True { $da.Principals.Count -eq 1 }
+        Assert-AreEqual $userId $da.Principals[0].ObjectId
+        Assert-AreEqual "User" $da.Principals[0].ObjectType
+    }
+    finally
+    {
+        if ($da)
+        {
+            Remove-AzDenyAssignment -Id $da.Id -Force
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a deny assignment targeting a specific service principal.
+#>
+function Test-NewDaWithServicePrincipal
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $spId = Get-TestServicePrincipalId
+    $daName = "Test-DA-SPPrincipal-" + [Guid]::NewGuid().ToString().Substring(0, 8)
+
+    try
+    {
+        $da = New-AzDenyAssignment `
+            -DenyAssignmentName $daName `
+            -Description "Test deny assignment targeting a specific service principal" `
+            -Scope $subscriptionScope `
+            -Action "Microsoft.Storage/storageAccounts/write" `
+            -PrincipalId $spId `
+            -PrincipalType "ServicePrincipal"
+
+        Assert-NotNull $da
+        Assert-AreEqual $daName $da.DenyAssignmentName
+        Assert-True { $da.Principals.Count -eq 1 }
+        Assert-AreEqual $spId $da.Principals[0].ObjectId
+        Assert-AreEqual "ServicePrincipal" $da.Principals[0].ObjectType
+    }
+    finally
+    {
+        if ($da)
+        {
+            Remove-AzDenyAssignment -Id $da.Id -Force
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Verifies that ExcludePrincipalId is optional in per-principal mode.
+#>
+function Test-NewDaPerPrincipalNoExcludes
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $userId = Get-TestExcludePrincipalId
+    $daName = "Test-DA-NoExcludes-" + [Guid]::NewGuid().ToString().Substring(0, 8)
+
+    try
+    {
+        # No ExcludePrincipalId — should succeed in per-principal mode
+        $da = New-AzDenyAssignment `
+            -DenyAssignmentName $daName `
+            -Description "Per-principal DA without excluded principals" `
+            -Scope $subscriptionScope `
+            -Action "Microsoft.Storage/storageAccounts/write" `
+            -PrincipalId $userId `
+            -PrincipalType "User"
+
+        Assert-NotNull $da
+        Assert-True { $da.ExcludePrincipals.Count -eq 0 -or $da.ExcludePrincipals -eq $null }
+    }
+    finally
+    {
+        if ($da)
+        {
+            Remove-AzDenyAssignment -Id $da.Id -Force
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Verifies that ExcludePrincipalId works as an optional parameter in per-principal mode.
+#>
+function Test-NewDaPerPrincipalWithExcludes
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $spId = Get-TestServicePrincipalId
+    $excludeUser = Get-TestExcludePrincipalId
+    $daName = "Test-DA-PerPrincipalExcl-" + [Guid]::NewGuid().ToString().Substring(0, 8)
+
+    try
+    {
+        $da = New-AzDenyAssignment `
+            -DenyAssignmentName $daName `
+            -Description "Per-principal DA with excluded principals" `
+            -Scope $subscriptionScope `
+            -Action "Microsoft.Storage/storageAccounts/write" `
+            -PrincipalId $spId `
+            -PrincipalType "ServicePrincipal" `
+            -ExcludePrincipalId $excludeUser `
+            -ExcludePrincipalType "User"
+
+        Assert-NotNull $da
+        Assert-True { $da.Principals.Count -eq 1 }
+        Assert-AreEqual $spId $da.Principals[0].ObjectId
+        Assert-True { $da.ExcludePrincipals.Count -ge 1 }
+    }
+    finally
+    {
+        if ($da)
+        {
+            Remove-AzDenyAssignment -Id $da.Id -Force
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Verifies that Group principal type is rejected client-side.
+#>
+function Test-NewDaPerPrincipalGroupRejected
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $groupId = [Guid]::NewGuid().ToString()
+
+    # Group type should be rejected by ValidateSet on the cmdlet parameter.
+    # The error will be a ParameterBindingValidationException.
+    Assert-Throws {
+        New-AzDenyAssignment `
+            -DenyAssignmentName "Test-DA-Group" `
+            -Scope $subscriptionScope `
+            -Action "Microsoft.Storage/storageAccounts/write" `
+            -PrincipalId $groupId `
+            -PrincipalType "Group"
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a per-principal deny assignment from a JSON input file.
+#>
+function Test-NewDaPerPrincipalFromInputFile
+{
+    $subscriptionScope = "/subscriptions/$((Get-AzContext).Subscription.Id)"
+    $userId = Get-TestExcludePrincipalId
+    $daName = "Test-DA-PerPrincipalFile-" + [Guid]::NewGuid().ToString().Substring(0, 8)
+
+    $inputObj = @{
+        denyAssignmentName = $daName
+        description = "Per-principal DA created from input file"
+        actions = @("Microsoft.Storage/storageAccounts/write")
+        notActions = @()
+        dataActions = @()
+        notDataActions = @()
+        principalIds = @($userId)
+        principalTypes = @("User")
+    }
+
+    $tempFile = [System.IO.Path]::GetTempFileName() + ".json"
+    $inputObj | ConvertTo-Json -Depth 5 | Set-Content -Path $tempFile
+
+    try
+    {
+        $da = New-AzDenyAssignment `
+            -InputFile $tempFile `
+            -Scope $subscriptionScope
+
+        Assert-NotNull $da
+        Assert-AreEqual $daName $da.DenyAssignmentName
+        Assert-True { $da.Principals.Count -eq 1 }
+        Assert-AreEqual $userId $da.Principals[0].ObjectId
+    }
+    finally
+    {
+        if ($da)
+        {
+            Remove-AzDenyAssignment -Id $da.Id -Force
+        }
+        Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.ps1
+++ b/src/Resources/Resources.Test/ScenarioTests/DenyAssignmentCrudTests.ps1
@@ -197,7 +197,7 @@ function Test-NewDaFromInputFile
         excludePrincipalIds = @($excludePrincipalId)
     }
 
-    $tempFile = [System.IO.Path]::GetTempFileName() + ".json"
+    $tempFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), ([Guid]::NewGuid().ToString() + ".json"))
     $inputObj | ConvertTo-Json -Depth 5 | Set-Content -Path $tempFile
 
     try
@@ -594,7 +594,7 @@ function Test-NewDaPerPrincipalFromInputFile
         principalTypes = @("User")
     }
 
-    $tempFile = [System.IO.Path]::GetTempFileName() + ".json"
+    $tempFile = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), ([Guid]::NewGuid().ToString() + ".json"))
     $inputObj | ConvertTo-Json -Depth 5 | Set-Content -Path $tempFile
 
     try

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 
 ## Upcoming Release
+* Added `-PrincipalId` and `-PrincipalType` parameters to `New-AzDenyAssignment` to support per-principal deny assignments targeting a specific User or ServicePrincipal, in addition to the existing Everyone mode.
 * Added `New-AzDenyAssignment` cmdlet for creating user-assigned deny assignments using the `2024-07-01-preview` API. Deny assignments allow denying specific write, delete, and action operations to all principals at a given scope while excluding specified principals.
 * Added `Remove-AzDenyAssignment` cmdlet for removing user-assigned deny assignments by ID, name and scope, or pipeline input.
 * Regenerated Authorization Management SDK from `2024-07-01-preview` swagger specification to include deny assignment create and delete operations.

--- a/src/Resources/Resources/DenyAssignments/NewAzureDenyAssignmentCommand.cs
+++ b/src/Resources/Resources/DenyAssignments/NewAzureDenyAssignmentCommand.cs
@@ -133,8 +133,14 @@ namespace Microsoft.Azure.Commands.Resources
         /// </summary>
         private static void ValidateDenyAssignmentOptions(CreateDenyAssignmentOptions options)
         {
+            bool isEveryonePrincipal = false;
+            if (options.PrincipalIds != null && options.PrincipalIds.Count == 1)
+            {
+                isEveryonePrincipal = Guid.TryParse(options.PrincipalIds[0], out Guid parsedId) && parsedId == Guid.Empty;
+            }
+
             bool hasPerPrincipal = options.PrincipalIds != null && options.PrincipalIds.Count > 0
-                && !(options.PrincipalIds.Count == 1 && options.PrincipalIds[0] == Guid.Empty.ToString());
+                && !isEveryonePrincipal;
             bool hasExcludes = options.ExcludePrincipalIds != null && options.ExcludePrincipalIds.Count > 0;
 
             // Validate per-principal fields
@@ -153,6 +159,13 @@ namespace Microsoft.Azure.Commands.Resources
                     throw new PSArgumentException(
                         "PrincipalTypes is required when PrincipalIds is specified. " +
                         "Accepted values: User, ServicePrincipal.");
+                }
+
+                if (options.PrincipalTypes.Count != options.PrincipalIds.Count)
+                {
+                    throw new PSArgumentException(
+                        "PrincipalTypes count must match PrincipalIds count. " +
+                        "Specify exactly one PrincipalType for the single PrincipalId.");
                 }
 
                 var supportedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "User", "ServicePrincipal" };

--- a/src/Resources/Resources/DenyAssignments/NewAzureDenyAssignmentCommand.cs
+++ b/src/Resources/Resources/DenyAssignments/NewAzureDenyAssignmentCommand.cs
@@ -31,60 +31,91 @@ namespace Microsoft.Azure.Commands.Resources
     /// </summary>
     [Cmdlet("New", ResourceManager.Common.AzureRMConstants.AzureRMPrefix + "DenyAssignment",
         SupportsShouldProcess = true,
-        DefaultParameterSetName = ScopeWithPrincipalsParameterSet),
+        DefaultParameterSetName = EveryoneParameterSet),
         OutputType(typeof(PSDenyAssignment))]
     public class NewAzureDenyAssignmentCommand : ResourcesBaseCmdlet
     {
-        private const string ScopeWithPrincipalsParameterSet = "ScopeWithPrincipalsParameterSet";
+        private const string EveryoneParameterSet = "EveryoneParameterSet";
+        private const string PerPrincipalParameterSet = "PerPrincipalParameterSet";
         private const string InputFileParameterSet = "InputFileParameterSet";
 
         #region Parameters
 
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "The display name for the deny assignment.")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
             HelpMessage = "The display name for the deny assignment.")]
         [ValidateNotNullOrEmpty]
         public string DenyAssignmentName { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "A description of the deny assignment.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
             HelpMessage = "A description of the deny assignment.")]
         public string Description { get; set; }
 
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
             HelpMessage = "Scope of the deny assignment. In the format of relative URI. For example, /subscriptions/{id}/resourceGroups/{rgName}.")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Scope of the deny assignment. In the format of relative URI.")]
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = InputFileParameterSet,
             HelpMessage = "Scope of the deny assignment. In the format of relative URI.")]
         [ValidateNotNullOrEmpty]
         [ScopeCompleter]
         public string Scope { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Actions to deny. Wildcards supported (e.g. Microsoft.Storage/storageAccounts/write, */delete). Note: read actions (*/read) are not permitted for user-assigned deny assignments.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
             HelpMessage = "Actions to deny. Wildcards supported (e.g. Microsoft.Storage/storageAccounts/write, */delete). Note: read actions (*/read) are not permitted for user-assigned deny assignments.")]
         public string[] Action { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Actions to exclude from the deny assignment.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
             HelpMessage = "Actions to exclude from the deny assignment.")]
         public string[] NotAction { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
-            HelpMessage = "Data actions to deny. Not supported for user-assigned deny assignments (Private Preview).")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Data actions to deny. Not supported for user-assigned deny assignments.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Data actions to deny. Not supported for user-assigned deny assignments.")]
         public string[] DataAction { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
-            HelpMessage = "Data actions to exclude from the deny assignment. Not supported for user-assigned deny assignments (Private Preview).")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Data actions to exclude from the deny assignment. Not supported for user-assigned deny assignments.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Data actions to exclude from the deny assignment. Not supported for user-assigned deny assignments.")]
         public string[] NotDataAction { get; set; }
 
-        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
-            HelpMessage = "Object IDs of principals to exclude from the deny assignment. Required when principal is Everyone.")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Object IDs of principals to exclude from the deny assignment. Required when targeting Everyone.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Object IDs of principals to exclude from the deny assignment. Optional when using -PrincipalId.")]
         [ValidateNotNullOrEmpty]
         public string[] ExcludePrincipalId { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "Type(s) of the exclude principals (User, Group, ServicePrincipal). One per ExcludePrincipalId, or a single value applied to all. Defaults to User.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
             HelpMessage = "Type(s) of the exclude principals (User, Group, ServicePrincipal). One per ExcludePrincipalId, or a single value applied to all. Defaults to User.")]
         [ValidateSet("User", "Group", "ServicePrincipal")]
         public string[] ExcludePrincipalType { get; set; }
 
-        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = ScopeWithPrincipalsParameterSet,
-            HelpMessage = "If set, the deny assignment does not apply to child scopes. Not supported for user-assigned deny assignments (Private Preview).")]
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Object ID of the user or service principal to deny.")]
+        [ValidateNotNullOrEmpty]
+        public string PrincipalId { get; set; }
+
+        [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "Type of the principal: User or ServicePrincipal. Group is not supported for user-assigned deny assignments.")]
+        [ValidateSet("User", "ServicePrincipal")]
+        public string PrincipalType { get; set; }
+
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = EveryoneParameterSet,
+            HelpMessage = "If set, the deny assignment does not apply to child scopes. Not supported for user-assigned deny assignments.")]
+        [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, ParameterSetName = PerPrincipalParameterSet,
+            HelpMessage = "If set, the deny assignment does not apply to child scopes. Not supported for user-assigned deny assignments.")]
         public SwitchParameter DoNotApplyToChildScope { get; set; }
 
         [Parameter(Mandatory = true, ValueFromPipelineByPropertyName = true, ParameterSetName = InputFileParameterSet,
@@ -96,6 +127,104 @@ namespace Microsoft.Azure.Commands.Resources
         public Guid DenyAssignmentId { get; set; }
 
         #endregion
+
+        /// <summary>
+        /// Validates options that apply to all input paths (command-line and InputFile).
+        /// </summary>
+        private static void ValidateDenyAssignmentOptions(CreateDenyAssignmentOptions options)
+        {
+            bool hasPerPrincipal = options.PrincipalIds != null && options.PrincipalIds.Count > 0
+                && !(options.PrincipalIds.Count == 1 && options.PrincipalIds[0] == Guid.Empty.ToString());
+            bool hasExcludes = options.ExcludePrincipalIds != null && options.ExcludePrincipalIds.Count > 0;
+
+            // Validate per-principal fields
+            if (hasPerPrincipal)
+            {
+                if (options.PrincipalIds.Count > 1)
+                {
+                    throw new PSArgumentException(
+                        "Only one principal is supported per user-assigned deny assignment. " +
+                        "Specify a single PrincipalId.");
+                }
+
+                // Validate principal type is present and supported
+                if (options.PrincipalTypes == null || options.PrincipalTypes.Count == 0)
+                {
+                    throw new PSArgumentException(
+                        "PrincipalTypes is required when PrincipalIds is specified. " +
+                        "Accepted values: User, ServicePrincipal.");
+                }
+
+                var supportedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "User", "ServicePrincipal" };
+                foreach (var principalType in options.PrincipalTypes)
+                {
+                    if (string.Equals(principalType, "Group", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new PSArgumentException(
+                            "Group type principals are not supported for user-assigned deny assignments. " +
+                            "Use 'User' or 'ServicePrincipal'.");
+                    }
+                    if (!supportedTypes.Contains(principalType))
+                    {
+                        throw new PSArgumentException(
+                            string.Format("Unsupported principal type '{0}'. Accepted values: User, ServicePrincipal.", principalType));
+                    }
+                }
+            }
+            else if (options.PrincipalTypes != null && options.PrincipalTypes.Count > 0)
+            {
+                throw new PSArgumentException(
+                    "PrincipalTypes must not be specified without PrincipalIds.");
+            }
+
+            // Everyone mode requires at least one excluded principal
+            if (!hasPerPrincipal && !hasExcludes)
+            {
+                throw new PSArgumentException(
+                    "At least one excluded principal is required via ExcludePrincipalIds when targeting Everyone. " +
+                    "Use PrincipalId and PrincipalType to target a specific user or service principal instead.");
+            }
+
+            // Validate ExcludePrincipalTypes consistency
+            if (!hasExcludes && options.ExcludePrincipalTypes != null && options.ExcludePrincipalTypes.Count > 0)
+            {
+                throw new PSArgumentException(
+                    "ExcludePrincipalTypes must not be specified without ExcludePrincipalIds.");
+            }
+
+            if (hasExcludes && options.ExcludePrincipalTypes != null && options.ExcludePrincipalTypes.Count > 1
+                && options.ExcludePrincipalTypes.Count != options.ExcludePrincipalIds.Count)
+            {
+                throw new PSArgumentException(
+                    string.Format("ExcludePrincipalTypes must specify either 1 value (applied to all) or exactly {0} values " +
+                    "(one per ExcludePrincipalIds). Got {1}.", options.ExcludePrincipalIds.Count, options.ExcludePrincipalTypes.Count));
+            }
+
+            // DataActions and DoNotApplyToChildScopes are not supported for UADA
+            bool hasDataActions = (options.DataActions != null && options.DataActions.Count > 0)
+                || (options.NotDataActions != null && options.NotDataActions.Count > 0);
+            if (hasDataActions)
+            {
+                throw new PSArgumentException(
+                    "DataActions and NotDataActions are not supported for user-assigned deny assignments. " +
+                    "Only Actions and NotActions are permitted.");
+            }
+
+            if (options.DoNotApplyToChildScopes)
+            {
+                throw new PSArgumentException(
+                    "DoNotApplyToChildScopes is not supported for user-assigned deny assignments.");
+            }
+
+            // Require at least one Action or NotAction
+            bool hasActions = (options.Actions != null && options.Actions.Count > 0)
+                || (options.NotActions != null && options.NotActions.Count > 0);
+            if (!hasActions)
+            {
+                throw new PSArgumentException(
+                    "At least one Action or NotAction is required to create a deny assignment.");
+            }
+        }
 
         public override void ExecuteCmdlet()
         {
@@ -119,48 +248,9 @@ namespace Microsoft.Azure.Commands.Resources
                 }
 
                 options.Scope = Scope;
-
-                // PP1 requires at least one excluded principal
-                if (options.ExcludePrincipalIds == null || options.ExcludePrincipalIds.Count == 0)
-                {
-                    throw new PSArgumentException(
-                        "Input file must specify at least one ExcludePrincipalIds entry. " +
-                        "PP1 deny assignments apply to Everyone and require at least one excluded principal.");
-                }
             }
             else
             {
-                // PP1 client-side validation: DataActions not supported
-                if ((DataAction != null && DataAction.Length > 0) || (NotDataAction != null && NotDataAction.Length > 0))
-                {
-                    throw new PSArgumentException(
-                        "DataActions and NotDataActions are not supported for PP1 user-assigned deny assignments. " +
-                        "Only Actions and NotActions are permitted.");
-                }
-
-                // PP1 client-side validation: DoNotApplyToChildScopes not supported
-                if (DoNotApplyToChildScope.IsPresent)
-                {
-                    throw new PSArgumentException(
-                        "DoNotApplyToChildScopes is not supported for PP1 user-assigned deny assignments.");
-                }
-
-                // Require at least one Action or NotAction
-                if ((Action == null || Action.Length == 0) && (NotAction == null || NotAction.Length == 0))
-                {
-                    throw new PSArgumentException(
-                        "At least one -Action or -NotAction is required to create a deny assignment.");
-                }
-
-                // Validate ExcludePrincipalType count matches ExcludePrincipalId count
-                if (ExcludePrincipalType != null && ExcludePrincipalType.Length > 1
-                    && ExcludePrincipalType.Length != ExcludePrincipalId.Length)
-                {
-                    throw new PSArgumentException(
-                        string.Format("-ExcludePrincipalType must specify either 1 value (applied to all) or exactly {0} values " +
-                        "(one per -ExcludePrincipalId). Got {1}.", ExcludePrincipalId.Length, ExcludePrincipalType.Length));
-                }
-
                 options = new CreateDenyAssignmentOptions
                 {
                     DenyAssignmentName = DenyAssignmentName,
@@ -174,8 +264,16 @@ namespace Microsoft.Azure.Commands.Resources
                     ExcludePrincipalTypes = ExcludePrincipalType != null ? new List<string>(ExcludePrincipalType) : null,
                     DoNotApplyToChildScopes = DoNotApplyToChildScope.IsPresent,
                 };
+
+                // Populate per-principal fields from cmdlet params
+                if (!string.IsNullOrEmpty(PrincipalId))
+                {
+                    options.PrincipalIds = new List<string> { PrincipalId };
+                    options.PrincipalTypes = new List<string> { PrincipalType };
+                }
             }
 
+            ValidateDenyAssignmentOptions(options);
             AuthorizationClient.ValidateScope(options.Scope, false);
 
             Guid assignmentId = DenyAssignmentId == Guid.Empty ? Guid.NewGuid() : DenyAssignmentId;

--- a/src/Resources/Resources/Models.Authorization/AuthorizationClient.cs
+++ b/src/Resources/Resources/Models.Authorization/AuthorizationClient.cs
@@ -640,8 +640,14 @@ namespace Microsoft.Azure.Commands.Resources.Models.Authorization
             };
 
             // Build principals list based on mode
-            bool isPerPrincipalMode = options.PrincipalIds != null && options.PrincipalIds.Count > 0
-                && !(options.PrincipalIds.Count == 1 && options.PrincipalIds[0] == Guid.Empty.ToString());
+            bool isEveryoneMode = options.PrincipalIds != null
+                && options.PrincipalIds.Count == 1
+                && Guid.TryParse(options.PrincipalIds[0], out Guid principalGuid)
+                && principalGuid == Guid.Empty;
+
+            bool isPerPrincipalMode = options.PrincipalIds != null
+                && options.PrincipalIds.Count > 0
+                && !isEveryoneMode;
 
             List<DenyAssignmentPrincipal> principals;
             if (isPerPrincipalMode)

--- a/src/Resources/Resources/Models.Authorization/AuthorizationClient.cs
+++ b/src/Resources/Resources/Models.Authorization/AuthorizationClient.cs
@@ -639,23 +639,37 @@ namespace Microsoft.Azure.Commands.Resources.Models.Authorization
                 }
             };
 
-            // PP1 model: principals must be Everyone (SystemDefined), actual targets go in excludePrincipals
-            if (options.PrincipalIds != null && options.PrincipalIds.Count > 0
-                && !(options.PrincipalIds.Count == 1 && options.PrincipalIds[0] == Guid.Empty.ToString()))
-            {
-                throw new ArgumentException(
-                    "PP1 deny assignments only support the Everyone principal (SystemDefined). " +
-                    "Custom principal IDs are not supported. Use ExcludePrincipalIds to exclude specific principals.");
-            }
+            // Build principals list based on mode
+            bool isPerPrincipalMode = options.PrincipalIds != null && options.PrincipalIds.Count > 0
+                && !(options.PrincipalIds.Count == 1 && options.PrincipalIds[0] == Guid.Empty.ToString());
 
-            var principals = new List<DenyAssignmentPrincipal>
+            List<DenyAssignmentPrincipal> principals;
+            if (isPerPrincipalMode)
             {
-                new DenyAssignmentPrincipal
+                // Per-principal mode: target a specific user or service principal
+                principals = new List<DenyAssignmentPrincipal>
                 {
-                    Id = Guid.Empty.ToString(),
-                    Type = "SystemDefined"
-                }
-            };
+                    new DenyAssignmentPrincipal
+                    {
+                        Id = options.PrincipalIds[0],
+                        Type = options.PrincipalTypes != null && options.PrincipalTypes.Count > 0
+                            ? options.PrincipalTypes[0]
+                            : "User"
+                    }
+                };
+            }
+            else
+            {
+                // Everyone mode (default): deny all principals
+                principals = new List<DenyAssignmentPrincipal>
+                {
+                    new DenyAssignmentPrincipal
+                    {
+                        Id = Guid.Empty.ToString(),
+                        Type = "SystemDefined"
+                    }
+                };
+            }
 
             var excludePrincipals = new List<DenyAssignmentPrincipal>();
             var excludeIds = options.ExcludePrincipalIds ?? new List<string>();

--- a/src/Resources/Resources/Models.Authorization/CreateDenyAssignmentOptions.cs
+++ b/src/Resources/Resources/Models.Authorization/CreateDenyAssignmentOptions.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Azure.Commands.Resources.Models.Authorization
         [JsonProperty("principalIds")]
         public List<string> PrincipalIds { get; set; } = new List<string>();
 
+        [JsonProperty("principalTypes")]
+        public List<string> PrincipalTypes { get; set; }
+
         [JsonProperty("excludePrincipalIds")]
         public List<string> ExcludePrincipalIds { get; set; } = new List<string>();
 

--- a/src/Resources/Resources/Models.Authorization/CreateDenyAssignmentOptions.cs
+++ b/src/Resources/Resources/Models.Authorization/CreateDenyAssignmentOptions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Commands.Resources.Models.Authorization
         public List<string> PrincipalIds { get; set; } = new List<string>();
 
         [JsonProperty("principalTypes")]
-        public List<string> PrincipalTypes { get; set; }
+        public List<string> PrincipalTypes { get; set; } = new List<string>();
 
         [JsonProperty("excludePrincipalIds")]
         public List<string> ExcludePrincipalIds { get; set; } = new List<string>();

--- a/src/Resources/Resources/help/New-AzDenyAssignment.md
+++ b/src/Resources/Resources/help/New-AzDenyAssignment.md
@@ -9,17 +9,27 @@ schema: 2.0.0
 
 ## SYNOPSIS
 Creates a user-assigned deny assignment at the specified scope.
-PP1 deny assignments apply to all principals (Everyone) and require at least one excluded principal.
+By default, the deny assignment targets Everyone and requires at least one excluded principal.
+Alternatively, use -PrincipalId and -PrincipalType to target a specific user or service principal.
 
 ## SYNTAX
 
-### ScopeWithPrincipalsParameterSet (Default)
+### EveryoneParameterSet (Default)
 ```
 New-AzDenyAssignment -DenyAssignmentName <String> -Scope <String> -ExcludePrincipalId <String[]>
  [-Description <String>] [-Action <String[]>] [-NotAction <String[]>] [-DataAction <String[]>]
  [-NotDataAction <String[]>] [-ExcludePrincipalType <String[]>] [-DoNotApplyToChildScope]
  [-DenyAssignmentId <Guid>] [-DefaultProfile <IAzureContextContainer>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### PerPrincipalParameterSet
+```
+New-AzDenyAssignment -DenyAssignmentName <String> -Scope <String> -PrincipalId <String>
+ -PrincipalType <String> [-Description <String>] [-Action <String[]>] [-NotAction <String[]>]
+ [-DataAction <String[]>] [-NotDataAction <String[]>] [-ExcludePrincipalId <String[]>]
+ [-ExcludePrincipalType <String[]>] [-DoNotApplyToChildScope] [-DenyAssignmentId <Guid>]
+ [-DefaultProfile <IAzureContextContainer>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputFileParameterSet
@@ -31,12 +41,15 @@ New-AzDenyAssignment -Scope <String> -InputFile <String> [-DenyAssignmentId <Gui
 ## DESCRIPTION
 Use the New-AzDenyAssignment command to create a new user-assigned deny assignment at the specified scope.
 
-PP1 deny assignments apply to all principals (Everyone) and require at least one excluded principal to be specified via the ExcludePrincipalId parameter.
-Only write, delete, and action operations can be denied. Read actions and data actions are not supported in PP1.
+By default, the deny assignment targets all principals (Everyone) and requires at least one excluded principal via the ExcludePrincipalId parameter.
+
+Alternatively, use -PrincipalId and -PrincipalType to target a specific user or service principal. In this mode, -ExcludePrincipalId is optional. Group type principals are not supported for user-assigned deny assignments.
+
+Only write, delete, and action operations can be denied. Read actions and data actions are not supported.
 
 ## EXAMPLES
 
-### Example 1: Create a deny assignment that blocks delete actions
+### Example 1: Create a deny assignment that blocks delete actions for everyone
 ```powershell
 New-AzDenyAssignment -DenyAssignmentName "Block deletes" `
     -Scope "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG" `
@@ -45,17 +58,39 @@ New-AzDenyAssignment -DenyAssignmentName "Block deletes" `
     -ExcludePrincipalType "User"
 ```
 
-Creates a deny assignment named "Block deletes" at the resource group scope that denies all delete actions. The specified user is excluded from the deny assignment.
+Creates a deny assignment named "Block deletes" at the resource group scope that denies all delete actions for everyone. The specified user is excluded from the deny assignment.
 
-### Example 2: Create a deny assignment from a JSON input file
+### Example 2: Block a specific user from performing write operations
+```powershell
+New-AzDenyAssignment -DenyAssignmentName "Block user writes" `
+    -Scope "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG" `
+    -Action "*/write" `
+    -PrincipalId "11111111-1111-1111-1111-111111111111" `
+    -PrincipalType "User"
+```
+
+Creates a deny assignment that blocks write operations for a specific user. No excluded principals are required in per-principal mode.
+
+### Example 3: Block a specific service principal from deleting resources
+```powershell
+New-AzDenyAssignment -DenyAssignmentName "Block SP deletes" `
+    -Scope "/subscriptions/00000000-0000-0000-0000-000000000000" `
+    -Action "*/delete" `
+    -PrincipalId "22222222-2222-2222-2222-222222222222" `
+    -PrincipalType "ServicePrincipal"
+```
+
+Creates a deny assignment that blocks delete operations for a specific service principal at subscription scope.
+
+### Example 4: Create a deny assignment from a JSON input file
 ```powershell
 New-AzDenyAssignment -Scope "/subscriptions/00000000-0000-0000-0000-000000000000" `
     -InputFile "C:\DenyAssignment.json"
 ```
 
-Creates a deny assignment using the definition in the specified JSON file. The input file must include DenyAssignmentName, Actions, and ExcludePrincipalIds.
+Creates a deny assignment using the definition in the specified JSON file. The input file must include DenyAssignmentName, Actions, and either ExcludePrincipalIds (Everyone mode) or PrincipalIds + PrincipalTypes (per-principal mode).
 
-### Example 3: Create a deny assignment with multiple exclude principals
+### Example 5: Create a deny assignment with multiple exclude principals
 ```powershell
 New-AzDenyAssignment -DenyAssignmentName "Block writes" `
     -Scope "/subscriptions/00000000-0000-0000-0000-000000000000" `
@@ -64,7 +99,7 @@ New-AzDenyAssignment -DenyAssignmentName "Block writes" `
     -ExcludePrincipalType "User", "ServicePrincipal"
 ```
 
-Creates a deny assignment that denies write actions, excluding a user and a service principal.
+Creates a deny assignment that denies write actions for everyone, excluding a user and a service principal.
 
 ## PARAMETERS
 
@@ -73,7 +108,7 @@ Actions to deny. Wildcards supported (e.g., */delete, Microsoft.Storage/storageA
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
@@ -84,11 +119,11 @@ Accept wildcard characters: False
 ```
 
 ### -DataAction
-Data actions to deny. Note: Data actions are not supported in Public Preview 1 user-assigned deny assignments and will be rejected by the service.
+Data actions to deny. Note: Data actions are not supported for user-assigned deny assignments and will be rejected by the service.
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
@@ -133,7 +168,7 @@ The display name for the deny assignment.
 
 ```yaml
 Type: System.String
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: True
@@ -148,7 +183,7 @@ A description of the deny assignment.
 
 ```yaml
 Type: System.String
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
@@ -159,11 +194,11 @@ Accept wildcard characters: False
 ```
 
 ### -DoNotApplyToChildScope
-If set, the deny assignment does not apply to child scopes. Note: This property is not supported in Public Preview 1 user-assigned deny assignments and will be rejected by the service.
+If set, the deny assignment does not apply to child scopes. Note: This property is not supported for user-assigned deny assignments and will be rejected by the service.
 
 ```yaml
 Type: System.Management.Automation.SwitchParameter
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
@@ -174,14 +209,26 @@ Accept wildcard characters: False
 ```
 
 ### -ExcludePrincipalId
-Object IDs of principals to exclude from the deny assignment. Required when principal is Everyone.
+Object IDs of principals to exclude from the deny assignment. Required when targeting Everyone. Optional when using -PrincipalId.
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+```yaml
+Type: System.String[]
+Parameter Sets: PerPrincipalParameterSet
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)
@@ -193,7 +240,7 @@ Type(s) of the exclude principals (User, Group, ServicePrincipal). One per Exclu
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 Accepted values: User, Group, ServicePrincipal
 
@@ -224,7 +271,7 @@ Actions to exclude from the deny assignment.
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
@@ -235,14 +282,45 @@ Accept wildcard characters: False
 ```
 
 ### -NotDataAction
-Data actions to exclude from the deny assignment. Note: Data actions are not supported in Public Preview 1 user-assigned deny assignments.
+Data actions to exclude from the deny assignment. Note: Data actions are not supported for user-assigned deny assignments.
 
 ```yaml
 Type: System.String[]
-Parameter Sets: ScopeWithPrincipalsParameterSet
+Parameter Sets: EveryoneParameterSet, PerPrincipalParameterSet
 Aliases:
 
 Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PrincipalId
+Object ID of the user or service principal to deny. When specified, the deny assignment targets this specific principal instead of Everyone.
+
+```yaml
+Type: System.String
+Parameter Sets: PerPrincipalParameterSet
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PrincipalType
+Type of the principal specified by -PrincipalId. Accepted values are User and ServicePrincipal. Group type is not supported for user-assigned deny assignments.
+
+```yaml
+Type: System.String
+Parameter Sets: PerPrincipalParameterSet
+Aliases:
+Accepted values: User, ServicePrincipal
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: True (ByPropertyName)


### PR DESCRIPTION
## Description

Adds `-PrincipalId` and `-PrincipalType` parameters to `New-AzDenyAssignment` to support targeting a specific User or ServicePrincipal in user-assigned deny assignments, in addition to the existing Everyone mode.

### Background

The PAS backend now supports per-principal user-assigned deny assignments (merged in [DA PR #15293894](https://msazure.visualstudio.com/One/_git/DA/pullrequest/15293894)). This PR exposes that capability in the PowerShell cmdlet.

### Changes

- **NewAzureDenyAssignmentCommand.cs**: New `PerPrincipalParameterSet` with `-PrincipalId` (string) and `-PrincipalType` (User|ServicePrincipal) parameters. Shared `ValidateDenyAssignmentOptions()` validation covers both cmdlet and InputFile paths. Group type is rejected client-side.
- **AuthorizationClient.cs**: Conditional principal construction — per-principal mode when PrincipalIds contains a non-Empty GUID, else Everyone mode with SystemDefined principal.
- **CreateDenyAssignmentOptions.cs**: Added `PrincipalTypes` list property with JSON serialization.
- **New-AzDenyAssignment.md**: Added PerPrincipal syntax block, per-principal examples (User + ServicePrincipal), and parameter documentation.
- **DenyAssignmentCrudTests.ps1/.cs**: 6 new test functions covering user principal, service principal, no excludes, with excludes, Group rejection, and InputFile per-principal paths.
- **ChangeLog.md**: Entry for per-principal support.

### Parameter Sets

| Set | Key Params | ExcludePrincipalId | Description |
|-----|-----------|-------------------|-------------|
| EveryoneParameterSet (default) | — | Required | Deny for everyone, exclude specified principals |
| PerPrincipalParameterSet | -PrincipalId, -PrincipalType | Optional | Deny for a specific user or SP |
| InputFileParameterSet | -InputFile | N/A (from file) | Define via JSON file (supports both modes) |

### Testing

- 6 new LiveOnly tests added (per-principal scenarios)
- Test recordings require interactive (delegated) auth — PAS deny assignment API rejects SP auth with \/me request is only valid with delegated authentication flow\. Recordings will be generated via interactive login session.
- All existing Everyone-mode tests remain unchanged.
