### PR TITLE
Fix Arc registration state verification failure in single-node scenario

### DIFF
--- a/src/StackHCI/StackHCI.Autorest/custom/stackhci.ps1
+++ b/src/StackHCI/StackHCI.Autorest/custom/stackhci.ps1
@@ -2103,7 +2103,7 @@ function Verify-NodesArcRegistrationState{
     $checkBlock = {
         param([string]$SubscriptionId, [string]$ArcResourceGroupName)
         $nodeName = $env:COMPUTERNAME
-        $result = @{ NodeName = $nodeName; IsMismatch = $false; Details = $null }
+        $result = [PSCustomObject]@{ NodeName = $nodeName; IsMismatch = $false; Details = $null }
 
         if(Test-Path -Path "C:\Program Files\AzureConnectedMachineAgent\azcmagent.exe")
         {
@@ -2168,7 +2168,7 @@ function Verify-NodesArcRegistrationState{
     }
 
     # Validate we received results from all nodes
-    $resultCount = if ($results -eq $null) { 0 } else { $results.Count }
+    $resultCount = if ($null -eq $results) { 0 } else { @($results).Count }
     $expectedCount = $computerNames.Count
     if ($resultCount -ne $expectedCount)
     {

--- a/src/StackHCI/StackHCI/ChangeLog.md
+++ b/src/StackHCI/StackHCI/ChangeLog.md
@@ -17,7 +17,8 @@
     * Overview of change #1
         - Additional information about change #1
 -->
-## Upcoming Release
+## Upcoming 
+* Fixed single node registration scenario.
 
 ## Version 2.7.0
 * Updated preannouncement breaking changes date to May 2026.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
"Arc registration state verification incomplete: expected results from 1 node(s) but received from . Some nodes may have failed silently."

This only affects single-node targets. When Invoke-Command targets 1 node, it returns a scalar instead of an array. Two issues compound:

1. The scriptblock returned a hashtable (@{}). Hashtables are enumerable by their keys, so @($scalarHashtable).Count returns 3 (key count) instead of 1.

2. After fixing to [PSCustomObject], $results.Count on a scalar PSCustomObject returns $null (no .Count property), printing as blank in the error and still failing the count check.

Both issues are invisible with 2+ nodes because Invoke-Command returns a real Object[], bypassing both code paths.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [X] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [ ] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
