### PR TITLE
[KeyVault] Fix New-AzKeyVault RequestDisallowedByPolicy error by explicitly setting enableSoftDelete in the request body

### DIFF
--- a/src/KeyVault/KeyVault.Test/UnitTests/NewAzureKeyVaultSoftDeleteTests.cs
+++ b/src/KeyVault/KeyVault.Test/UnitTests/NewAzureKeyVaultSoftDeleteTests.cs
@@ -1,0 +1,97 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.KeyVault.Models;
+using Microsoft.Azure.Management.KeyVault;
+using Microsoft.Azure.Management.KeyVault.Models;
+using Microsoft.Rest.Azure;
+using Microsoft.WindowsAzure.Commands.ScenarioTest;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
+{
+    /// <summary>
+    /// Verify that New-AzKeyVault explicitly sets EnableSoftDelete=true in the request body
+    /// so that Azure Policy checks requiring the property to be present are satisfied.
+    /// </summary>
+    public class NewAzureKeyVaultSoftDeleteTests : KeyVaultUnitTestBase
+    {
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void CreateNewVault_Sets_EnableSoftDelete_True_In_VaultProperties()
+        {
+            // Arrange
+            VaultCreateOrUpdateParameters capturedParameters = null;
+            var mockVaultsOperations = new Mock<IVaultsOperations>();
+            mockVaultsOperations
+                .Setup(v => v.CreateOrUpdateWithHttpMessagesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<VaultCreateOrUpdateParameters>(),
+                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, VaultCreateOrUpdateParameters, Dictionary<string, List<string>>, CancellationToken>(
+                    (rg, name, parameters, headers, ct) => capturedParameters = parameters)
+                .Returns(Task.FromResult(new AzureOperationResponse<Vault>
+                {
+                    Body = new Vault(
+                        properties: new VaultProperties
+                        {
+                            TenantId = Guid.NewGuid(),
+                            Sku = new Sku(SkuName.Standard),
+                            AccessPolicies = new AccessPolicyEntry[] { },
+                            VaultUri = "https://testvault.vault.azure.net"
+                        },
+                        name: "testvault",
+                        location: "eastus")
+                }));
+
+            var mockClient = new Mock<IKeyVaultManagementClient>();
+            mockClient.Setup(c => c.Vaults).Returns(mockVaultsOperations.Object);
+
+            var vaultManagementClient = new VaultManagementClient();
+            // Use reflection to set the private KeyVaultManagementClient property
+            var prop = typeof(VaultManagementClient).GetProperty("KeyVaultManagementClient",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            prop.SetValue(vaultManagementClient, mockClient.Object);
+
+            var createParameters = new VaultCreationOrUpdateParameters
+            {
+                Name = "testvault",
+                ResourceGroupName = "testrg",
+                Location = "eastus",
+                SkuFamilyName = "A",
+                SkuName = "Standard",
+                TenantId = Guid.NewGuid(),
+                EnableSoftDelete = true,
+                SoftDeleteRetentionInDays = 90,
+                NetworkAcls = new NetworkRuleSet()
+            };
+
+            // Act
+            vaultManagementClient.CreateNewVault(createParameters);
+
+            // Assert
+            Assert.NotNull(capturedParameters);
+            Assert.True(capturedParameters.Properties.EnableSoftDelete,
+                "CreateNewVault must set EnableSoftDelete=true in the request body " +
+                "to satisfy Azure Policy checks");
+        }
+    }
+}

--- a/src/KeyVault/KeyVault.Test/UnitTests/NewAzureKeyVaultSoftDeleteTests.cs
+++ b/src/KeyVault/KeyVault.Test/UnitTests/NewAzureKeyVaultSoftDeleteTests.cs
@@ -13,6 +13,7 @@
 // ----------------------------------------------------------------------------------
 
 using Microsoft.Azure.Commands.KeyVault.Models;
+using Microsoft.Azure.Management.Internal.Resources;
 using Microsoft.Azure.Management.KeyVault;
 using Microsoft.Azure.Management.KeyVault.Models;
 using Microsoft.Rest.Azure;
@@ -20,9 +21,14 @@ using Microsoft.WindowsAzure.Commands.ScenarioTest;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Management.Automation;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using KVSku = Microsoft.Azure.Management.KeyVault.Models.Sku;
 
 namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
 {
@@ -32,14 +38,32 @@ namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
     /// </summary>
     public class NewAzureKeyVaultSoftDeleteTests : KeyVaultUnitTestBase
     {
-        [Fact]
-        [Trait(Category.AcceptanceType, Category.CheckIn)]
-        public void CreateNewVault_Sets_EnableSoftDelete_True_In_VaultProperties()
+        private VaultCreateOrUpdateParameters _capturedSdkParameters;
+        private VaultManagementClient _vaultManagementClient;
+
+        /// <summary>
+        /// A fake HTTP handler that returns an empty resource list for any GET (FilterResources)
+        /// and prevents real network calls during unit tests.
+        /// </summary>
+        private class FakeHttpHandler : HttpClientHandler
         {
-            // Arrange
-            VaultCreateOrUpdateParameters capturedParameters = null;
-            var mockVaultsOperations = new Mock<IVaultsOperations>();
-            mockVaultsOperations
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"value\":[]}")
+                };
+                response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                return Task.FromResult(response);
+            }
+        }
+
+        private void SetupVaultManagementClient()
+        {
+            _capturedSdkParameters = null;
+
+            var mockVaultsOps = new Mock<IVaultsOperations>();
+            mockVaultsOps
                 .Setup(v => v.CreateOrUpdateWithHttpMessagesAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
@@ -47,14 +71,14 @@ namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
                     It.IsAny<Dictionary<string, List<string>>>(),
                     It.IsAny<CancellationToken>()))
                 .Callback<string, string, VaultCreateOrUpdateParameters, Dictionary<string, List<string>>, CancellationToken>(
-                    (rg, name, parameters, headers, ct) => capturedParameters = parameters)
+                    (rg, name, parameters, headers, ct) => _capturedSdkParameters = parameters)
                 .Returns(Task.FromResult(new AzureOperationResponse<Vault>
                 {
                     Body = new Vault(
                         properties: new VaultProperties
                         {
                             TenantId = Guid.NewGuid(),
-                            Sku = new Sku(SkuName.Standard),
+                            Sku = new KVSku(SkuName.Standard),
                             AccessPolicies = new AccessPolicyEntry[] { },
                             VaultUri = "https://testvault.vault.azure.net"
                         },
@@ -62,14 +86,75 @@ namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
                         location: "eastus")
                 }));
 
