### PR TITLE
fix(Resources): propagate ARM nested error details in deployment validation

### DIFF
--- a/src/Resources/ResourceManager/SdkClient/NewResourceManagerSdkClient.cs
+++ b/src/Resources/ResourceManager/SdkClient/NewResourceManagerSdkClient.cs
@@ -543,16 +543,24 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.SdkClient
             if (ex is CloudException cloudEx)
             {
                 // Map ARM API error details from the CloudException body, preserving the full nested error hierarchy.
-                // Using ex.InnerException here would traverse the .NET exception chain rather than the ARM error details,
-                // causing nested ARM errors (e.g. MultipleErrorsOccurred sub-errors) to be silently dropped.
+                // Using ex.InnerException when ARM details are present would traverse the .NET exception chain rather than
+                // the ARM error details, causing nested ARM errors (e.g. MultipleErrorsOccurred sub-errors) to be silently dropped.
+                // Fall back to ex.InnerException only when the ARM body carries no details (e.g. when Body itself is null).
                 var details = cloudEx.Body?.Details?
                     .Select(ConvertCloudErrorToErrorResponse)
                     .ToList();
+                var nestedDetails = details?.Count > 0
+                    ? details
+                    : HandleError(ex.InnerException);
+                var message = string.IsNullOrEmpty(cloudEx.Body?.Message)
+                    ? cloudEx.Message
+                    : cloudEx.Body.Message;
+
                 error = new ErrorResponse(
                     cloudEx.Body?.Code,
-                    cloudEx.Body?.Message,
+                    message,
                     cloudEx.Body?.Target,
-                    details?.Count > 0 ? details : null);
+                    nestedDetails);
             }
             else
             {

--- a/src/Resources/ResourceManager/SdkClient/NewResourceManagerSdkClient.cs
+++ b/src/Resources/ResourceManager/SdkClient/NewResourceManagerSdkClient.cs
@@ -539,20 +539,51 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.SdkClient
                 return null;
             }
 
-            ErrorResponse error = null;
-            var innerException = HandleError(ex.InnerException);
-            if (ex is CloudException)
+            ErrorResponse error;
+            if (ex is CloudException cloudEx)
             {
-                var cloudEx = ex as CloudException;
-                error = new ErrorResponse(cloudEx.Body?.Code, cloudEx.Body?.Message, cloudEx.Body?.Target, innerException);
+                // Map ARM API error details from the CloudException body, preserving the full nested error hierarchy.
+                // Using ex.InnerException here would traverse the .NET exception chain rather than the ARM error details,
+                // causing nested ARM errors (e.g. MultipleErrorsOccurred sub-errors) to be silently dropped.
+                var details = cloudEx.Body?.Details?
+                    .Select(ConvertCloudErrorToErrorResponse)
+                    .ToList();
+                error = new ErrorResponse(
+                    cloudEx.Body?.Code,
+                    cloudEx.Body?.Message,
+                    cloudEx.Body?.Target,
+                    details?.Count > 0 ? details : null);
             }
             else
             {
+                var innerException = HandleError(ex.InnerException);
                 error = new ErrorResponse(null, ex.Message, null, innerException);
             }
 
             return new List<ErrorResponse> { error };
+        }
 
+        /// <summary>
+        /// Recursively converts an ARM <see cref="CloudError"/> to an <see cref="ErrorResponse"/>,
+        /// preserving all nested error details.
+        /// </summary>
+        private static ErrorResponse ConvertCloudErrorToErrorResponse(CloudError cloudError)
+        {
+            if (cloudError == null)
+            {
+                return null;
+            }
+
+            var subDetails = cloudError.Details?
+                .Select(ConvertCloudErrorToErrorResponse)
+                .Where(d => d != null)
+                .ToList();
+
+            return new ErrorResponse(
+                cloudError.Code,
+                cloudError.Message,
+                cloudError.Target,
+                subDetails?.Count > 0 ? subDetails : null);
         }
 
         private IPage<DeploymentOperation> ListDeploymentOperations(PSDeploymentCmdletParameters parameters)

