### PR TITLE
Pinned System.Security.Cryptography.Xml to 8.0.3 In /Tools/Az.nonprod.props

### DIFF
--- a/tools/Az.nonprod.props
+++ b/tools/Az.nonprod.props
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" IncludeAssets="All" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" IncludeAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Addressing:
[CVE-2026-33116](https://github.com/dotnet/runtime/security/advisories/GHSA-37gx-xxp4-5rgx)
[CVE-2026-26171](https://github.com/dotnet/runtime/security/advisories/GHSA-w3x6-4m5h-cxqf)

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [ ] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [ ] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