-            var mockClient = new Mock<IKeyVaultManagementClient>();
-            mockClient.Setup(c => c.Vaults).Returns(mockVaultsOperations.Object);
+            var mockKvMgmtClient = new Mock<IKeyVaultManagementClient>();
+            mockKvMgmtClient.Setup(c => c.Vaults).Returns(mockVaultsOps.Object);
 
-            var vaultManagementClient = new VaultManagementClient();
-            // Use reflection to set the private KeyVaultManagementClient property
-            var prop = typeof(VaultManagementClient).GetProperty("KeyVaultManagementClient",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            prop.SetValue(vaultManagementClient, mockClient.Object);
+            _vaultManagementClient = new VaultManagementClient();
+            typeof(VaultManagementClient)
+                .GetProperty("KeyVaultManagementClient", BindingFlags.NonPublic | BindingFlags.Instance)
+                .SetValue(_vaultManagementClient, mockKvMgmtClient.Object);
+        }
+
+        private ResourceManagementClient CreateFakeResourceClient()
+        {
+            var client = new ResourceManagementClient(
+                new Microsoft.Rest.TokenCredentials("fake-token"),
+                new FakeHttpHandler());
+            client.SubscriptionId = "00000000-0000-0000-0000-000000000000";
+            return client;
+        }
+
+        /// <summary>
+        /// Exercises NewAzureKeyVault.ExecuteCmdlet() end-to-end and verifies that
+        /// the cmdlet hardcodes EnableSoftDelete=true in the outgoing request.
+        /// This test would FAIL if the assignment at NewAzureKeyVault.cs line 171
+        /// were removed, because VaultManagementClient is a pure pass-through
+        /// (as proved by VaultManagementClient_Does_Not_Default_EnableSoftDelete).
+        /// </summary>
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void ExecuteCmdlet_Sets_EnableSoftDelete_True_In_Request()
+        {
+            // Arrange
+            SetupVaultManagementClient();
+
+            var cmdRuntimeMock = new Mock<ICommandRuntime>();
+            cmdRuntimeMock.Setup(cr => cr.ShouldProcess(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
+            var cmdlet = new NewAzureKeyVault
+            {
+                CommandRuntime = cmdRuntimeMock.Object,
+                Name = "test-vault",
+                ResourceGroupName = "test-rg",
+                Location = "eastus"
+            };
+            cmdlet.KeyVaultManagementClient = _vaultManagementClient;
+            cmdlet.ResourceClient = CreateFakeResourceClient();
+
+            // Act
+            cmdlet.ExecuteCmdlet();
+
+            // Assert
+            Assert.NotNull(_capturedSdkParameters);
+            Assert.True(_capturedSdkParameters.Properties.EnableSoftDelete,
+                "NewAzureKeyVault.ExecuteCmdlet() must set EnableSoftDelete=true in the request body " +
+                "so that Azure Policy checks requiring the property to be present are satisfied.");
+        }
+
+        /// <summary>
+        /// Proves VaultManagementClient.CreateNewVault is a pure pass-through:
+        /// it does NOT inject a default for EnableSoftDelete.
+        /// Combined with ExecuteCmdlet_Sets_EnableSoftDelete_True_In_Request, this proves
+        /// that only the cmdlet's hardcoded assignment provides the value.
+        /// If someone removes EnableSoftDelete=true from NewAzureKeyVault.cs,
+        /// the request would go out with EnableSoftDelete=null and Azure Policy would reject it.
+        /// </summary>
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void VaultManagementClient_Does_Not_Default_EnableSoftDelete()
+        {
+            // Arrange
+            SetupVaultManagementClient();
 
             var createParameters = new VaultCreationOrUpdateParameters
             {
@@ -79,19 +164,17 @@ namespace Microsoft.Azure.Commands.KeyVault.Test.UnitTests
                 SkuFamilyName = "A",
                 SkuName = "Standard",
                 TenantId = Guid.NewGuid(),
-                EnableSoftDelete = true,
+                EnableSoftDelete = null, // Deliberately not set
                 SoftDeleteRetentionInDays = 90,
                 NetworkAcls = new NetworkRuleSet()
             };
 
             // Act
-            vaultManagementClient.CreateNewVault(createParameters);
+            _vaultManagementClient.CreateNewVault(createParameters);
 
-            // Assert
-            Assert.NotNull(capturedParameters);
-            Assert.True(capturedParameters.Properties.EnableSoftDelete,
-                "CreateNewVault must set EnableSoftDelete=true in the request body " +
-                "to satisfy Azure Policy checks");
+            // Assert - null in means null out; client does NOT inject a default
+            Assert.NotNull(_capturedSdkParameters);
+            Assert.Null(_capturedSdkParameters.Properties.EnableSoftDelete);
         }
     }
 }