--- a/src/Resources/Resources.Test/Models.ResourceGroups/ResourceClientTests.cs
+++ b/src/Resources/Resources.Test/Models.ResourceGroups/ResourceClientTests.cs
@@ -1299,6 +1299,69 @@ namespace Microsoft.Azure.Commands.Resources.Test.Models
             deploymentsMock.Verify(f => f.CancelWithHttpMessagesAsync(resourceGroupName, deploymentName + 3, null, new CancellationToken()), Times.Once());
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-powershell/issues/28308.
+        /// Verifies that when the ARM validation API returns a CloudException whose body contains
+        /// nested error details (e.g. MultipleErrorsOccurred → KeyVaultParameterReferenceSecretRetrieveFailed),
+        /// those inner errors are propagated into the TemplateValidationInfo and not silently dropped.
+        /// </summary>
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void ValidateDeployment_WhenCloudExceptionHasNestedDetails_PropagatesInnerErrors()
+        {
+            // Arrange
+            PSDeploymentCmdletParameters parameters = new PSDeploymentCmdletParameters()
+            {
+                ScopeType = DeploymentScopeType.ResourceGroup,
+                ResourceGroupName = resourceGroupName,
+                DeploymentName = deploymentName,
+                DeploymentMode = DeploymentMode.Incremental,
+                TemplateFile = templateFile,
+            };
+
+            // CloudError.Details has a private setter; use JSON deserialization to populate it,
+            // mirroring how the ARM SDK populates the error body from a real HTTP response.
+            const string cloudErrorJson = @"{
+                ""code"": ""MultipleErrorsOccurred"",
+                ""message"": ""Multiple error occurred: NotFound,NotFound,NotFound,NotFound. Please see details."",
+                ""details"": [
+                    { ""code"": ""KeyVaultParameterReferenceSecretRetrieveFailed"", ""message"": ""Secret 'A-pass' not found in key vault."" },
+                    { ""code"": ""KeyVaultParameterReferenceSecretRetrieveFailed"", ""message"": ""Secret 'B-pass' not found in key vault."" },
+                    { ""code"": ""KeyVaultParameterReferenceSecretRetrieveFailed"", ""message"": ""Secret 'C-user' not found in key vault."" },
+                    { ""code"": ""KeyVaultParameterReferenceSecretRetrieveFailed"", ""message"": ""Secret 'C-pass' not found in key vault."" }
+                ]
+            }";
+
+            var cloudError = JsonConvert.DeserializeObject<CloudError>(cloudErrorJson);
+            var cloudException = new CloudException("Multiple errors occurred") { Body = cloudError };
+
+            deploymentsMock
+                .Setup(f => f.ValidateWithHttpMessagesAsync(
+                    resourceGroupName,
+                    It.IsAny<string>(),
+                    It.IsAny<Deployment>(),
+                    null,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromException<AzureOperationResponse<DeploymentValidateResult>>(cloudException));
+
+            // Act
+            TemplateValidationInfo result = resourcesClient.ValidateDeployment(parameters);
+
+            // Assert – top-level error must be the MultipleErrorsOccurred envelope
+            Assert.Single(result.Errors);
+            ErrorResponse topError = result.Errors[0];
+            Assert.Equal("MultipleErrorsOccurred", topError.Code);
+
+            // Assert – the four nested details must be propagated (previously they were silently dropped)
+            Assert.NotNull(topError.Details);
+            Assert.Equal(4, topError.Details.Count);
+            Assert.All(topError.Details, d => Assert.Equal("KeyVaultParameterReferenceSecretRetrieveFailed", d.Code));
+            Assert.Contains(topError.Details, d => d.Message.Contains("A-pass"));
+            Assert.Contains(topError.Details, d => d.Message.Contains("B-pass"));
+            Assert.Contains(topError.Details, d => d.Message.Contains("C-user"));
+            Assert.Contains(topError.Details, d => d.Message.Contains("C-pass"));
+        }
+
         //[Fact(Skip = "Test produces different outputs since hashtable order is not guaranteed.")]
         //[Trait(Category.AcceptanceType, Category.CheckIn)]
         //public void SerializeHashtableProperlyHandlesAllDataTypes()

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -23,7 +23,7 @@
 * Added `New-AzDenyAssignment` cmdlet for creating user-assigned deny assignments using the `2024-07-01-preview` API. Deny assignments allow denying specific write, delete, and action operations to all principals at a given scope while excluding specified principals.
 * Added `Remove-AzDenyAssignment` cmdlet for removing user-assigned deny assignments by ID, name and scope, or pipeline input.
 * Regenerated Authorization Management SDK from `2024-07-01-preview` swagger specification to include deny assignment create and delete operations.