--- a/src/KeyVault/KeyVault/ChangeLog.md
+++ b/src/KeyVault/KeyVault/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Fixed `New-AzKeyVault` `RequestDisallowedByPolicy` error by explicitly setting `enableSoftDelete` in the request body to satisfy Azure Policy checks
 
 ## Version 6.4.3
 * Added upcoming breaking change warning messages to `Get-AzKeyVaultKey` and `Get-AzKeyVaultSecret` for filtering certificate-backed keys and secrets.

--- a/src/KeyVault/KeyVault/Commands/KeyVault/NewAzureKeyVault.cs
+++ b/src/KeyVault/KeyVault/Commands/KeyVault/NewAzureKeyVault.cs
@@ -166,7 +166,9 @@ namespace Microsoft.Azure.Commands.KeyVault
                     EnabledForDeployment = this.EnabledForDeployment.IsPresent ? true : null as bool?,
                     EnabledForTemplateDeployment = EnabledForTemplateDeployment.IsPresent ? true : null as bool?,
                     EnabledForDiskEncryption = EnabledForDiskEncryption.IsPresent ? true : null as bool?,
-                    EnableSoftDelete = null,
+                    // Explicitly set to satisfy Azure Policy checks that require
+                    // enableSoftDelete to be present in the request body.
+                    EnableSoftDelete = true,
                     EnablePurgeProtection = EnablePurgeProtection.IsPresent ? true : (bool?)null, // false is not accepted
                     EnableRbacAuthorization = DisableRbacAuthorization.IsPresent ? false : true,
                     /*


### PR DESCRIPTION
## Description

Explicitly set EnableSoftDelete=true in the request body for New-AzKeyVault to satisfy Azure Policy checks that require the property to be present.

While soft delete is already enabled by default on the service side, Azure Policy checks may require the property to be explicitly present in the request body. Without it, New-AzKeyVault fails with a RequestDisallowedByPolicy error when such policies are enforced.

This is a non-breaking fix — no new parameters are exposed and customer behavior is unchanged.

## Related CLI PR
https://github.com/Azure/azure-cli/pull/33265

## Testing Guide

# Basic vault creation (should succeed without RequestDisallowedByPolicy)
New-AzKeyVault -Name <vault-name> -ResourceGroupName <rg-name> -Location <location>

# Verify soft delete is enabled on the created vault
(Get-AzKeyVault -VaultName <vault-name>).EnableSoftDelete
# Expected: True

## Changes

- \src/KeyVault/KeyVault/Commands/KeyVault/NewAzureKeyVault.cs\ — Changed EnableSoftDelete = null to EnableSoftDelete = true
- \src/KeyVault/KeyVault.Test/UnitTests/NewAzureKeyVaultSoftDeleteTests.cs\ — Added unit test verifying the property is explicitly set
- \src/KeyVault/KeyVault/ChangeLog.md\ — Added changelog entry

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [X] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-powershell/blob/main/CONTRIBUTING.md).
- [X] I have read the [Contribution Guidelines](https://github.com/Azure/azure-powershell/blob/main/CONTRIBUTING.md).
- [X] The changes are non-breaking.