-* Fixed `New-AzDeployment` not reporting nested ARM error details (e.g. `KeyVaultParameterReferenceSecretRetrieveFailed`) when a `MultipleErrorsOccurred` validation failure is returned. Previously, the inner errors were silently dropped and only the generic top-level error was shown. [#28308]
+* Fixed `New-AzDeployment` not reporting nested ARM (Azure Resource Manager) error details (e.g. `KeyVaultParameterReferenceSecretRetrieveFailed`) when a `MultipleErrorsOccurred` validation failure is returned. Previously, the inner errors were silently dropped and only the generic top-level error was shown. [#28308]
 
 ## Version 9.0.3
 * Updated the implementation of -Metadata parameter processing for cmdlets that use it for security. No behavior change.

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -23,6 +23,7 @@
 * Added `New-AzDenyAssignment` cmdlet for creating user-assigned deny assignments using the `2024-07-01-preview` API. Deny assignments allow denying specific write, delete, and action operations to all principals at a given scope while excluding specified principals.
 * Added `Remove-AzDenyAssignment` cmdlet for removing user-assigned deny assignments by ID, name and scope, or pipeline input.
 * Regenerated Authorization Management SDK from `2024-07-01-preview` swagger specification to include deny assignment create and delete operations.
+* Fixed `New-AzDeployment` not reporting nested ARM error details (e.g. `KeyVaultParameterReferenceSecretRetrieveFailed`) when a `MultipleErrorsOccurred` validation failure is returned. Previously, the inner errors were silently dropped and only the generic top-level error was shown. [#28308]
 
 ## Version 9.0.3
 * Updated the implementation of -Metadata parameter processing for cmdlets that use it for security. No behavior change.


### PR DESCRIPTION
## Description

Fixes #28308

When `New-AzDeployment` fails validation with `MultipleErrorsOccurred`, the actual inner error details (e.g. `KeyVaultParameterReferenceSecretRetrieveFailed`) were silently dropped. The `HandleError` method was using `ex.InnerException` (the .NET exception chain) as the ARM Details payload instead of `cloudEx.Body.Details`, which holds the true ARM sub-errors from the HTTP response body.

## Root Cause

In `NewResourceManagerSdkClient.HandleError(Exception ex)`, when a `CloudException` is caught, the original code called `HandleError(ex.InnerException)` to populate the `Details` field. However, `CloudException.InnerException` is a low-level HTTP exception, not the ARM nested errors. The ARM nested errors live in `cloudEx.Body.Details` and were never mapped, so `DisplayInnerDetailErrorMessage` was never reached.

## Changes

- Rewrote `HandleError` to use pattern matching for `CloudException` and map `cloudEx.Body?.Details` through a new `ConvertCloudErrorToErrorResponse` helper
- Added `private static ConvertCloudErrorToErrorResponse` that recursively converts `IList<CloudError>` to `IList<ErrorResponse>`, preserving the full nested hierarchy
- Added regression test `ValidateDeployment_WhenCloudExceptionHasNestedDetails_PropagatesInnerErrors`
- Updated ChangeLog.md under Upcoming Release

## Before vs After

**Before:** Only the top-level vague error was shown:
```
New-AzDeployment: MultipleErrorsOccurred
```

**After:** All nested errors are surfaced:
```
New-AzDeployment: MultipleErrorsOccurred
  KeyVaultParameterReferenceSecretRetrieveFailed: Secret 'mySecret1' in Key Vault '...' could not be found
  KeyVaultParameterReferenceSecretRetrieveFailed: Secret 'mySecret2' in Key Vault '...' could not be found
```

## Testing

```powershell
dotnet test src\Resources\Resources.Test\Resources.Test.csproj --filter "ValidateDeployment_WhenCloudExceptionHasNestedDetails_PropagatesInnerErrors"
```

All 15 `ResourceClientTests` pass with 0 regressions.

## Checklist

- [x] Follows Microsoft patterns and naming conventions
- [x] Unit test added for the regression case
- [x] Build succeeds with 0 errors and 0 warnings
- [x] ChangeLog.md updated