### PR TITLE
[DO NOT MERGE] Add DisableCnameChainValidation to DNS security rule cmdlets

### DIFF
--- a/src/DnsResolver/DnsResolver.Autorest/README.md
+++ b/src/DnsResolver/DnsResolver.Autorest/README.md
@@ -71,7 +71,7 @@ commit: 6e8964026a4ed0f55fdb2c55a141fc7d501b94a6
 require:
   - $(this-folder)/../../readme.azure.noprofile.md
 input-file:
-  - $(repo)/specification/dnsresolver/resource-manager/Microsoft.Network/DnsResolver/preview/2025-10-01-preview/openapi.json
+  - $(repo)/specification/dnsresolver/resource-manager/Microsoft.Network/DnsResolver/preview/2026-07-01-preview/openapi.json
 
 module-version: 0.2.9
 title: DnsResolver
@@ -127,14 +127,14 @@ directive:
     set:
       preview-announcement:
         preview-message: "*****************************************************************************************\\r\\n* This cmdlet will undergo a breaking change in Az v16.0.0, to be released in May 2026. *\\r\\n* At least one change applies to this cmdlet.                                                     *\\r\\n* See all possible breaking changes at https://go.microsoft.com/fwlink/?linkid=2333486            *\\r\\n**************************************************************************************************"
-  # Breaking change: ActionBlockResponseCode parameter removed in 2025-10-01-preview
+  # Breaking change: ActionBlockResponseCode parameter removed in 2026-07-01-preview
   - where:
       verb: New|Update
       subject: PolicyDnsSecurityRule
       parameter-name: ActionBlockResponseCode
     set:
       breaking-change:
-        change-description: The parameter 'ActionBlockResponseCode' has been removed. The block response code is no longer configurable in API version 2025-10-01-preview.
+        change-description: The parameter 'ActionBlockResponseCode' has been removed. The block response code is no longer configurable in API version 2026-07-01-preview.
         deprecated-by-version: 2.0.0
         deprecated-by-azversion: 16.0.0
         change-effective-date: 2026/05/01

--- a/src/DnsResolver/DnsResolver.Autorest/examples/New-AzDnsResolverPolicyDnsSecurityRule.md
+++ b/src/DnsResolver/DnsResolver.Autorest/examples/New-AzDnsResolverPolicyDnsSecurityRule.md
@@ -22,3 +22,16 @@ westus2  sampleSecurityRule       Microsoft.Network/dnsSecurityRules       "0000
 ```
 
 This cmdlet creates a DNS security rule with tag.
+
+### Example 3: Create a DNS security rule with DisableCnameChainValidation
+```powershell
+New-AzDnsResolverPolicyDnsSecurityRule -Name sampleSecurityRule -ResourceGroupName powershell-test-rg -DnsResolverPolicyName samplePolicyName -Location westus2 -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DnsResolverDomainList @{id = "/subscriptions/0e5a46b1-de0b-4ec3-a5d7-dda908b4e076/resourceGroups/powershell-test-rg/providers/Microsoft.Network/dnsResolverDomainLists/exampleDomainListName";} -DisableCnameChainValidation
+```
+
+```output
+Location Name                     Type                                     Etag
+-------- ----                     ----                                     ----
+westus2  sampleSecurityRule       Microsoft.Network/dnsSecurityRules       "00009ad5-0000-0800-0000-604016d10000"
+```
+
+This cmdlet creates a DNS security rule with CNAME chain validation disabled. When set, the resolver will not validate the full CNAME chain against domain lists and will match only on the queried domain name.

--- a/src/DnsResolver/DnsResolver.Autorest/examples/Update-AzDnsResolverPolicyDnsSecurityRule.md
+++ b/src/DnsResolver/DnsResolver.Autorest/examples/Update-AzDnsResolverPolicyDnsSecurityRule.md
@@ -23,3 +23,15 @@ Location Name                                Type                               
 westus2  psdnssecurityrulename33nmy1fz       Microsoft.Network/dnsSecurityRules       "0000efd6-0000-0800-0000-60401c7c0000"
 ```
 This command updates an existing DNS Security Rules by identity ( removing tag ).
+
+### Example 3: Update DNS Security Rule with DisableCnameChainValidation
+```powershell
+Update-AzDnsResolverPolicyDnsSecurityRule -ResourceGroupName powershell-test-rg -DnsResolverPolicyName exampleDnsResolverPolicyName -Name psdnssecurityrulename33nmy1fz -DisableCnameChainValidation
+```
+
+```output
+Location Name                                Type                                     Etag
+-------- ----                                ----                                     ----
+westus2  psdnssecurityrulename33nmy1fz       Microsoft.Network/dnsSecurityRules       "0000f0d6-0000-0800-0000-60401c7d0000"
+```
+This command updates a DNS Security Rule to disable CNAME chain validation. When set, the resolver will not validate the full CNAME chain against domain lists and will match only on the queried domain name.

--- a/src/DnsResolver/DnsResolver.Autorest/test/Get-AzDnsResolverPolicyDnsSecurityRule.Recording.json
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Get-AzDnsResolverPolicyDnsSecurityRule.Recording.json
@@ -1,8 +1,8 @@
 {
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g?api-version=2025-10-01-preview+1": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag?api-version=2026-07-01-preview+1": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g?api-version=2025-10-01-preview",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag?api-version=2026-07-01-preview",
       "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
       "isContentBase64": false,
       "Headers": {
@@ -15,46 +15,29 @@
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:26:14 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "e94555ed-2465-4514-8c59-b39825fba17d" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=?api-version=2025-10-01-preview\u0026t=639096254014216048\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=XKmrsCyraCsta8K5Vt8-19flELTkFxRkY1qrTLBZ1pUWYMhpg0P6zmjim9tJywoAmDXDXO9OBF8g7DtF-7scRoyoNPSOD2vxeG9KLXwjHFyDAtW5bk077Q_MOQeb-WsuBFXdHZbpfmgVWo-w9rZ0ffQqUBxzlWTRJ8pHYLitQ1M9IM-nSHOwdezIZFUHwkIcRO9Oy88l8n4CAFeK2p4Fb05wSjBI62tGTbi923TwCtAMu48pNhBnrtZ1Po1IJqai-j0NWGapBhhOPF8o1WNFfmbAT9VQ7ELKygWM1AIrKvTYTs_dpnCUnD_07wZ8L7W-pqlwH3Uclap5TdOPWLJPaA\u0026h=9xh6Qh3U79N4bLy_X-xenPCbeSYMQ_s8fcpYcm9F49k" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/54de0ac5-cd0f-4975-b9cd-54bb3f51d4a6" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "e94555ed-2465-4514-8c59-b39825fba17d" ],
-        "x-ms-correlation-request-id": [ "e94555ed-2465-4514-8c59-b39825fba17d" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174321Z:e94555ed-2465-4514-8c59-b39825fba17d" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 3D5CFC47A3C74AF6A3829E46B7DCB5C9 Ref B: MWH011020807060 Ref C: 2026-03-20T17:43:20Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:43:21 GMT" ]
+        "x-ms-activity-id": [ "6cde24e1-27a5-4c19-b5a6-e6142d749010" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYjBjODA0MzgtYzIxNS00Mzg2LTg2MTctZGRkNDYwMzJhNDNkIn0=?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "528" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "421" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5601a761-0000-0700-0000-69bd87390000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g\",\"name\":\"policy-secrule-g\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T17:43:21.0466097Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:43:21.0466097Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080051ae-0000-0800-0000-69fa6e870000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag\",\"name\":\"psdnsresolverpolicyforrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=?api-version=2025-10-01-preview\u0026t=639096254014216048\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=XKmrsCyraCsta8K5Vt8-19flELTkFxRkY1qrTLBZ1pUWYMhpg0P6zmjim9tJywoAmDXDXO9OBF8g7DtF-7scRoyoNPSOD2vxeG9KLXwjHFyDAtW5bk077Q_MOQeb-WsuBFXdHZbpfmgVWo-w9rZ0ffQqUBxzlWTRJ8pHYLitQ1M9IM-nSHOwdezIZFUHwkIcRO9Oy88l8n4CAFeK2p4Fb05wSjBI62tGTbi923TwCtAMu48pNhBnrtZ1Po1IJqai-j0NWGapBhhOPF8o1WNFfmbAT9VQ7ELKygWM1AIrKvTYTs_dpnCUnD_07wZ8L7W-pqlwH3Uclap5TdOPWLJPaA\u0026h=9xh6Qh3U79N4bLy_X-xenPCbeSYMQ_s8fcpYcm9F49k+2": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYjBjODA0MzgtYzIxNS00Mzg2LTg2MTctZGRkNDYwMzJhNDNkIn0=?api-version=2026-07-01-preview+2": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=?api-version=2025-10-01-preview\u0026t=639096254014216048\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=XKmrsCyraCsta8K5Vt8-19flELTkFxRkY1qrTLBZ1pUWYMhpg0P6zmjim9tJywoAmDXDXO9OBF8g7DtF-7scRoyoNPSOD2vxeG9KLXwjHFyDAtW5bk077Q_MOQeb-WsuBFXdHZbpfmgVWo-w9rZ0ffQqUBxzlWTRJ8pHYLitQ1M9IM-nSHOwdezIZFUHwkIcRO9Oy88l8n4CAFeK2p4Fb05wSjBI62tGTbi923TwCtAMu48pNhBnrtZ1Po1IJqai-j0NWGapBhhOPF8o1WNFfmbAT9VQ7ELKygWM1AIrKvTYTs_dpnCUnD_07wZ8L7W-pqlwH3Uclap5TdOPWLJPaA\u0026h=9xh6Qh3U79N4bLy_X-xenPCbeSYMQ_s8fcpYcm9F49k",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYjBjODA0MzgtYzIxNS00Mzg2LTg2MTctZGRkNDYwMzJhNDNkIn0=?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "3" ],
-        "x-ms-client-request-id": [ "3d0e91db-2b03-4ed4-9ed3-633ae41b7ff7" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -62,260 +45,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "8efd1b6f-4001-4f71-892d-3dce2ee6cf18" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/2bd4314f-7ceb-465b-8551-0475e909ec9f" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "8efd1b6f-4001-4f71-892d-3dce2ee6cf18" ],
-        "x-ms-correlation-request-id": [ "8efd1b6f-4001-4f71-892d-3dce2ee6cf18" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174327Z:8efd1b6f-4001-4f71-892d-3dce2ee6cf18" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 2CDA5ABB627C4E358902FD042018B01E Ref B: MWH011020807060 Ref C: 2026-03-20T17:43:26Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:43:27 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "511" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=\",\"startTime\":\"2026-03-20T17:43:21.0000000Z\",\"status\":\"InProgress\"}",
-      "isContentBase64": false
-    }
-  },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=?api-version=2025-10-01-preview\u0026t=639096254014216048\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=XKmrsCyraCsta8K5Vt8-19flELTkFxRkY1qrTLBZ1pUWYMhpg0P6zmjim9tJywoAmDXDXO9OBF8g7DtF-7scRoyoNPSOD2vxeG9KLXwjHFyDAtW5bk077Q_MOQeb-WsuBFXdHZbpfmgVWo-w9rZ0ffQqUBxzlWTRJ8pHYLitQ1M9IM-nSHOwdezIZFUHwkIcRO9Oy88l8n4CAFeK2p4Fb05wSjBI62tGTbi923TwCtAMu48pNhBnrtZ1Po1IJqai-j0NWGapBhhOPF8o1WNFfmbAT9VQ7ELKygWM1AIrKvTYTs_dpnCUnD_07wZ8L7W-pqlwH3Uclap5TdOPWLJPaA\u0026h=9xh6Qh3U79N4bLy_X-xenPCbeSYMQ_s8fcpYcm9F49k+3": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=?api-version=2025-10-01-preview\u0026t=639096254014216048\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=XKmrsCyraCsta8K5Vt8-19flELTkFxRkY1qrTLBZ1pUWYMhpg0P6zmjim9tJywoAmDXDXO9OBF8g7DtF-7scRoyoNPSOD2vxeG9KLXwjHFyDAtW5bk077Q_MOQeb-WsuBFXdHZbpfmgVWo-w9rZ0ffQqUBxzlWTRJ8pHYLitQ1M9IM-nSHOwdezIZFUHwkIcRO9Oy88l8n4CAFeK2p4Fb05wSjBI62tGTbi923TwCtAMu48pNhBnrtZ1Po1IJqai-j0NWGapBhhOPF8o1WNFfmbAT9VQ7ELKygWM1AIrKvTYTs_dpnCUnD_07wZ8L7W-pqlwH3Uclap5TdOPWLJPaA\u0026h=9xh6Qh3U79N4bLy_X-xenPCbeSYMQ_s8fcpYcm9F49k",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "4" ],
-        "x-ms-client-request-id": [ "3d0e91db-2b03-4ed4-9ed3-633ae41b7ff7" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "1f82a7b0-999c-48f7-b068-0e3e97e3db6c" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/a05fa5e8-f5f2-4c07-b8b8-c0b5228ef486" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "1f82a7b0-999c-48f7-b068-0e3e97e3db6c" ],
-        "x-ms-correlation-request-id": [ "1f82a7b0-999c-48f7-b068-0e3e97e3db6c" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174359Z:1f82a7b0-999c-48f7-b068-0e3e97e3db6c" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: DE1FBA771FFF4D91BB821C459A774B98 Ref B: MWH011020807060 Ref C: 2026-03-20T17:43:57Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:43:58 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "551" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYWRjZTUxNjgtYWM0Ny00ZTQ2LThmNmYtMDE4OTg0MGExZGE1In0=\",\"startTime\":\"2026-03-20T17:43:21.0000000Z\",\"endTime\":\"2026-03-20T17:43:32.0000000Z\",\"status\":\"Succeeded\"}",
-      "isContentBase64": false
-    }
-  },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g?api-version=2025-10-01-preview+4": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "5" ],
-        "x-ms-client-request-id": [ "3d0e91db-2b03-4ed4-9ed3-633ae41b7ff7" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "72e5acd3-09e1-4954-b123-40efb8338a5b" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "72e5acd3-09e1-4954-b123-40efb8338a5b" ],
-        "x-ms-correlation-request-id": [ "72e5acd3-09e1-4954-b123-40efb8338a5b" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174400Z:72e5acd3-09e1-4954-b123-40efb8338a5b" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 441E5A4951ED4307886670C2A70B761E Ref B: MWH011020807060 Ref C: 2026-03-20T17:43:59Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:43:59 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "563" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"dbd04a2e-fbed-48b5-afa1-8f0280c7e89f\"},\"etag\":\"\\\"d0001948-0000-0700-0000-69bd87420000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g\",\"name\":\"policy-secrule-g\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T17:43:21.0466097Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:43:21.0466097Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g?api-version=2025-10-01-preview+5": {
-    "Request": {
-      "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\" ]\r\n  }\r\n}",
-      "isContentBase64": false,
-      "Headers": {
-      },
-      "ContentHeaders": {
-        "Content-Type": [ "application/json" ],
-        "Content-Length": [ "89" ]
-      }
-    },
-    "Response": {
-      "StatusCode": 201,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g?api-version=2025-10-01-preview" ],
-        "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "6edb9af9-efe9-48e5-92f9-95babc66a17b" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9?api-version=2025-10-01-preview\u0026t=639096254418190718\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=kwyeMatZwxyb0_AY10_-O5Mhi1BKUQkpsgxwHNB5y_nz0h9VhurZZC_iVWihsiXwLSihRlnGdte7VuVcLQmD4rTq5gZAqO5p5ZE0U6VmdRAarh0jU4LcQ4AlFFQ43GxrUCAUL7uxbLGQVb2TTh0NlUG02thQuZCs1fuNa04eSVhEN6d3-bTG3eBb83gt1E4JkUDAV8abTtfLnbOsQ-t2799R6e8ZdgcbYrZUdr9IacRSUse77LtVShi8IgKA98jl61KNTGdwRxjaWt6SboolC1Zwe7KRlf2F_yQHYl738qkhKQ6JBFc30IAHEJ-_-riTFVG6ftcwlh_uS3DmHR4Brw\u0026h=_RKZjNTSgX7LngKapyMWXNzMQEC3kBFLYkgh3LmPaNI" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/993319e7-6715-4c77-89ce-ba38400a314d" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "6edb9af9-efe9-48e5-92f9-95babc66a17b" ],
-        "x-ms-correlation-request-id": [ "6edb9af9-efe9-48e5-92f9-95babc66a17b" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174401Z:6edb9af9-efe9-48e5-92f9-95babc66a17b" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: CBAF4276DE4648AE91A2496F79279EF1 Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:00Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:01 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "587" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5601bc63-0000-0700-0000-69bd87610000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\",\"name\":\"domainlist-secrule-g\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:01.4444031Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:01.4444031Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9?api-version=2025-10-01-preview\u0026t=639096254418190718\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=kwyeMatZwxyb0_AY10_-O5Mhi1BKUQkpsgxwHNB5y_nz0h9VhurZZC_iVWihsiXwLSihRlnGdte7VuVcLQmD4rTq5gZAqO5p5ZE0U6VmdRAarh0jU4LcQ4AlFFQ43GxrUCAUL7uxbLGQVb2TTh0NlUG02thQuZCs1fuNa04eSVhEN6d3-bTG3eBb83gt1E4JkUDAV8abTtfLnbOsQ-t2799R6e8ZdgcbYrZUdr9IacRSUse77LtVShi8IgKA98jl61KNTGdwRxjaWt6SboolC1Zwe7KRlf2F_yQHYl738qkhKQ6JBFc30IAHEJ-_-riTFVG6ftcwlh_uS3DmHR4Brw\u0026h=_RKZjNTSgX7LngKapyMWXNzMQEC3kBFLYkgh3LmPaNI+6": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9?api-version=2025-10-01-preview\u0026t=639096254418190718\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=kwyeMatZwxyb0_AY10_-O5Mhi1BKUQkpsgxwHNB5y_nz0h9VhurZZC_iVWihsiXwLSihRlnGdte7VuVcLQmD4rTq5gZAqO5p5ZE0U6VmdRAarh0jU4LcQ4AlFFQ43GxrUCAUL7uxbLGQVb2TTh0NlUG02thQuZCs1fuNa04eSVhEN6d3-bTG3eBb83gt1E4JkUDAV8abTtfLnbOsQ-t2799R6e8ZdgcbYrZUdr9IacRSUse77LtVShi8IgKA98jl61KNTGdwRxjaWt6SboolC1Zwe7KRlf2F_yQHYl738qkhKQ6JBFc30IAHEJ-_-riTFVG6ftcwlh_uS3DmHR4Brw\u0026h=_RKZjNTSgX7LngKapyMWXNzMQEC3kBFLYkgh3LmPaNI",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "7" ],
-        "x-ms-client-request-id": [ "ab86473a-6c7f-4308-aea5-3ab4864c6680" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "28d16055-7412-4485-8ae4-13e4fcc1c100" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/3de8a442-da07-4cd4-9d95-417c391d7940" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "28d16055-7412-4485-8ae4-13e4fcc1c100" ],
-        "x-ms-correlation-request-id": [ "28d16055-7412-4485-8ae4-13e4fcc1c100" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174407Z:28d16055-7412-4485-8ae4-13e4fcc1c100" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 034E5BD5C3F84B628F1F127F28A8A11D Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:06Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:07 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "519" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9\",\"startTime\":\"2026-03-20T17:44:01.0000000Z\",\"status\":\"InProgress\"}",
-      "isContentBase64": false
-    }
-  },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9?api-version=2025-10-01-preview\u0026t=639096254418190718\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=kwyeMatZwxyb0_AY10_-O5Mhi1BKUQkpsgxwHNB5y_nz0h9VhurZZC_iVWihsiXwLSihRlnGdte7VuVcLQmD4rTq5gZAqO5p5ZE0U6VmdRAarh0jU4LcQ4AlFFQ43GxrUCAUL7uxbLGQVb2TTh0NlUG02thQuZCs1fuNa04eSVhEN6d3-bTG3eBb83gt1E4JkUDAV8abTtfLnbOsQ-t2799R6e8ZdgcbYrZUdr9IacRSUse77LtVShi8IgKA98jl61KNTGdwRxjaWt6SboolC1Zwe7KRlf2F_yQHYl738qkhKQ6JBFc30IAHEJ-_-riTFVG6ftcwlh_uS3DmHR4Brw\u0026h=_RKZjNTSgX7LngKapyMWXNzMQEC3kBFLYkgh3LmPaNI+7": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9?api-version=2025-10-01-preview\u0026t=639096254418190718\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=kwyeMatZwxyb0_AY10_-O5Mhi1BKUQkpsgxwHNB5y_nz0h9VhurZZC_iVWihsiXwLSihRlnGdte7VuVcLQmD4rTq5gZAqO5p5ZE0U6VmdRAarh0jU4LcQ4AlFFQ43GxrUCAUL7uxbLGQVb2TTh0NlUG02thQuZCs1fuNa04eSVhEN6d3-bTG3eBb83gt1E4JkUDAV8abTtfLnbOsQ-t2799R6e8ZdgcbYrZUdr9IacRSUse77LtVShi8IgKA98jl61KNTGdwRxjaWt6SboolC1Zwe7KRlf2F_yQHYl738qkhKQ6JBFc30IAHEJ-_-riTFVG6ftcwlh_uS3DmHR4Brw\u0026h=_RKZjNTSgX7LngKapyMWXNzMQEC3kBFLYkgh3LmPaNI",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "8" ],
-        "x-ms-client-request-id": [ "ab86473a-6c7f-4308-aea5-3ab4864c6680" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "5e2f5f0c-4c0e-4fb6-9260-dfa91420d858" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/3429fbd4-197a-48da-a43c-c90739145061" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "5e2f5f0c-4c0e-4fb6-9260-dfa91420d858" ],
-        "x-ms-correlation-request-id": [ "5e2f5f0c-4c0e-4fb6-9260-dfa91420d858" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174439Z:5e2f5f0c-4c0e-4fb6-9260-dfa91420d858" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: BDC7E8802E9747E6BCBF8D37273A7DCA Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:38Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:39 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:19 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "80e2cc7a-892b-4d32-8460-ffaf9d521687" ]
       },
       "ContentHeaders": {
         "Content-Length": [ "559" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRmMTY0MmY5LWZmNGQtNDA4ZS1hMDFhLWNlOGM1NGQxODhkMiJ9\",\"startTime\":\"2026-03-20T17:44:01.0000000Z\",\"endTime\":\"2026-03-20T17:44:12.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYjBjODA0MzgtYzIxNS00Mzg2LTg2MTctZGRkNDYwMzJhNDNkIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYjBjODA0MzgtYzIxNS00Mzg2LTg2MTctZGRkNDYwMzJhNDNkIn0=\",\"startTime\":\"2026-05-05T22:26:15.0000000Z\",\"endTime\":\"2026-05-05T22:26:19.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g?api-version=2025-10-01-preview+8": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag?api-version=2026-07-01-preview+3": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "9" ],
-        "x-ms-client-request-id": [ "ab86473a-6c7f-4308-aea5-3ab4864c6680" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -323,84 +72,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "8eef8da6-8c0b-4bd1-a712-29d8426b4925" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "8eef8da6-8c0b-4bd1-a712-29d8426b4925" ],
-        "x-ms-correlation-request-id": [ "8eef8da6-8c0b-4bd1-a712-29d8426b4925" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174440Z:8eef8da6-8c0b-4bd1-a712-29d8426b4925" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: FD37062752534164A444DA77FA172085 Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:39Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:40 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:20 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "8ee1d6fc-8950-42e0-b4ee-da207befc2c4" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "622" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "456" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"9d868a28-4160-4a58-934b-f80ace26bc85\"},\"etag\":\"\\\"0f0021f6-0000-0700-0000-69bd876a0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\",\"name\":\"domainlist-secrule-g\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:01.4444031Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:01.4444031Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"eee63c2f-b4df-45a7-97d3-e0b4475469e0\"},\"etag\":\"\\\"12006854-0000-0800-0000-69fa6e8b0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag\",\"name\":\"psdnsresolverpolicyforrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview+9": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag?api-version=2026-07-01-preview+4": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "405" ]
+        "Content-Length": [ "105" ]
       }
     },
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:26:20 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "abd138ac-3f3b-40e9-90e5-cdc421cbbd41" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9?api-version=2025-10-01-preview\u0026t=639096254831120049\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=oyP3EFZhBFmYcYVu58YkpEAvL5cuk6uhOtJT9x9qy9i8Bv-GGYtLyuwqaRlSZ2_X-rHyUC2-5RFgFi-sY4RiVURMbXeN4u7whCx8gpKxL3K528Of95pb56YM-vZ8NCM-O-k4LExl8DDAPe7Ut5VKPmCbnXnDaD5rNLDhc-9gmAsL6XNyc0jnzO9mgh9VVA3bNs-mfeG0q1TxKycWVTV42qGQ3AT0C01prMDfV3F5NsSmWvQ1R5E4GLrnvs64_bBEnt1Phic0AeW-mJ5XghENWXGPJ3l68Wgk2mZe8NxNVZpfJao5pRprLf_TkBWvDpIGVjTnxWT9KaV7GzLFerSG7Q\u0026h=dsNEGGGDyS7XrfEQhrUJlHjbdXh6jQJfCM9En89nTWY" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/137d2ca4-efa4-4dde-ac36-6194e4ed4228" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "abd138ac-3f3b-40e9-90e5-cdc421cbbd41" ],
-        "x-ms-correlation-request-id": [ "abd138ac-3f3b-40e9-90e5-cdc421cbbd41" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174443Z:abd138ac-3f3b-40e9-90e5-cdc421cbbd41" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 77835F81C2F04A3C88DF039DE3F86C76 Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:40Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:42 GMT" ]
+        "x-ms-activity-id": [ "77f680fb-dc50-4ad9-affd-53e3ad568760" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ5ZjNmODhkLTZiZjctNDEwNS04OTI4LWNjODIwMTVlMDYwOSJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "865" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "495" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"d000044e-0000-0700-0000-69bd878a0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1\",\"name\":\"secrule-get-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:42.5494982Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:42.5494982Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080093ae-0000-0800-0000-69fa6e8c0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\",\"name\":\"psdnsresolverdomainlistforrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9?api-version=2025-10-01-preview\u0026t=639096254831120049\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=oyP3EFZhBFmYcYVu58YkpEAvL5cuk6uhOtJT9x9qy9i8Bv-GGYtLyuwqaRlSZ2_X-rHyUC2-5RFgFi-sY4RiVURMbXeN4u7whCx8gpKxL3K528Of95pb56YM-vZ8NCM-O-k4LExl8DDAPe7Ut5VKPmCbnXnDaD5rNLDhc-9gmAsL6XNyc0jnzO9mgh9VVA3bNs-mfeG0q1TxKycWVTV42qGQ3AT0C01prMDfV3F5NsSmWvQ1R5E4GLrnvs64_bBEnt1Phic0AeW-mJ5XghENWXGPJ3l68Wgk2mZe8NxNVZpfJao5pRprLf_TkBWvDpIGVjTnxWT9KaV7GzLFerSG7Q\u0026h=dsNEGGGDyS7XrfEQhrUJlHjbdXh6jQJfCM9En89nTWY+10": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ5ZjNmODhkLTZiZjctNDEwNS04OTI4LWNjODIwMTVlMDYwOSJ9?api-version=2026-07-01-preview+5": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9?api-version=2025-10-01-preview\u0026t=639096254831120049\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=oyP3EFZhBFmYcYVu58YkpEAvL5cuk6uhOtJT9x9qy9i8Bv-GGYtLyuwqaRlSZ2_X-rHyUC2-5RFgFi-sY4RiVURMbXeN4u7whCx8gpKxL3K528Of95pb56YM-vZ8NCM-O-k4LExl8DDAPe7Ut5VKPmCbnXnDaD5rNLDhc-9gmAsL6XNyc0jnzO9mgh9VVA3bNs-mfeG0q1TxKycWVTV42qGQ3AT0C01prMDfV3F5NsSmWvQ1R5E4GLrnvs64_bBEnt1Phic0AeW-mJ5XghENWXGPJ3l68Wgk2mZe8NxNVZpfJao5pRprLf_TkBWvDpIGVjTnxWT9KaV7GzLFerSG7Q\u0026h=dsNEGGGDyS7XrfEQhrUJlHjbdXh6jQJfCM9En89nTWY",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ5ZjNmODhkLTZiZjctNDEwNS04OTI4LWNjODIwMTVlMDYwOSJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "11" ],
-        "x-ms-client-request-id": [ "99c4602c-3b3b-41be-a71d-36fcc571f198" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -408,43 +130,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "7c8e50ed-579f-46e9-aa93-b4cd5c276ee1" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/50061dbf-4691-4c81-9c89-c2638aa9fc4c" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "7c8e50ed-579f-46e9-aa93-b4cd5c276ee1" ],
-        "x-ms-correlation-request-id": [ "7c8e50ed-579f-46e9-aa93-b4cd5c276ee1" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174449Z:7c8e50ed-579f-46e9-aa93-b4cd5c276ee1" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 296DBB3D67734D0AB97366AAA33E367A Ref B: MWH011020807060 Ref C: 2026-03-20T17:44:48Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:44:49 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:25 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "f0be8513-9556-422e-a880-8c5d4cff6340" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "503" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "567" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9\",\"startTime\":\"2026-03-20T17:44:42.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ5ZjNmODhkLTZiZjctNDEwNS04OTI4LWNjODIwMTVlMDYwOSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ5ZjNmODhkLTZiZjctNDEwNS04OTI4LWNjODIwMTVlMDYwOSJ9\",\"startTime\":\"2026-05-05T22:26:20.0000000Z\",\"endTime\":\"2026-05-05T22:26:23.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9?api-version=2025-10-01-preview\u0026t=639096254831120049\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=oyP3EFZhBFmYcYVu58YkpEAvL5cuk6uhOtJT9x9qy9i8Bv-GGYtLyuwqaRlSZ2_X-rHyUC2-5RFgFi-sY4RiVURMbXeN4u7whCx8gpKxL3K528Of95pb56YM-vZ8NCM-O-k4LExl8DDAPe7Ut5VKPmCbnXnDaD5rNLDhc-9gmAsL6XNyc0jnzO9mgh9VVA3bNs-mfeG0q1TxKycWVTV42qGQ3AT0C01prMDfV3F5NsSmWvQ1R5E4GLrnvs64_bBEnt1Phic0AeW-mJ5XghENWXGPJ3l68Wgk2mZe8NxNVZpfJao5pRprLf_TkBWvDpIGVjTnxWT9KaV7GzLFerSG7Q\u0026h=dsNEGGGDyS7XrfEQhrUJlHjbdXh6jQJfCM9En89nTWY+11": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag?api-version=2026-07-01-preview+6": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9?api-version=2025-10-01-preview\u0026t=639096254831120049\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=oyP3EFZhBFmYcYVu58YkpEAvL5cuk6uhOtJT9x9qy9i8Bv-GGYtLyuwqaRlSZ2_X-rHyUC2-5RFgFi-sY4RiVURMbXeN4u7whCx8gpKxL3K528Of95pb56YM-vZ8NCM-O-k4LExl8DDAPe7Ut5VKPmCbnXnDaD5rNLDhc-9gmAsL6XNyc0jnzO9mgh9VVA3bNs-mfeG0q1TxKycWVTV42qGQ3AT0C01prMDfV3F5NsSmWvQ1R5E4GLrnvs64_bBEnt1Phic0AeW-mJ5XghENWXGPJ3l68Wgk2mZe8NxNVZpfJao5pRprLf_TkBWvDpIGVjTnxWT9KaV7GzLFerSG7Q\u0026h=dsNEGGGDyS7XrfEQhrUJlHjbdXh6jQJfCM9En89nTWY",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "12" ],
-        "x-ms-client-request-id": [ "99c4602c-3b3b-41be-a71d-36fcc571f198" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -452,43 +157,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "495e6307-58f3-4eed-a36a-3ad061614c7b" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/795aac82-d463-413d-bf31-d1b62dc63dee" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "495e6307-58f3-4eed-a36a-3ad061614c7b" ],
-        "x-ms-correlation-request-id": [ "495e6307-58f3-4eed-a36a-3ad061614c7b" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174519Z:495e6307-58f3-4eed-a36a-3ad061614c7b" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: F1F9E493ABD14437A6DE99E6CAA931C0 Ref B: MWH011020807060 Ref C: 2026-03-20T17:45:19Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:45:19 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:25 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "323f4369-07bb-4a7e-b5a1-de922ca6251e" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "543" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "530" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImFjNDY1ZmEzLTM3NzUtNDU5OS1iMDZiLTA4MjY5ZGUzOTQ0MSJ9\",\"startTime\":\"2026-03-20T17:44:42.0000000Z\",\"endTime\":\"2026-03-20T17:44:54.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"54c95e31-b993-4a57-8670-d84f59390d1d\"},\"etag\":\"\\\"a2083c7b-0000-0800-0000-69fa6e8e0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\",\"name\":\"psdnsresolverdomainlistforrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview+12": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "434" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:25 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "e7895842-f2d5-42ed-8392-757b29befdfe" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY3YzZmNzI1LTg0MTUtNDMwZC1iY2M3LWU1NDMwYjNiYTc0YyJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "796" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"1200d054-0000-0800-0000-69fa6e920000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag\",\"name\":\"psdnssecurityrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY3YzZmNzI1LTg0MTUtNDMwZC1iY2M3LWU1NDMwYjNiYTc0YyJ9?api-version=2026-07-01-preview+8": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY3YzZmNzI1LTg0MTUtNDMwZC1iY2M3LWU1NDMwYjNiYTc0YyJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "13" ],
-        "x-ms-client-request-id": [ "99c4602c-3b3b-41be-a71d-36fcc571f198" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -496,42 +215,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "3486c8c4-4ed6-42b9-9ec3-041f9e40edcb" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "3486c8c4-4ed6-42b9-9ec3-041f9e40edcb" ],
-        "x-ms-correlation-request-id": [ "3486c8c4-4ed6-42b9-9ec3-041f9e40edcb" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174520Z:3486c8c4-4ed6-42b9-9ec3-041f9e40edcb" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 0F5B608027CF4BFE8635DDA5687F8A11 Ref B: MWH011020807060 Ref C: 2026-03-20T17:45:19Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:45:20 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:30 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "383db1c1-bfbb-4d44-8ac2-9e2916d929d0" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "866" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "551" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"c8006e09-0000-0700-0000-69bd87930000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1\",\"name\":\"secrule-get-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:42.5494982Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:42.5494982Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY3YzZmNzI1LTg0MTUtNDMwZC1iY2M3LWU1NDMwYjNiYTc0YyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY3YzZmNzI1LTg0MTUtNDMwZC1iY2M3LWU1NDMwYjNiYTc0YyJ9\",\"startTime\":\"2026-05-05T22:26:26.0000000Z\",\"endTime\":\"2026-05-05T22:26:29.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get a security rule by name+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview+1": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview+9": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "x-ms-unique-id": [ "14" ],
-        "x-ms-client-request-id": [ "7322d91b-cefa-4569-ab96-fa1fcb3b85bc" ],
-        "CommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule_Get" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ],
-        "Authorization": [ "[Filtered]" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -539,42 +242,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "4c09f779-f2ed-411a-a41b-457c98f1c41d" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "4c09f779-f2ed-411a-a41b-457c98f1c41d" ],
-        "x-ms-correlation-request-id": [ "4c09f779-f2ed-411a-a41b-457c98f1c41d" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174522Z:4c09f779-f2ed-411a-a41b-457c98f1c41d" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: CD76FDD39ECF4D018BE4D5A470A0F4ED Ref B: MWH011020807060 Ref C: 2026-03-20T17:45:21Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:45:21 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:30 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "6bd155ae-67c5-4605-bfcb-86c4fcef1c67" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "866" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "797" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"c8006e09-0000-0700-0000-69bd87930000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1\",\"name\":\"secrule-get-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:42.5494982Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:42.5494982Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900db2e-0000-0800-0000-69fa6e950000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag\",\"name\":\"psdnssecurityrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
       "isContentBase64": false
     }
   },
-  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List security rules in policy+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules?api-version=2025-10-01-preview+1": {
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Get single DNS security rule by name, expect DNS security rule by name retrieved+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview+10": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "x-ms-unique-id": [ "15" ],
-        "x-ms-client-request-id": [ "00d6b172-9fcc-4cd6-ad74-293457981a43" ],
-        "CommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule_List" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ],
-        "Authorization": [ "[Filtered]" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -582,27 +269,297 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-original-request-ids": [ "" ],
-        "x-ms-activity-id": [ "a38bf25c-bac1-4c1c-9338-baab8071905c" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-ratelimit-remaining-subscription-resource-entities-read": [ "60000" ],
-        "x-ms-request-id": [ "a38bf25c-bac1-4c1c-9338-baab8071905c" ],
-        "x-ms-correlation-request-id": [ "a38bf25c-bac1-4c1c-9338-baab8071905c" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T174523Z:a38bf25c-bac1-4c1c-9338-baab8071905c" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 881B5502AFB449EDB7EB04AD9F1554BD Ref B: MWH011020807060 Ref C: 2026-03-20T17:45:22Z" ],
-        "Date": [ "Fri, 20 Mar 2026 17:45:23 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:26:30 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "0874d605-4c79-4722-9955-3f9650e09792" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "878" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "797" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"value\":[{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"c8006e09-0000-0700-0000-69bd87930000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-get-41328/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-g/dnsSecurityRules/secrule-get-1\",\"name\":\"secrule-get-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T17:44:42.5494982Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T17:44:42.5494982Z\",\"lastModifiedByType\":\"User\"}}]}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename1m0cdag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900db2e-0000-0800-0000-69fa6e950000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename1m0cdag/dnsSecurityRules/psdnssecurityrulename1m0cdag\",\"name\":\"psdnssecurityrulename1m0cdag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag?api-version=2026-07-01-preview+1": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "29" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:31 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "f1831e24-35f4-47dc-b711-90fe7757c6e6" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiNDg4ZTQ5NWUtN2JhNy00OTQ2LTgyYzgtMmVhMjVhMDQwMWM0In0=?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "421" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080006af-0000-0800-0000-69fa6e970000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag\",\"name\":\"psdnsresolverpolicyforrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiNDg4ZTQ5NWUtN2JhNy00OTQ2LTgyYzgtMmVhMjVhMDQwMWM0In0=?api-version=2026-07-01-preview+2": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiNDg4ZTQ5NWUtN2JhNy00OTQ2LTgyYzgtMmVhMjVhMDQwMWM0In0=?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "41c73d71-3cb9-48fb-bb78-09be8ce86b09" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "559" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiNDg4ZTQ5NWUtN2JhNy00OTQ2LTgyYzgtMmVhMjVhMDQwMWM0In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiNDg4ZTQ5NWUtN2JhNy00OTQ2LTgyYzgtMmVhMjVhMDQwMWM0In0=\",\"startTime\":\"2026-05-05T22:26:31.0000000Z\",\"endTime\":\"2026-05-05T22:26:33.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag?api-version=2026-07-01-preview+3": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "c1ee5860-3888-4475-8f27-05965f045527" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "456" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"5280f3fb-5a60-40b5-8a81-019f59b199ec\"},\"etag\":\"\\\"12001d55-0000-0800-0000-69fa6e990000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag\",\"name\":\"psdnsresolverpolicyforrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag?api-version=2026-07-01-preview+4": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "105" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "3e6b4d80-75f5-4404-ac3d-118168b65a3e" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjE3YTFjMWEyLTQ1NjYtNDQ3Yy1iZmQ4LTQ5YzVmZTY0NmM2YiJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "495" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080042af-0000-0800-0000-69fa6e9c0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\",\"name\":\"psdnsresolverdomainlistforrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjE3YTFjMWEyLTQ1NjYtNDQ3Yy1iZmQ4LTQ5YzVmZTY0NmM2YiJ9?api-version=2026-07-01-preview+5": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjE3YTFjMWEyLTQ1NjYtNDQ3Yy1iZmQ4LTQ5YzVmZTY0NmM2YiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "300f0209-d5b1-4585-a924-3af12e7874e8" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "567" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjE3YTFjMWEyLTQ1NjYtNDQ3Yy1iZmQ4LTQ5YzVmZTY0NmM2YiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjE3YTFjMWEyLTQ1NjYtNDQ3Yy1iZmQ4LTQ5YzVmZTY0NmM2YiJ9\",\"startTime\":\"2026-05-05T22:26:36.0000000Z\",\"endTime\":\"2026-05-05T22:26:39.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag?api-version=2026-07-01-preview+6": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "8d8a2a34-8440-4b2d-8f20-282101246aa0" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "530" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"6ee4ce12-d210-41be-81da-c234957a5f74\"},\"etag\":\"\\\"a208ca7d-0000-0800-0000-69fa6e9f0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\",\"name\":\"psdnsresolverdomainlistforrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "434" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "880e8422-8166-4ecb-b4c8-34b6cd67bc23" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM3ZjEyOGNiLTZjMjctNGIxYS04NGVlLTZlZDYxYWJlMjY4MiJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "796" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"12008355-0000-0800-0000-69fa6ea10000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag\",\"name\":\"psdnssecurityrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM3ZjEyOGNiLTZjMjctNGIxYS04NGVlLTZlZDYxYWJlMjY4MiJ9?api-version=2026-07-01-preview+8": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM3ZjEyOGNiLTZjMjctNGIxYS04NGVlLTZlZDYxYWJlMjY4MiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:46 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "1542a7e9-1bb5-4372-8a95-3ae797b88a53" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "551" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM3ZjEyOGNiLTZjMjctNGIxYS04NGVlLTZlZDYxYWJlMjY4MiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM3ZjEyOGNiLTZjMjctNGIxYS04NGVlLTZlZDYxYWJlMjY4MiJ9\",\"startTime\":\"2026-05-05T22:26:41.0000000Z\",\"endTime\":\"2026-05-05T22:26:43.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag?api-version=2026-07-01-preview+9": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:46 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "cf09e535-0aa9-42d7-b64d-4abd2eeffcb8" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "797" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900e02e-0000-0800-0000-69fa6ea30000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag\",\"name\":\"psdnssecurityrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Get-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules?api-version=2026-07-01-preview+10": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:26:46 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "4b67e08e-7243-4aa5-9c84-6bf96b1ec18a" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "809" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"value\":[{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename2n1edag\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900e02e-0000-0800-0000-69fa6ea30000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-get/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename2n1edag/dnsSecurityRules/psdnssecurityrulename2n1edag\",\"name\":\"psdnssecurityrulename2n1edag\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}]}",
       "isContentBase64": false
     }
   }

--- a/src/DnsResolver/DnsResolver.Autorest/test/Get-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Get-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
@@ -1,30 +1,61 @@
-$TestRecordingFile = Join-Path $PSScriptRoot 'Get-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) { $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File; $currentPath = Split-Path -Path $currentPath -Parent }
-. ($mockingPath | Select-Object -First 1).FullName
+if(($null -eq $TestName) -or ($TestName -contains 'Get-AzDnsResolverPolicyDnsSecurityRule'))
+{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)
+  $TestRecordingFile = Join-Path $PSScriptRoot 'Get-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
+  $currentPath = $PSScriptRoot
+  while(-not $mockingPath) {
+      $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+      $currentPath = Split-Path -Path $currentPath -Parent
+  }
+  . ($mockingPath | Select-Object -First 1).FullName
+}
+
+# Load post-merge test helper for routing to Frontend endpoint
+. (Join-Path $PSScriptRoot 'postMergeTestHelper.ps1')
+if ($TestMode -ne 'playback') {
+    $postMergeStep = New-PostMergeTestHttpPipelineStep
+    $existingMock = $PSDefaultParameterValues["*:HttpPipelinePrepend"]
+    $PSDefaultParameterValues["*:HttpPipelinePrepend"] = [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep[]]@(
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$postMergeStep,
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$existingMock
+    )
+}
 
 Describe 'Get-AzDnsResolverPolicyDnsSecurityRule' {
-    BeforeAll {
-        $subscriptionId = '97db216c-169d-4ea9-9d98-114adba0aa20'; $location = 'westus2'
-        $rgName = "ps-secrule-get-41328"
-        if ($TestMode -ne 'playback') {
-            Select-AzSubscription -SubscriptionId $subscriptionId
-            New-AzResourceGroup -Name $rgName -Location $location
-            New-AzDnsResolverPolicy -Name "policy-secrule-g" -ResourceGroupName $rgName -Location $location
-            New-AzDnsResolverDomainList -Name "domainlist-secrule-g" -ResourceGroupName $rgName -Location $location -Domain @("contoso.com.")
-            $dlId = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-g"
-            New-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-get-1" -DnsResolverPolicyName "policy-secrule-g" -ResourceGroupName $rgName -Location $location -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DnsResolverDomainList @(@{id = $dlId})
-        }
+    It 'Get single DNS security rule by name, expect DNS security rule by name retrieved' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename1m0cdag";
+        $dnsSecurityRuleName = "psdnssecurityrulename1m0cdag";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename1m0cdag";
+        $resourceGroupName = "powershell-test-rg-debug-get";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT - ASSERT
+        {Get-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName} | Should -Not -Throw
     }
-    AfterAll {
-        if ($TestMode -ne 'playback') { Remove-AzResourceGroup -Name $rgName -ErrorAction SilentlyContinue -AsJob | Out-Null }
-    }
-    It 'Get a security rule by name' {
-        $rule = Get-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-get-1" -DnsResolverPolicyName "policy-secrule-g" -ResourceGroupName $rgName
-        $rule.ProvisioningState | Should -Be "Succeeded"
-    }
-    It 'List security rules in policy' {
-        $rules = Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName "policy-secrule-g" -ResourceGroupName $rgName
-        $rules.Count | Should -BeGreaterThan 0
+
+    It 'List DNS resolver policies in a resource group, expected least number of DNS resolver policies retrieved' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename2n1edag";
+        $dnsSecurityRuleName = "psdnssecurityrulename2n1edag";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename2n1edag";
+        $resourceGroupName = "powershell-test-rg-debug-get";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT
+        $securityRules =  Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName
+
+        # ASSERT
+        $securityRules.Count | Should -BeGreaterThan 0
     }
 }

--- a/src/DnsResolver/DnsResolver.Autorest/test/New-AzDnsResolverPolicyDnsSecurityRule.Recording.json
+++ b/src/DnsResolver/DnsResolver.Autorest/test/New-AzDnsResolverPolicyDnsSecurityRule.Recording.json
@@ -1,8 +1,8 @@
 {
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1?api-version=2025-10-01-preview+1": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg?api-version=2026-07-01-preview+1": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg?api-version=2026-07-01-preview",
       "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
       "isContentBase64": false,
       "Headers": {
@@ -13,48 +13,31 @@
       }
     },
     "Response": {
-      "StatusCode": 201,
+      "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:33:03 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "9fab34a7-9b0d-40df-b5d7-c99684f1e111" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=?api-version=2025-10-01-preview\u0026t=639096280121126782\u0026c=MIIIJjCCBw6gAwIBAgIQXAg_KQfqNmXWsnKmcWm-CjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXQ1VTIENBIDAxMB4XDTI2MDMwMzE4NDAwNFoXDTI2MDgzMDAwNDAwNFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCq2QsnpddKa8kR8gt-vA9VEusmZorO2S-vbINESl_vgl_PJICxJntGEX47Fd1DDc76k_3GujB58pb9CVQcLZ3-ca4xBv6hEqbf7VGNJdlUmL6V31uaLBLUMfEySd5hdTIpu4K8C1BsXVfomETR-eBTaEKo7U6rad09i8wEBquSFVf5S7J71JehWC4rsigucyf3uMHNqTzZudQy7Dr4g3o1z8GDPMMNrN8NB6XUfnHR60daMf2EzZU2v746EHu58MN3kAveFfbqRrcWd5-tDS7K-u-_1JBNmgg_vgVE_HIXLJ-H3nSUSgujW4YOVJzkyLbU8xAJiSJ_NeLBYjJyJhCNAgMBAAGjggUkMIIFIDCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRvNYqFx4fDp-iV_6CV_JvtWzks-DAfBgNVHSMEGDAWgBQU0jfg9tZ9ft2NurplqwSUJeCWHTCCAfsGA1UdHwSCAfIwggHuMHugeaB3hnVodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwfaB7oHmGd2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI1L2N1cnJlbnQuY3JsMGygaqBohmZodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwgYGgf6B9hntodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwggIABggrBgEFBQcBAQSCAfIwggHuMH4GCCsGAQUFBzAChnJodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwgYAGCCsGAQUFBzAChnRodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBvBggrBgEFBQcwAoZjaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHgGCCsGAQUFBzAChmxodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBAHyESoM-hJA8co5aYFKQj6Yb2naSt-_hW50RjbHBbcf7c32Ujn8L-srkiIyVxkEpzXn0sgWpC8m9Wmwi-IXcD8wG3oPqMrn5ZYvIwrFdrlRwKg23jUltqn23uy8oAzIxCBsBblPSNyWSbEL5Vi52YbLITPHu4uEC7Exy9jJvn6cttL4bste7Sfve85Dd-RbogDrr8HBad8-CN8sHHSyii8mKaK7rq75VE6arRrM28SQgrKJDPrv40C9I6Z5pK40CEUfpYyWTzS6FkLMf7SIjhz0Ilua9xqzb0IO32oVtuv4c-GmmjyJy8FRZzgEYbW_CUh19Gx-9L_Sd5ZzebW5exxE\u0026s=GyVkZxjJsBHA9dYa88ODv_yxwh8SRAKWNTVBhiZtaledeZdGuUQR51CmKpQOMf7qrmH77ARwSeYPzHw1JvJOZUo97BPB49AhtVTKBu_R_V1gPAok-Y1kH1c0BQowWF4P7xrPnim6h-XFNKM-UYdc1JanUX5hUns2If9bQs2h8yOtwuzvQXVUZpCkeFCuvnwSgbGpDX0dmGcntfWgaaUvS95LSr-DQi0WP30PDkz3cgJ077k1zs2ClduO1pjQp2uCh84YAbht9vY87Hs9ehi6vLG_ToVN3L_tiQ_Iif5fEk_0O5oulCcgThvsvMvnsCNQQ37F87CNDqyk6rEWNkov5w\u0026h=yei7I8oHPLrTCRNQAgveoRzzgmpY5Tks4PgRAh7MbP0" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus/a0eee744-740d-4086-b922-373bd5ef35a2" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "9fab34a7-9b0d-40df-b5d7-c99684f1e111" ],
-        "x-ms-correlation-request-id": [ "9fab34a7-9b0d-40df-b5d7-c99684f1e111" ],
-        "x-ms-routing-request-id": [ "WESTUS:20260320T182652Z:9fab34a7-9b0d-40df-b5d7-c99684f1e111" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: D5FE3776A60D483391F695DC92C4AD8F Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:26:49Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:26:51 GMT" ]
+        "x-ms-activity-id": [ "e5dbd445-2bf3-44c5-843d-a83b8c753503" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "528" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "421" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5701fbd2-0000-0700-0000-69bd916b0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1\",\"name\":\"policy-secrule-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T18:26:51.4252042Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:26:51.4252042Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Updating\",\"resourceGuid\":null},\"etag\":\"\\\"0800dbbf-0000-0800-0000-69fa70200000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg\",\"name\":\"psdnsresolverpolicyforrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=?api-version=2025-10-01-preview\u0026t=639096280121126782\u0026c=MIIIJjCCBw6gAwIBAgIQXAg_KQfqNmXWsnKmcWm-CjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXQ1VTIENBIDAxMB4XDTI2MDMwMzE4NDAwNFoXDTI2MDgzMDAwNDAwNFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCq2QsnpddKa8kR8gt-vA9VEusmZorO2S-vbINESl_vgl_PJICxJntGEX47Fd1DDc76k_3GujB58pb9CVQcLZ3-ca4xBv6hEqbf7VGNJdlUmL6V31uaLBLUMfEySd5hdTIpu4K8C1BsXVfomETR-eBTaEKo7U6rad09i8wEBquSFVf5S7J71JehWC4rsigucyf3uMHNqTzZudQy7Dr4g3o1z8GDPMMNrN8NB6XUfnHR60daMf2EzZU2v746EHu58MN3kAveFfbqRrcWd5-tDS7K-u-_1JBNmgg_vgVE_HIXLJ-H3nSUSgujW4YOVJzkyLbU8xAJiSJ_NeLBYjJyJhCNAgMBAAGjggUkMIIFIDCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRvNYqFx4fDp-iV_6CV_JvtWzks-DAfBgNVHSMEGDAWgBQU0jfg9tZ9ft2NurplqwSUJeCWHTCCAfsGA1UdHwSCAfIwggHuMHugeaB3hnVodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwfaB7oHmGd2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI1L2N1cnJlbnQuY3JsMGygaqBohmZodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwgYGgf6B9hntodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwggIABggrBgEFBQcBAQSCAfIwggHuMH4GCCsGAQUFBzAChnJodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwgYAGCCsGAQUFBzAChnRodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBvBggrBgEFBQcwAoZjaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHgGCCsGAQUFBzAChmxodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBAHyESoM-hJA8co5aYFKQj6Yb2naSt-_hW50RjbHBbcf7c32Ujn8L-srkiIyVxkEpzXn0sgWpC8m9Wmwi-IXcD8wG3oPqMrn5ZYvIwrFdrlRwKg23jUltqn23uy8oAzIxCBsBblPSNyWSbEL5Vi52YbLITPHu4uEC7Exy9jJvn6cttL4bste7Sfve85Dd-RbogDrr8HBad8-CN8sHHSyii8mKaK7rq75VE6arRrM28SQgrKJDPrv40C9I6Z5pK40CEUfpYyWTzS6FkLMf7SIjhz0Ilua9xqzb0IO32oVtuv4c-GmmjyJy8FRZzgEYbW_CUh19Gx-9L_Sd5ZzebW5exxE\u0026s=GyVkZxjJsBHA9dYa88ODv_yxwh8SRAKWNTVBhiZtaledeZdGuUQR51CmKpQOMf7qrmH77ARwSeYPzHw1JvJOZUo97BPB49AhtVTKBu_R_V1gPAok-Y1kH1c0BQowWF4P7xrPnim6h-XFNKM-UYdc1JanUX5hUns2If9bQs2h8yOtwuzvQXVUZpCkeFCuvnwSgbGpDX0dmGcntfWgaaUvS95LSr-DQi0WP30PDkz3cgJ077k1zs2ClduO1pjQp2uCh84YAbht9vY87Hs9ehi6vLG_ToVN3L_tiQ_Iif5fEk_0O5oulCcgThvsvMvnsCNQQ37F87CNDqyk6rEWNkov5w\u0026h=yei7I8oHPLrTCRNQAgveoRzzgmpY5Tks4PgRAh7MbP0+2": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview+2": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=?api-version=2025-10-01-preview\u0026t=639096280121126782\u0026c=MIIIJjCCBw6gAwIBAgIQXAg_KQfqNmXWsnKmcWm-CjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXQ1VTIENBIDAxMB4XDTI2MDMwMzE4NDAwNFoXDTI2MDgzMDAwNDAwNFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCq2QsnpddKa8kR8gt-vA9VEusmZorO2S-vbINESl_vgl_PJICxJntGEX47Fd1DDc76k_3GujB58pb9CVQcLZ3-ca4xBv6hEqbf7VGNJdlUmL6V31uaLBLUMfEySd5hdTIpu4K8C1BsXVfomETR-eBTaEKo7U6rad09i8wEBquSFVf5S7J71JehWC4rsigucyf3uMHNqTzZudQy7Dr4g3o1z8GDPMMNrN8NB6XUfnHR60daMf2EzZU2v746EHu58MN3kAveFfbqRrcWd5-tDS7K-u-_1JBNmgg_vgVE_HIXLJ-H3nSUSgujW4YOVJzkyLbU8xAJiSJ_NeLBYjJyJhCNAgMBAAGjggUkMIIFIDCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRvNYqFx4fDp-iV_6CV_JvtWzks-DAfBgNVHSMEGDAWgBQU0jfg9tZ9ft2NurplqwSUJeCWHTCCAfsGA1UdHwSCAfIwggHuMHugeaB3hnVodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwfaB7oHmGd2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI1L2N1cnJlbnQuY3JsMGygaqBohmZodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwgYGgf6B9hntodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwggIABggrBgEFBQcBAQSCAfIwggHuMH4GCCsGAQUFBzAChnJodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwgYAGCCsGAQUFBzAChnRodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBvBggrBgEFBQcwAoZjaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHgGCCsGAQUFBzAChmxodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBAHyESoM-hJA8co5aYFKQj6Yb2naSt-_hW50RjbHBbcf7c32Ujn8L-srkiIyVxkEpzXn0sgWpC8m9Wmwi-IXcD8wG3oPqMrn5ZYvIwrFdrlRwKg23jUltqn23uy8oAzIxCBsBblPSNyWSbEL5Vi52YbLITPHu4uEC7Exy9jJvn6cttL4bste7Sfve85Dd-RbogDrr8HBad8-CN8sHHSyii8mKaK7rq75VE6arRrM28SQgrKJDPrv40C9I6Z5pK40CEUfpYyWTzS6FkLMf7SIjhz0Ilua9xqzb0IO32oVtuv4c-GmmjyJy8FRZzgEYbW_CUh19Gx-9L_Sd5ZzebW5exxE\u0026s=GyVkZxjJsBHA9dYa88ODv_yxwh8SRAKWNTVBhiZtaledeZdGuUQR51CmKpQOMf7qrmH77ARwSeYPzHw1JvJOZUo97BPB49AhtVTKBu_R_V1gPAok-Y1kH1c0BQowWF4P7xrPnim6h-XFNKM-UYdc1JanUX5hUns2If9bQs2h8yOtwuzvQXVUZpCkeFCuvnwSgbGpDX0dmGcntfWgaaUvS95LSr-DQi0WP30PDkz3cgJ077k1zs2ClduO1pjQp2uCh84YAbht9vY87Hs9ehi6vLG_ToVN3L_tiQ_Iif5fEk_0O5oulCcgThvsvMvnsCNQQ37F87CNDqyk6rEWNkov5w\u0026h=yei7I8oHPLrTCRNQAgveoRzzgmpY5Tks4PgRAh7MbP0",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "3" ],
-        "x-ms-client-request-id": [ "c8007f8d-8f63-42cc-9c7a-6789fc909136" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -62,260 +45,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "bed9f6db-3dac-4613-a715-7fb73e6d4a96" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/9947a9df-4a72-4d0f-95f5-8cdb3f6d9b6a" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "bed9f6db-3dac-4613-a715-7fb73e6d4a96" ],
-        "x-ms-correlation-request-id": [ "bed9f6db-3dac-4613-a715-7fb73e6d4a96" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182658Z:bed9f6db-3dac-4613-a715-7fb73e6d4a96" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: F7F2463BEFE64D938A87715C6E6CD2C0 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:26:57Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:26:57 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "511" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=\",\"startTime\":\"2026-03-20T18:26:51.0000000Z\",\"status\":\"InProgress\"}",
-      "isContentBase64": false
-    }
-  },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=?api-version=2025-10-01-preview\u0026t=639096280121126782\u0026c=MIIIJjCCBw6gAwIBAgIQXAg_KQfqNmXWsnKmcWm-CjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXQ1VTIENBIDAxMB4XDTI2MDMwMzE4NDAwNFoXDTI2MDgzMDAwNDAwNFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCq2QsnpddKa8kR8gt-vA9VEusmZorO2S-vbINESl_vgl_PJICxJntGEX47Fd1DDc76k_3GujB58pb9CVQcLZ3-ca4xBv6hEqbf7VGNJdlUmL6V31uaLBLUMfEySd5hdTIpu4K8C1BsXVfomETR-eBTaEKo7U6rad09i8wEBquSFVf5S7J71JehWC4rsigucyf3uMHNqTzZudQy7Dr4g3o1z8GDPMMNrN8NB6XUfnHR60daMf2EzZU2v746EHu58MN3kAveFfbqRrcWd5-tDS7K-u-_1JBNmgg_vgVE_HIXLJ-H3nSUSgujW4YOVJzkyLbU8xAJiSJ_NeLBYjJyJhCNAgMBAAGjggUkMIIFIDCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRvNYqFx4fDp-iV_6CV_JvtWzks-DAfBgNVHSMEGDAWgBQU0jfg9tZ9ft2NurplqwSUJeCWHTCCAfsGA1UdHwSCAfIwggHuMHugeaB3hnVodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwfaB7oHmGd2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI1L2N1cnJlbnQuY3JsMGygaqBohmZodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwgYGgf6B9hntodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwggIABggrBgEFBQcBAQSCAfIwggHuMH4GCCsGAQUFBzAChnJodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwgYAGCCsGAQUFBzAChnRodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBvBggrBgEFBQcwAoZjaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHgGCCsGAQUFBzAChmxodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBAHyESoM-hJA8co5aYFKQj6Yb2naSt-_hW50RjbHBbcf7c32Ujn8L-srkiIyVxkEpzXn0sgWpC8m9Wmwi-IXcD8wG3oPqMrn5ZYvIwrFdrlRwKg23jUltqn23uy8oAzIxCBsBblPSNyWSbEL5Vi52YbLITPHu4uEC7Exy9jJvn6cttL4bste7Sfve85Dd-RbogDrr8HBad8-CN8sHHSyii8mKaK7rq75VE6arRrM28SQgrKJDPrv40C9I6Z5pK40CEUfpYyWTzS6FkLMf7SIjhz0Ilua9xqzb0IO32oVtuv4c-GmmjyJy8FRZzgEYbW_CUh19Gx-9L_Sd5ZzebW5exxE\u0026s=GyVkZxjJsBHA9dYa88ODv_yxwh8SRAKWNTVBhiZtaledeZdGuUQR51CmKpQOMf7qrmH77ARwSeYPzHw1JvJOZUo97BPB49AhtVTKBu_R_V1gPAok-Y1kH1c0BQowWF4P7xrPnim6h-XFNKM-UYdc1JanUX5hUns2If9bQs2h8yOtwuzvQXVUZpCkeFCuvnwSgbGpDX0dmGcntfWgaaUvS95LSr-DQi0WP30PDkz3cgJ077k1zs2ClduO1pjQp2uCh84YAbht9vY87Hs9ehi6vLG_ToVN3L_tiQ_Iif5fEk_0O5oulCcgThvsvMvnsCNQQ37F87CNDqyk6rEWNkov5w\u0026h=yei7I8oHPLrTCRNQAgveoRzzgmpY5Tks4PgRAh7MbP0+3": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=?api-version=2025-10-01-preview\u0026t=639096280121126782\u0026c=MIIIJjCCBw6gAwIBAgIQXAg_KQfqNmXWsnKmcWm-CjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBXQ1VTIENBIDAxMB4XDTI2MDMwMzE4NDAwNFoXDTI2MDgzMDAwNDAwNFowQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCq2QsnpddKa8kR8gt-vA9VEusmZorO2S-vbINESl_vgl_PJICxJntGEX47Fd1DDc76k_3GujB58pb9CVQcLZ3-ca4xBv6hEqbf7VGNJdlUmL6V31uaLBLUMfEySd5hdTIpu4K8C1BsXVfomETR-eBTaEKo7U6rad09i8wEBquSFVf5S7J71JehWC4rsigucyf3uMHNqTzZudQy7Dr4g3o1z8GDPMMNrN8NB6XUfnHR60daMf2EzZU2v746EHu58MN3kAveFfbqRrcWd5-tDS7K-u-_1JBNmgg_vgVE_HIXLJ-H3nSUSgujW4YOVJzkyLbU8xAJiSJ_NeLBYjJyJhCNAgMBAAGjggUkMIIFIDCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBRvNYqFx4fDp-iV_6CV_JvtWzks-DAfBgNVHSMEGDAWgBQU0jfg9tZ9ft2NurplqwSUJeCWHTCCAfsGA1UdHwSCAfIwggHuMHugeaB3hnVodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwfaB7oHmGd2h0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L3dlc3RjZW50cmFsdXMvY3Jscy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxLzI1L2N1cnJlbnQuY3JsMGygaqBohmZodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vd2VzdGNlbnRyYWx1cy9jcmxzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwgYGgf6B9hntodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvMjUvY3VycmVudC5jcmwwggIABggrBgEFBQcBAQSCAfIwggHuMH4GCCsGAQUFBzAChnJodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvd2VzdGNlbnRyYWx1cy9jYWNlcnRzL2NjbWV3ZXN0Y2VudHJhbHVzcGtpL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEvY2VydC5jZXIwgYAGCCsGAQUFBzAChnRodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC93ZXN0Y2VudHJhbHVzL2NhY2VydHMvY2NtZXdlc3RjZW50cmFsdXNwa2kvY2NtZXdlc3RjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBvBggrBgEFBQcwAoZjaHR0cDovL2NybC5taWNyb3NvZnQuY29tL3dlc3RjZW50cmFsdXMvY2FjZXJ0cy9jY21ld2VzdGNlbnRyYWx1c3BraS9jY21ld2VzdGNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHgGCCsGAQUFBzAChmxodHRwOi8vY2NtZXdlc3RjZW50cmFsdXNwa2kud2VzdGNlbnRyYWx1cy5wa2kuY29yZS53aW5kb3dzLm5ldC9jZXJ0aWZpY2F0ZUF1dGhvcml0aWVzL2NjbWV3ZXN0Y2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBAHyESoM-hJA8co5aYFKQj6Yb2naSt-_hW50RjbHBbcf7c32Ujn8L-srkiIyVxkEpzXn0sgWpC8m9Wmwi-IXcD8wG3oPqMrn5ZYvIwrFdrlRwKg23jUltqn23uy8oAzIxCBsBblPSNyWSbEL5Vi52YbLITPHu4uEC7Exy9jJvn6cttL4bste7Sfve85Dd-RbogDrr8HBad8-CN8sHHSyii8mKaK7rq75VE6arRrM28SQgrKJDPrv40C9I6Z5pK40CEUfpYyWTzS6FkLMf7SIjhz0Ilua9xqzb0IO32oVtuv4c-GmmjyJy8FRZzgEYbW_CUh19Gx-9L_Sd5ZzebW5exxE\u0026s=GyVkZxjJsBHA9dYa88ODv_yxwh8SRAKWNTVBhiZtaledeZdGuUQR51CmKpQOMf7qrmH77ARwSeYPzHw1JvJOZUo97BPB49AhtVTKBu_R_V1gPAok-Y1kH1c0BQowWF4P7xrPnim6h-XFNKM-UYdc1JanUX5hUns2If9bQs2h8yOtwuzvQXVUZpCkeFCuvnwSgbGpDX0dmGcntfWgaaUvS95LSr-DQi0WP30PDkz3cgJ077k1zs2ClduO1pjQp2uCh84YAbht9vY87Hs9ehi6vLG_ToVN3L_tiQ_Iif5fEk_0O5oulCcgThvsvMvnsCNQQ37F87CNDqyk6rEWNkov5w\u0026h=yei7I8oHPLrTCRNQAgveoRzzgmpY5Tks4PgRAh7MbP0",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "4" ],
-        "x-ms-client-request-id": [ "c8007f8d-8f63-42cc-9c7a-6789fc909136" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "b127d1e1-1dc4-467e-b3ff-66c9805f25a6" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/81595e60-2121-4ea1-8064-d108a287fc51" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "b127d1e1-1dc4-467e-b3ff-66c9805f25a6" ],
-        "x-ms-correlation-request-id": [ "b127d1e1-1dc4-467e-b3ff-66c9805f25a6" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182729Z:b127d1e1-1dc4-467e-b3ff-66c9805f25a6" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 5F256DCA12584D5AAFF3FFF6E5FF15BF Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:27:28Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:27:29 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "551" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmZiYTRkYzktNzM0Yi00NjY0LWJkZDEtOWIwMWE0Y2Y2NGYzIn0=\",\"startTime\":\"2026-03-20T18:26:51.0000000Z\",\"endTime\":\"2026-03-20T18:27:04.0000000Z\",\"status\":\"Succeeded\"}",
-      "isContentBase64": false
-    }
-  },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1?api-version=2025-10-01-preview+4": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "5" ],
-        "x-ms-client-request-id": [ "c8007f8d-8f63-42cc-9c7a-6789fc909136" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "7ad8e1a1-a426-4d2f-9bf3-a5dcc4f90444" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "7ad8e1a1-a426-4d2f-9bf3-a5dcc4f90444" ],
-        "x-ms-correlation-request-id": [ "7ad8e1a1-a426-4d2f-9bf3-a5dcc4f90444" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182730Z:7ad8e1a1-a426-4d2f-9bf3-a5dcc4f90444" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 66767A4E8D884643A020AEE555307A8B Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:27:29Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:27:30 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "563" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"a56c216d-18db-46e2-a679-24368544c464\"},\"etag\":\"\\\"d1006271-0000-0700-0000-69bd91760000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1\",\"name\":\"policy-secrule-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T18:26:51.4252042Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:26:51.4252042Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1?api-version=2025-10-01-preview+5": {
-    "Request": {
-      "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\" ]\r\n  }\r\n}",
-      "isContentBase64": false,
-      "Headers": {
-      },
-      "ContentHeaders": {
-        "Content-Type": [ "application/json" ],
-        "Content-Length": [ "89" ]
-      }
-    },
-    "Response": {
-      "StatusCode": 201,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1?api-version=2025-10-01-preview" ],
-        "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "f64e2150-6b75-4616-a16a-7789af7cda50" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9?api-version=2025-10-01-preview\u0026t=639096280517832315\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=q2dQPOEsY8oPHqbaogjaipnv4SHVpBa6OwGif8wWUj0-T9vFg2biumjkxwRW43_WMr7uAThBm-XpNL0H-T-nLVOjX8w7Hbe_c54WvY6RVLkiYnySaj0SBYxT3D5gjPW6lzuM1TYEQO6pMdCiATHiwyyOEqQRmYj4KJ0Bg0LWvauzd-9h9LjY0IUzg5viZ_e84-OBxLpeJnKvq2kXeVTnMcDUHTss9j9M-CxxkJCx3ycJGrlLDJ8_AUR7-UCmiiZ8_6KbpmOTaUYHbElHW6L_-R17OnRe71zWAKjjLFuGnXjGweiERXxVk_RFzdwJckzYBKfPLDqBgmV3DeXWc2eLDg\u0026h=yk_ae3ACcyG_QKpm3XkepP1lszrcj7Sn5gfJtBVI278" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/71aff4ab-dca1-401e-ab8c-14acefde883f" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "f64e2150-6b75-4616-a16a-7789af7cda50" ],
-        "x-ms-correlation-request-id": [ "f64e2150-6b75-4616-a16a-7789af7cda50" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182731Z:f64e2150-6b75-4616-a16a-7789af7cda50" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: B069F8E9F43C4EF5B2E5D1EED1ACA1C9 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:27:31Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:27:30 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "587" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5701a3d8-0000-0700-0000-69bd91930000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1\",\"name\":\"domainlist-secrule-1\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T18:27:31.4238552Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:27:31.4238552Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9?api-version=2025-10-01-preview\u0026t=639096280517832315\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=q2dQPOEsY8oPHqbaogjaipnv4SHVpBa6OwGif8wWUj0-T9vFg2biumjkxwRW43_WMr7uAThBm-XpNL0H-T-nLVOjX8w7Hbe_c54WvY6RVLkiYnySaj0SBYxT3D5gjPW6lzuM1TYEQO6pMdCiATHiwyyOEqQRmYj4KJ0Bg0LWvauzd-9h9LjY0IUzg5viZ_e84-OBxLpeJnKvq2kXeVTnMcDUHTss9j9M-CxxkJCx3ycJGrlLDJ8_AUR7-UCmiiZ8_6KbpmOTaUYHbElHW6L_-R17OnRe71zWAKjjLFuGnXjGweiERXxVk_RFzdwJckzYBKfPLDqBgmV3DeXWc2eLDg\u0026h=yk_ae3ACcyG_QKpm3XkepP1lszrcj7Sn5gfJtBVI278+6": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9?api-version=2025-10-01-preview\u0026t=639096280517832315\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=q2dQPOEsY8oPHqbaogjaipnv4SHVpBa6OwGif8wWUj0-T9vFg2biumjkxwRW43_WMr7uAThBm-XpNL0H-T-nLVOjX8w7Hbe_c54WvY6RVLkiYnySaj0SBYxT3D5gjPW6lzuM1TYEQO6pMdCiATHiwyyOEqQRmYj4KJ0Bg0LWvauzd-9h9LjY0IUzg5viZ_e84-OBxLpeJnKvq2kXeVTnMcDUHTss9j9M-CxxkJCx3ycJGrlLDJ8_AUR7-UCmiiZ8_6KbpmOTaUYHbElHW6L_-R17OnRe71zWAKjjLFuGnXjGweiERXxVk_RFzdwJckzYBKfPLDqBgmV3DeXWc2eLDg\u0026h=yk_ae3ACcyG_QKpm3XkepP1lszrcj7Sn5gfJtBVI278",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "7" ],
-        "x-ms-client-request-id": [ "6b48b48b-7c03-4e62-9177-25883e0fd829" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "49d9b1ee-a3d8-438e-ba7d-47dc66073553" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/b440d37e-e431-4fa0-90fd-79d2b1a96c1a" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "49d9b1ee-a3d8-438e-ba7d-47dc66073553" ],
-        "x-ms-correlation-request-id": [ "49d9b1ee-a3d8-438e-ba7d-47dc66073553" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182737Z:49d9b1ee-a3d8-438e-ba7d-47dc66073553" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 4167B469A1DF4AFB8C3983C414C5E1C3 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:27:36Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:27:37 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "519" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9\",\"startTime\":\"2026-03-20T18:27:31.0000000Z\",\"status\":\"InProgress\"}",
-      "isContentBase64": false
-    }
-  },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9?api-version=2025-10-01-preview\u0026t=639096280517832315\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=q2dQPOEsY8oPHqbaogjaipnv4SHVpBa6OwGif8wWUj0-T9vFg2biumjkxwRW43_WMr7uAThBm-XpNL0H-T-nLVOjX8w7Hbe_c54WvY6RVLkiYnySaj0SBYxT3D5gjPW6lzuM1TYEQO6pMdCiATHiwyyOEqQRmYj4KJ0Bg0LWvauzd-9h9LjY0IUzg5viZ_e84-OBxLpeJnKvq2kXeVTnMcDUHTss9j9M-CxxkJCx3ycJGrlLDJ8_AUR7-UCmiiZ8_6KbpmOTaUYHbElHW6L_-R17OnRe71zWAKjjLFuGnXjGweiERXxVk_RFzdwJckzYBKfPLDqBgmV3DeXWc2eLDg\u0026h=yk_ae3ACcyG_QKpm3XkepP1lszrcj7Sn5gfJtBVI278+7": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9?api-version=2025-10-01-preview\u0026t=639096280517832315\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=q2dQPOEsY8oPHqbaogjaipnv4SHVpBa6OwGif8wWUj0-T9vFg2biumjkxwRW43_WMr7uAThBm-XpNL0H-T-nLVOjX8w7Hbe_c54WvY6RVLkiYnySaj0SBYxT3D5gjPW6lzuM1TYEQO6pMdCiATHiwyyOEqQRmYj4KJ0Bg0LWvauzd-9h9LjY0IUzg5viZ_e84-OBxLpeJnKvq2kXeVTnMcDUHTss9j9M-CxxkJCx3ycJGrlLDJ8_AUR7-UCmiiZ8_6KbpmOTaUYHbElHW6L_-R17OnRe71zWAKjjLFuGnXjGweiERXxVk_RFzdwJckzYBKfPLDqBgmV3DeXWc2eLDg\u0026h=yk_ae3ACcyG_QKpm3XkepP1lszrcj7Sn5gfJtBVI278",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "8" ],
-        "x-ms-client-request-id": [ "6b48b48b-7c03-4e62-9177-25883e0fd829" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "68220934-182a-45db-bb0b-6fb9c786cd23" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/bc1953f1-cb5b-4ef6-9ac8-76032221b34e" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "68220934-182a-45db-bb0b-6fb9c786cd23" ],
-        "x-ms-correlation-request-id": [ "68220934-182a-45db-bb0b-6fb9c786cd23" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182809Z:68220934-182a-45db-bb0b-6fb9c786cd23" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 26EC759014C9414797D0FC1750B847E8 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:08Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:08 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:33:08 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "bf18835a-b57a-48d4-b1d1-b80895a45e45" ]
       },
       "ContentHeaders": {
         "Content-Length": [ "559" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQ3ZWYzOTRlLTM4NDctNGNjYy04YTdkLTFhMDQ3NThlNmI1NCJ9\",\"startTime\":\"2026-03-20T18:27:31.0000000Z\",\"endTime\":\"2026-03-20T18:27:44.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=\",\"startTime\":\"2026-05-05T22:33:04.0000000Z\",\"endTime\":\"2026-05-05T22:33:04.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1?api-version=2025-10-01-preview+8": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview+3": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZjBlNzczNjUtMzE1OS00YTZiLTllZjMtMjg0MWQ5NmZlMzk2In0=?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "9" ],
-        "x-ms-client-request-id": [ "6b48b48b-7c03-4e62-9177-25883e0fd829" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -323,84 +72,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "c233afca-3420-4a63-8b95-7164d9919428" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "c233afca-3420-4a63-8b95-7164d9919428" ],
-        "x-ms-correlation-request-id": [ "c233afca-3420-4a63-8b95-7164d9919428" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182810Z:c233afca-3420-4a63-8b95-7164d9919428" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: C0E8E698665D45C6A5712F77A4710447 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:09Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:09 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:33:08 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "de31c723-aec1-484b-a7b0-164f49c98571" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "622" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "557" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"ac111d44-68b0-4fac-9191-614456e23928\"},\"etag\":\"\\\"0f00f5fe-0000-0700-0000-69bd919e0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1\",\"name\":\"domainlist-secrule-1\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T18:27:31.4238552Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:27:31.4238552Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"8b7cc1d0-d917-4dd5-aa6d-c596f15fa4f2\"},\"etag\":\"\\\"1200736a-0000-0800-0000-69fa70200000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg\",\"name\":\"psdnsresolverpolicyforrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create a DNS security rule+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1?api-version=2025-10-01-preview+1": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg?api-version=2026-07-01-preview+4": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "405" ]
+        "Content-Length": [ "105" ]
       }
     },
     "Response": {
-      "StatusCode": 201,
+      "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:33:08 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "8fbadfe1-b7ac-4394-9a3a-c73367c5649f" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9?api-version=2025-10-01-preview\u0026t=639096280923935011\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=Bz-F1okpTmUdwq4LFIcBRJVp1VUR4b6OsyzYjGGGEBsYeFh2DAHKg5R2lheOj64O6qEpErRlVEiJlll7avAlkdGTMY_NnMdpSw7Cclo-oqrdD6ucLX8wFeAAuXYVT26uI0ww_h3ewbyB-jDMlfv-ZQgypTpATp0a6FcKFBVy5gIWLO6yDs00JwovGdoan-qFqizelhRD_Hh9VdSaU5dK-hMCbaVbYqft5jOn8nk5urheWdknoQlR8WzC7N_6dmznW0lWcdyX3ZtwJ6x-peXtgSIrLw1W6AS6XeOxM0gqLkieXqdC-bd9EYk8dnkENzvNqkJDRjFkepKMGD_6LIA6og\u0026h=M7_El5_4dc--N_xpDr4B7wYqC_Mu1w6A5UFjlXkrvbw" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/90c268df-05ce-44b5-b438-bc3b94d52fc2" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "8fbadfe1-b7ac-4394-9a3a-c73367c5649f" ],
-        "x-ms-correlation-request-id": [ "8fbadfe1-b7ac-4394-9a3a-c73367c5649f" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182812Z:8fbadfe1-b7ac-4394-9a3a-c73367c5649f" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: C5438303781347AFA16CE24871EFDE26 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:10Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:11 GMT" ]
+        "x-ms-activity-id": [ "7a79317e-32c2-4654-8c7c-3ded77c07206" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "865" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "495" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"d1000f79-0000-0700-0000-69bd91bc0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1\",\"name\":\"secrule-new-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T18:28:11.7841049Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:28:11.7841049Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Updating\",\"resourceGuid\":null},\"etag\":\"\\\"08000bc0-0000-0800-0000-69fa70250000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\",\"name\":\"psdnsresolverdomainlistforrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create a DNS security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9?api-version=2025-10-01-preview\u0026t=639096280923935011\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=Bz-F1okpTmUdwq4LFIcBRJVp1VUR4b6OsyzYjGGGEBsYeFh2DAHKg5R2lheOj64O6qEpErRlVEiJlll7avAlkdGTMY_NnMdpSw7Cclo-oqrdD6ucLX8wFeAAuXYVT26uI0ww_h3ewbyB-jDMlfv-ZQgypTpATp0a6FcKFBVy5gIWLO6yDs00JwovGdoan-qFqizelhRD_Hh9VdSaU5dK-hMCbaVbYqft5jOn8nk5urheWdknoQlR8WzC7N_6dmznW0lWcdyX3ZtwJ6x-peXtgSIrLw1W6AS6XeOxM0gqLkieXqdC-bd9EYk8dnkENzvNqkJDRjFkepKMGD_6LIA6og\u0026h=M7_El5_4dc--N_xpDr4B7wYqC_Mu1w6A5UFjlXkrvbw+2": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview+5": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9?api-version=2025-10-01-preview\u0026t=639096280923935011\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=Bz-F1okpTmUdwq4LFIcBRJVp1VUR4b6OsyzYjGGGEBsYeFh2DAHKg5R2lheOj64O6qEpErRlVEiJlll7avAlkdGTMY_NnMdpSw7Cclo-oqrdD6ucLX8wFeAAuXYVT26uI0ww_h3ewbyB-jDMlfv-ZQgypTpATp0a6FcKFBVy5gIWLO6yDs00JwovGdoan-qFqizelhRD_Hh9VdSaU5dK-hMCbaVbYqft5jOn8nk5urheWdknoQlR8WzC7N_6dmznW0lWcdyX3ZtwJ6x-peXtgSIrLw1W6AS6XeOxM0gqLkieXqdC-bd9EYk8dnkENzvNqkJDRjFkepKMGD_6LIA6og\u0026h=M7_El5_4dc--N_xpDr4B7wYqC_Mu1w6A5UFjlXkrvbw",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "11" ],
-        "x-ms-client-request-id": [ "d6dfd298-a147-4b20-a0b5-cd931d6cc50c" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -408,43 +130,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "535b3760-e67c-4864-9c10-c4a3123e28ff" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/7fc0be01-68d2-48e6-bbd4-4af16d7b02c2" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "535b3760-e67c-4864-9c10-c4a3123e28ff" ],
-        "x-ms-correlation-request-id": [ "535b3760-e67c-4864-9c10-c4a3123e28ff" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182818Z:535b3760-e67c-4864-9c10-c4a3123e28ff" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 86E47FCDDC5F4A62A1A4DD9701757449 Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:17Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:17 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:33:13 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "ac550f62-c6e3-44bd-903e-9538ad831dbd" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "503" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "567" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9\",\"startTime\":\"2026-03-20T18:28:12.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9\",\"startTime\":\"2026-05-05T22:33:09.0000000Z\",\"endTime\":\"2026-05-05T22:33:12.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create a DNS security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9?api-version=2025-10-01-preview\u0026t=639096280923935011\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=Bz-F1okpTmUdwq4LFIcBRJVp1VUR4b6OsyzYjGGGEBsYeFh2DAHKg5R2lheOj64O6qEpErRlVEiJlll7avAlkdGTMY_NnMdpSw7Cclo-oqrdD6ucLX8wFeAAuXYVT26uI0ww_h3ewbyB-jDMlfv-ZQgypTpATp0a6FcKFBVy5gIWLO6yDs00JwovGdoan-qFqizelhRD_Hh9VdSaU5dK-hMCbaVbYqft5jOn8nk5urheWdknoQlR8WzC7N_6dmznW0lWcdyX3ZtwJ6x-peXtgSIrLw1W6AS6XeOxM0gqLkieXqdC-bd9EYk8dnkENzvNqkJDRjFkepKMGD_6LIA6og\u0026h=M7_El5_4dc--N_xpDr4B7wYqC_Mu1w6A5UFjlXkrvbw+3": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview+6": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9?api-version=2025-10-01-preview\u0026t=639096280923935011\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=Bz-F1okpTmUdwq4LFIcBRJVp1VUR4b6OsyzYjGGGEBsYeFh2DAHKg5R2lheOj64O6qEpErRlVEiJlll7avAlkdGTMY_NnMdpSw7Cclo-oqrdD6ucLX8wFeAAuXYVT26uI0ww_h3ewbyB-jDMlfv-ZQgypTpATp0a6FcKFBVy5gIWLO6yDs00JwovGdoan-qFqizelhRD_Hh9VdSaU5dK-hMCbaVbYqft5jOn8nk5urheWdknoQlR8WzC7N_6dmznW0lWcdyX3ZtwJ6x-peXtgSIrLw1W6AS6XeOxM0gqLkieXqdC-bd9EYk8dnkENzvNqkJDRjFkepKMGD_6LIA6og\u0026h=M7_El5_4dc--N_xpDr4B7wYqC_Mu1w6A5UFjlXkrvbw",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjQxYTc4ODhjLTIxMGMtNDdkZi04NzdkLWMzZDk0NmRiMjczMiJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "12" ],
-        "x-ms-client-request-id": [ "d6dfd298-a147-4b20-a0b5-cd931d6cc50c" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -452,43 +157,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "069d11a5-f4e8-418d-befc-5e1987751381" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/3da32725-049b-48d2-9dbb-57bb4e2990f9" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "069d11a5-f4e8-418d-befc-5e1987751381" ],
-        "x-ms-correlation-request-id": [ "069d11a5-f4e8-418d-befc-5e1987751381" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182848Z:069d11a5-f4e8-418d-befc-5e1987751381" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 2E1D3A9A975A4C5AAAFBD4A64372D64F Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:48Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:48 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:33:13 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "195a17b3-a631-4c40-ac4a-3d068933c616" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "543" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "631" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjJjNjYxODk5LWYxZDYtNDExZC1iZTE5LWZmMTg3NjE0MmQyMyJ9\",\"startTime\":\"2026-03-20T18:28:12.0000000Z\",\"endTime\":\"2026-03-20T18:28:26.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"45fd7786-00f1-4d04-8c59-0fc41de08d4f\"},\"etag\":\"\\\"a208ffc0-0000-0800-0000-69fa70270000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\",\"name\":\"psdnsresolverdomainlistforrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
       "isContentBase64": false
     }
   },
-  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create a DNS security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1?api-version=2025-10-01-preview+4": {
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "434" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:13 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "5bfe5e4a-fd7d-446b-bf74-fc995d73961d" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "796" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Updating\"},\"etag\":\"\\\"1200066b-0000-0800-0000-69fa702a0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg\",\"name\":\"psdnssecurityrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview+8": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "13" ],
-        "x-ms-client-request-id": [ "d6dfd298-a147-4b20-a0b5-cd931d6cc50c" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -496,25 +215,351 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "23234e70-02b1-4922-b280-0de5c699fce8" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "23234e70-02b1-4922-b280-0de5c699fce8" ],
-        "x-ms-correlation-request-id": [ "23234e70-02b1-4922-b280-0de5c699fce8" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T182850Z:23234e70-02b1-4922-b280-0de5c699fce8" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: C57DC8EBD242420883CCF718407357FF Ref B: CO6AA3150217051 Ref C: 2026-03-20T18:28:49Z" ],
-        "Date": [ "Fri, 20 Mar 2026 18:28:49 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:33:19 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "f2429228-2ad1-4c22-9466-368f761a220b" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "866" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "551" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"c9006815-0000-0700-0000-69bd91c70000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-new-68744/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-1/dnsSecurityRules/secrule-new-1\",\"name\":\"secrule-new-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T18:28:11.7841049Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T18:28:11.7841049Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9\",\"startTime\":\"2026-05-05T22:33:14.0000000Z\",\"endTime\":\"2026-05-05T22:33:19.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview+9": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBhNTM2Zjk5LWRlZTYtNDQwYy1hYzNjLTZiZTM4NjUwNGUwYyJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:19 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b12fdc18-395a-4778-a202-d12af3ce4939" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "898" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900382f-0000-0800-0000-69fa702f0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg\",\"name\":\"psdnssecurityrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg?api-version=2026-07-01-preview+10": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:19 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b7414454-353f-4c71-83aa-b99728136333" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "898" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j0cdzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900382f-0000-0800-0000-69fa702f0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j0cdzg/dnsSecurityRules/psdnssecurityrulename0j0cdzg\",\"name\":\"psdnssecurityrulename0j0cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1?api-version=2026-07-01-preview+1": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "29" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:19 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "06a5f25f-2420-47b8-9287-3c5023e036fc" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "415" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Updating\",\"resourceGuid\":null},\"etag\":\"\\\"080082c0-0000-0800-0000-69fa702f0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1\",\"name\":\"psdnsresolverpolicyforrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview+2": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:24 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "e85157f3-763c-4c91-8c42-a168f60224eb" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "559" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=\",\"startTime\":\"2026-05-05T22:33:19.0000000Z\",\"endTime\":\"2026-05-05T22:33:22.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview+3": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjE4YTNhZjktNTQ5OC00MzBiLWJlN2EtMzdkNTE2NzRhOTE5In0=?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:24 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "ac618da6-9860-495a-91c5-7e9b5e20c56c" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "551" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"3d3231ba-6a45-4ad5-9669-8e3052212a20\"},\"etag\":\"\\\"1200a26b-0000-0800-0000-69fa70310000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1\",\"name\":\"psdnsresolverpolicyforrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1?api-version=2026-07-01-preview+4": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "105" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:24 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "b1b57964-aaea-40cb-b5c6-944cbdca8cfe" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "489" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Updating\",\"resourceGuid\":null},\"etag\":\"\\\"0800dcc0-0000-0800-0000-69fa70340000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\",\"name\":\"psdnsresolverdomainlistforrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview+5": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:29 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "d4cd3438-835a-44bb-b30e-6132048e654e" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "567" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9\",\"startTime\":\"2026-05-05T22:33:24.0000000Z\",\"endTime\":\"2026-05-05T22:33:29.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview+6": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjhhZjA4Y2U0LTBhMzItNGYxYy04NmYyLTkxYzI1MTBhMjg2ZCJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:29 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "c78ee263-2ef2-4544-ab67-8d0d80ff9abd" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "625" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"f7d61ef3-1b05-4a20-8ebe-1bc1da9c6a14\"},\"etag\":\"\\\"a208b8c4-0000-0800-0000-69fa70390000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\",\"name\":\"psdnsresolverdomainlistforrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\",\r\n    \"disableCnameChainValidation\": true\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "473" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:29 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "8147329d-cd79-4e8a-b10e-0b0fd5eae2f4" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "819" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Updating\",\"disableCnameChainValidation\":true},\"etag\":\"\\\"1200406c-0000-0800-0000-69fa70390000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1\",\"name\":\"psdnssecurityrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview+8": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:34 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "6b8f6bb9-8edf-488b-9a1b-699d585ff3e4" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "551" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9\",\"startTime\":\"2026-05-05T22:33:29.0000000Z\",\"endTime\":\"2026-05-05T22:33:32.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview+9": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjdmZDY1MzFlLThlMWQtNGE1Ni1iMzY5LTliNzZhNzhmMDg0MiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:34 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "cbd69876-5326-40d0-b5f0-642f21eea39c" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "921" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\",\"disableCnameChainValidation\":true},\"etag\":\"\\\"09003e2f-0000-0800-0000-69fa703b0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1\",\"name\":\"psdnssecurityrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "New-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Create DNS security rule with DisableCnameChainValidation+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1?api-version=2026-07-01-preview+10": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:33:34 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "ad8deeba-0309-4768-b936-ed0c5e54d2fd" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "921" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv1\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\",\"disableCnameChainValidation\":true},\"etag\":\"\\\"09003e2f-0000-0800-0000-69fa703b0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-new/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv1/dnsSecurityRules/psdnssecurityrulenamedcv1\",\"name\":\"psdnssecurityrulenamedcv1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
       "isContentBase64": false
     }
   }

--- a/src/DnsResolver/DnsResolver.Autorest/test/New-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
+++ b/src/DnsResolver/DnsResolver.Autorest/test/New-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
@@ -1,26 +1,65 @@
-$TestRecordingFile = Join-Path $PSScriptRoot 'New-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) { $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File; $currentPath = Split-Path -Path $currentPath -Parent }
-. ($mockingPath | Select-Object -First 1).FullName
+if(($null -eq $TestName) -or ($TestName -contains 'New-AzDnsResolverPolicyDnsSecurityRule'))
+{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)
+  $TestRecordingFile = Join-Path $PSScriptRoot 'New-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
+  $currentPath = $PSScriptRoot
+  while(-not $mockingPath) {
+      $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+      $currentPath = Split-Path -Path $currentPath -Parent
+  }
+  . ($mockingPath | Select-Object -First 1).FullName
+}
+
+# Load post-merge test helper for routing to Frontend endpoint
+. (Join-Path $PSScriptRoot 'postMergeTestHelper.ps1')
+if ($TestMode -ne 'playback') {
+    $postMergeStep = New-PostMergeTestHttpPipelineStep
+    $existingMock = $PSDefaultParameterValues["*:HttpPipelinePrepend"]
+    # Order matters: steps are chained last→first, so [PostMerge, Mock] yields Mock→PostMerge→terminal
+    $PSDefaultParameterValues["*:HttpPipelinePrepend"] = [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep[]]@(
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$postMergeStep,
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$existingMock
+    )
+}
 
 Describe 'New-AzDnsResolverPolicyDnsSecurityRule' {
-    BeforeAll {
-        $subscriptionId = '97db216c-169d-4ea9-9d98-114adba0aa20'; $location = 'westus2'
-        $rgName = "ps-secrule-new-68744"
-        if ($TestMode -ne 'playback') {
-            Select-AzSubscription -SubscriptionId $subscriptionId
-            New-AzResourceGroup -Name $rgName -Location $location
-            New-AzDnsResolverPolicy -Name "policy-secrule-1" -ResourceGroupName $rgName -Location $location
-            New-AzDnsResolverDomainList -Name "domainlist-secrule-1" -ResourceGroupName $rgName -Location $location -Domain @("contoso.com.")
-        }
+    It 'Create DNS security rule' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename0j0cdzg";
+        $dnsSecurityRuleName = "psdnssecurityrulename0j0cdzg";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename0j0cdzg";
+        $resourceGroupName = "powershell-test-rg-debug-new";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+
+        # ACT
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ASSERT
+        {Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -DnsSecurityRuleName $dnsSecurityRuleName -ResourceGroupName $resourceGroupName } | Should -Not -Throw
     }
-    AfterAll {
-        if ($TestMode -ne 'playback') { Remove-AzResourceGroup -Name $rgName -ErrorAction SilentlyContinue -AsJob | Out-Null }
-    }
-    It 'Create a DNS security rule' {
-        $dlId = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-1"
-        $rule = New-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-new-1" -DnsResolverPolicyName "policy-secrule-1" -ResourceGroupName $rgName -Location $location -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DnsResolverDomainList @(@{id = $dlId})
-        $rule.ProvisioningState | Should -Be "Succeeded"
-        $rule.Name | Should -Be "secrule-new-1"
+
+    It 'Create DNS security rule with DisableCnameChainValidation' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulenamedcv1";
+        $dnsSecurityRuleName = "psdnssecurityrulenamedcv1";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulenamedcv1";
+        $resourceGroupName = "powershell-test-rg-debug-new";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+
+        # ACT
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DisableCnameChainValidation
+
+        # ASSERT
+        $securityRule.DisableCnameChainValidation | Should -Be $true
+        $retrievedRule = Get-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName
+        $retrievedRule.DisableCnameChainValidation | Should -Be $true
     }
 }

--- a/src/DnsResolver/DnsResolver.Autorest/test/Remove-AzDnsResolverPolicyDnsSecurityRule.Recording.json
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Remove-AzDnsResolverPolicyDnsSecurityRule.Recording.json
@@ -1,8 +1,8 @@
 {
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r?api-version=2025-10-01-preview+1": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg?api-version=2026-07-01-preview+1": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r?api-version=2025-10-01-preview",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg?api-version=2026-07-01-preview",
       "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
       "isContentBase64": false,
       "Headers": {
@@ -15,46 +15,29 @@
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:00 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "43d01e20-7828-4b1f-b355-b3451ef1ba47" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=?api-version=2025-10-01-preview\u0026t=639096308426479003\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EpiiF0sCMKkMiHcim0WQDyGvez_jJxFGuz4mXdHjXCChRizdh6nvs4PdQrXks-u0J-ajOSTfoJYATivPHYQOnRxzISAxWPkukAMO5xJ9IFpKD5n58Iy_PGui674B3C8qfkw9Nt0VJCsiv8mQRZ4laGg-8tHcjjG-oqubDoVftD9QSd8tEkGw_gTj3881MtI8GaFbW7VDM8P7isJDnsCLrrzO5C6kkoa0kJU580X3WSh_TaKhVAR5T3jIhra7JuKAa6yjyWIUwDQQ_bwuRMyECvFAlkTTc4ZfiTE4di2tI1g3-jN2SwB0pq283F_6wc3_djn1nUp__bzzAE9cVCVV-A\u0026h=N-PyyHSle6SSasp21LS0THLjn8_bRABZC3locLboDN8" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/4a394bb6-0cc3-4a23-9d6d-a28ce939ce3f" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "43d01e20-7828-4b1f-b355-b3451ef1ba47" ],
-        "x-ms-correlation-request-id": [ "43d01e20-7828-4b1f-b355-b3451ef1ba47" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191402Z:43d01e20-7828-4b1f-b355-b3451ef1ba47" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 83775265730E48A49DF3D19D10804F02 Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:01Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:02 GMT" ]
+        "x-ms-activity-id": [ "19ded443-6b6a-4184-806c-ac8e5bc2572b" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiN2UwMjVlNzEtZmZiZS00NTc0LTgxYTAtMzM5MDE3Zjc0MDQ1In0=?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "527" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "424" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"59018923-0000-0700-0000-69bd9c7a0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r\",\"name\":\"policy-secrule-r\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T19:14:02.2572782Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:14:02.2572782Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080032b0-0000-0800-0000-69fa6eb50000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg\",\"name\":\"psdnsresolverpolicyforrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=?api-version=2025-10-01-preview\u0026t=639096308426479003\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EpiiF0sCMKkMiHcim0WQDyGvez_jJxFGuz4mXdHjXCChRizdh6nvs4PdQrXks-u0J-ajOSTfoJYATivPHYQOnRxzISAxWPkukAMO5xJ9IFpKD5n58Iy_PGui674B3C8qfkw9Nt0VJCsiv8mQRZ4laGg-8tHcjjG-oqubDoVftD9QSd8tEkGw_gTj3881MtI8GaFbW7VDM8P7isJDnsCLrrzO5C6kkoa0kJU580X3WSh_TaKhVAR5T3jIhra7JuKAa6yjyWIUwDQQ_bwuRMyECvFAlkTTc4ZfiTE4di2tI1g3-jN2SwB0pq283F_6wc3_djn1nUp__bzzAE9cVCVV-A\u0026h=N-PyyHSle6SSasp21LS0THLjn8_bRABZC3locLboDN8+2": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiN2UwMjVlNzEtZmZiZS00NTc0LTgxYTAtMzM5MDE3Zjc0MDQ1In0=?api-version=2026-07-01-preview+2": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=?api-version=2025-10-01-preview\u0026t=639096308426479003\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EpiiF0sCMKkMiHcim0WQDyGvez_jJxFGuz4mXdHjXCChRizdh6nvs4PdQrXks-u0J-ajOSTfoJYATivPHYQOnRxzISAxWPkukAMO5xJ9IFpKD5n58Iy_PGui674B3C8qfkw9Nt0VJCsiv8mQRZ4laGg-8tHcjjG-oqubDoVftD9QSd8tEkGw_gTj3881MtI8GaFbW7VDM8P7isJDnsCLrrzO5C6kkoa0kJU580X3WSh_TaKhVAR5T3jIhra7JuKAa6yjyWIUwDQQ_bwuRMyECvFAlkTTc4ZfiTE4di2tI1g3-jN2SwB0pq283F_6wc3_djn1nUp__bzzAE9cVCVV-A\u0026h=N-PyyHSle6SSasp21LS0THLjn8_bRABZC3locLboDN8",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiN2UwMjVlNzEtZmZiZS00NTc0LTgxYTAtMzM5MDE3Zjc0MDQ1In0=?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "3" ],
-        "x-ms-client-request-id": [ "58bdbeb0-e9a3-4d58-81a3-3545ee5a757d" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -62,172 +45,84 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "6cafcfbd-0410-422d-9e2c-291933fdb30f" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/48bc8c47-b040-4b6b-a280-6c9d9dd6ccec" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "6cafcfbd-0410-422d-9e2c-291933fdb30f" ],
-        "x-ms-correlation-request-id": [ "6cafcfbd-0410-422d-9e2c-291933fdb30f" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191408Z:6cafcfbd-0410-422d-9e2c-291933fdb30f" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 846D6AFEAD714689A52CD5446F70D2D4 Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:07Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:08 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "510" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=\",\"startTime\":\"2026-03-20T19:14:02.0000000Z\",\"status\":\"InProgress\"}",
-      "isContentBase64": false
-    }
-  },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=?api-version=2025-10-01-preview\u0026t=639096308426479003\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EpiiF0sCMKkMiHcim0WQDyGvez_jJxFGuz4mXdHjXCChRizdh6nvs4PdQrXks-u0J-ajOSTfoJYATivPHYQOnRxzISAxWPkukAMO5xJ9IFpKD5n58Iy_PGui674B3C8qfkw9Nt0VJCsiv8mQRZ4laGg-8tHcjjG-oqubDoVftD9QSd8tEkGw_gTj3881MtI8GaFbW7VDM8P7isJDnsCLrrzO5C6kkoa0kJU580X3WSh_TaKhVAR5T3jIhra7JuKAa6yjyWIUwDQQ_bwuRMyECvFAlkTTc4ZfiTE4di2tI1g3-jN2SwB0pq283F_6wc3_djn1nUp__bzzAE9cVCVV-A\u0026h=N-PyyHSle6SSasp21LS0THLjn8_bRABZC3locLboDN8+3": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=?api-version=2025-10-01-preview\u0026t=639096308426479003\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EpiiF0sCMKkMiHcim0WQDyGvez_jJxFGuz4mXdHjXCChRizdh6nvs4PdQrXks-u0J-ajOSTfoJYATivPHYQOnRxzISAxWPkukAMO5xJ9IFpKD5n58Iy_PGui674B3C8qfkw9Nt0VJCsiv8mQRZ4laGg-8tHcjjG-oqubDoVftD9QSd8tEkGw_gTj3881MtI8GaFbW7VDM8P7isJDnsCLrrzO5C6kkoa0kJU580X3WSh_TaKhVAR5T3jIhra7JuKAa6yjyWIUwDQQ_bwuRMyECvFAlkTTc4ZfiTE4di2tI1g3-jN2SwB0pq283F_6wc3_djn1nUp__bzzAE9cVCVV-A\u0026h=N-PyyHSle6SSasp21LS0THLjn8_bRABZC3locLboDN8",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "4" ],
-        "x-ms-client-request-id": [ "58bdbeb0-e9a3-4d58-81a3-3545ee5a757d" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "2691e516-0779-4c96-bf27-ec80bee22c02" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/42e3b4aa-6df8-41c2-a1fd-ea038aa121bb" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "2691e516-0779-4c96-bf27-ec80bee22c02" ],
-        "x-ms-correlation-request-id": [ "2691e516-0779-4c96-bf27-ec80bee22c02" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191440Z:2691e516-0779-4c96-bf27-ec80bee22c02" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 40C4A1B8D26245F0A1E42BD86D25C54F Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:39Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:39 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "550" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMWZkYjdhNTEtNjgzZC00NjI3LWI3NDMtYTUyY2I3NzEzZDdhIn0=\",\"startTime\":\"2026-03-20T19:14:02.0000000Z\",\"endTime\":\"2026-03-20T19:14:16.0000000Z\",\"status\":\"Succeeded\"}",
-      "isContentBase64": false
-    }
-  },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r?api-version=2025-10-01-preview+4": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "5" ],
-        "x-ms-client-request-id": [ "58bdbeb0-e9a3-4d58-81a3-3545ee5a757d" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "ef6f9061-1ea9-41b3-bf89-c53916486b01" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "ef6f9061-1ea9-41b3-bf89-c53916486b01" ],
-        "x-ms-correlation-request-id": [ "ef6f9061-1ea9-41b3-bf89-c53916486b01" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191441Z:ef6f9061-1ea9-41b3-bf89-c53916486b01" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 3BCC3B9668B64012ADA22874D5D64958 Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:40Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:41 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:05 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "aab23477-dbb1-44ff-8b05-efbef91d185e" ]
       },
       "ContentHeaders": {
         "Content-Length": [ "562" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"1f529667-5068-4b7d-87dc-d55cbe98228f\"},\"etag\":\"\\\"d200d0c2-0000-0700-0000-69bd9c860000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r\",\"name\":\"policy-secrule-r\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T19:14:02.2572782Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:14:02.2572782Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiN2UwMjVlNzEtZmZiZS00NTc0LTgxYTAtMzM5MDE3Zjc0MDQ1In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiN2UwMjVlNzEtZmZiZS00NTc0LTgxYTAtMzM5MDE3Zjc0MDQ1In0=\",\"startTime\":\"2026-05-05T22:27:01.0000000Z\",\"endTime\":\"2026-05-05T22:27:02.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r?api-version=2025-10-01-preview+5": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg?api-version=2026-07-01-preview+3": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:05 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b15f9a64-4bb1-4fa9-ad47-09538d13362d" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "459" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"467f5ed1-980c-44d6-b5d9-e83f09693549\"},\"etag\":\"\\\"1200c856-0000-0800-0000-69fa6eb60000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg\",\"name\":\"psdnsresolverpolicyforrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg?api-version=2026-07-01-preview+4": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\" ]\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "89" ]
+        "Content-Length": [ "105" ]
       }
     },
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:05 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "170d5aa5-e100-4ae0-a385-75cae3f9c50e" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9?api-version=2025-10-01-preview\u0026t=639096308828675840\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BIWkrzkAL7qvA1nV_CuqoOct-ObG-JwZnvD1zfVVb8s3GECMkCLKI1mNEXdxKV6zvvTAHxAdRy9Kg9jCodC-RM_odbcogOIecDtDuQmIlUCJqM_zcIuFcySh09YqpQQoQIt6_ASQdmKFtdTxBqzojJ3DUBNHiztbZrJmr_iiQke079CYhce9gyBKiJ1Gsg3KcFj3WjAR8t6D2tMOzcjOXk1okRYy-U359-GztTTttQk7zJf1MGKLKdlG_1z52oRIDoZxWQ-qEPnOR-1hvjZFEeEGrSSuHhfmhx_Mo4SqkQRP2cBu1tY5yAO9UAYYVkxKBR44D3Rh0b69DLZFj61LxA\u0026h=_IdQqPjXNgYQRSqJaIZ4XWwqLty0289PhjuRtxp9RWQ" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/ae50b7f5-07d1-4dcb-b82e-2644cb4273cb" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "170d5aa5-e100-4ae0-a385-75cae3f9c50e" ],
-        "x-ms-correlation-request-id": [ "170d5aa5-e100-4ae0-a385-75cae3f9c50e" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191442Z:170d5aa5-e100-4ae0-a385-75cae3f9c50e" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: B316E36692CF41418A0D8D6DE8E9653F Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:41Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:42 GMT" ]
+        "x-ms-activity-id": [ "aa199c96-8fe0-4a2b-9c1c-f602eb83053b" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImM4NTA0ZDQxLWQ5ZDgtNGI3Mi1hN2ZjLWVmZGY0Y2UyYTNlNCJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "586" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "498" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"59013728-0000-0700-0000-69bd9ca20000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r\",\"name\":\"domainlist-secrule-r\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T19:14:42.4925605Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:14:42.4925605Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080075b0-0000-0800-0000-69fa6eba0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg\",\"name\":\"psdnsresolverdomainlistforrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9?api-version=2025-10-01-preview\u0026t=639096308828675840\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BIWkrzkAL7qvA1nV_CuqoOct-ObG-JwZnvD1zfVVb8s3GECMkCLKI1mNEXdxKV6zvvTAHxAdRy9Kg9jCodC-RM_odbcogOIecDtDuQmIlUCJqM_zcIuFcySh09YqpQQoQIt6_ASQdmKFtdTxBqzojJ3DUBNHiztbZrJmr_iiQke079CYhce9gyBKiJ1Gsg3KcFj3WjAR8t6D2tMOzcjOXk1okRYy-U359-GztTTttQk7zJf1MGKLKdlG_1z52oRIDoZxWQ-qEPnOR-1hvjZFEeEGrSSuHhfmhx_Mo4SqkQRP2cBu1tY5yAO9UAYYVkxKBR44D3Rh0b69DLZFj61LxA\u0026h=_IdQqPjXNgYQRSqJaIZ4XWwqLty0289PhjuRtxp9RWQ+6": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImM4NTA0ZDQxLWQ5ZDgtNGI3Mi1hN2ZjLWVmZGY0Y2UyYTNlNCJ9?api-version=2026-07-01-preview+5": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9?api-version=2025-10-01-preview\u0026t=639096308828675840\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BIWkrzkAL7qvA1nV_CuqoOct-ObG-JwZnvD1zfVVb8s3GECMkCLKI1mNEXdxKV6zvvTAHxAdRy9Kg9jCodC-RM_odbcogOIecDtDuQmIlUCJqM_zcIuFcySh09YqpQQoQIt6_ASQdmKFtdTxBqzojJ3DUBNHiztbZrJmr_iiQke079CYhce9gyBKiJ1Gsg3KcFj3WjAR8t6D2tMOzcjOXk1okRYy-U359-GztTTttQk7zJf1MGKLKdlG_1z52oRIDoZxWQ-qEPnOR-1hvjZFEeEGrSSuHhfmhx_Mo4SqkQRP2cBu1tY5yAO9UAYYVkxKBR44D3Rh0b69DLZFj61LxA\u0026h=_IdQqPjXNgYQRSqJaIZ4XWwqLty0289PhjuRtxp9RWQ",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImM4NTA0ZDQxLWQ5ZDgtNGI3Mi1hN2ZjLWVmZGY0Y2UyYTNlNCJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "7" ],
-        "x-ms-client-request-id": [ "fbd9deb4-9259-4a25-9644-a177b434fe20" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -235,43 +130,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "3e0ae06e-db85-4795-9f9e-f2d99018928d" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/a5019b25-8a5a-4ec0-9517-51299737d1e9" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "3e0ae06e-db85-4795-9f9e-f2d99018928d" ],
-        "x-ms-correlation-request-id": [ "3e0ae06e-db85-4795-9f9e-f2d99018928d" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191448Z:3e0ae06e-db85-4795-9f9e-f2d99018928d" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: B470ED843CA349F3BED20EF1425349A8 Ref B: MWH011020809060 Ref C: 2026-03-20T19:14:48Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:14:48 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:10 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b65909c0-bd9b-4e68-add8-025f19dd3ff0" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "518" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "570" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9\",\"startTime\":\"2026-03-20T19:14:42.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImM4NTA0ZDQxLWQ5ZDgtNGI3Mi1hN2ZjLWVmZGY0Y2UyYTNlNCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImM4NTA0ZDQxLWQ5ZDgtNGI3Mi1hN2ZjLWVmZGY0Y2UyYTNlNCJ9\",\"startTime\":\"2026-05-05T22:27:06.0000000Z\",\"endTime\":\"2026-05-05T22:27:09.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9?api-version=2025-10-01-preview\u0026t=639096308828675840\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BIWkrzkAL7qvA1nV_CuqoOct-ObG-JwZnvD1zfVVb8s3GECMkCLKI1mNEXdxKV6zvvTAHxAdRy9Kg9jCodC-RM_odbcogOIecDtDuQmIlUCJqM_zcIuFcySh09YqpQQoQIt6_ASQdmKFtdTxBqzojJ3DUBNHiztbZrJmr_iiQke079CYhce9gyBKiJ1Gsg3KcFj3WjAR8t6D2tMOzcjOXk1okRYy-U359-GztTTttQk7zJf1MGKLKdlG_1z52oRIDoZxWQ-qEPnOR-1hvjZFEeEGrSSuHhfmhx_Mo4SqkQRP2cBu1tY5yAO9UAYYVkxKBR44D3Rh0b69DLZFj61LxA\u0026h=_IdQqPjXNgYQRSqJaIZ4XWwqLty0289PhjuRtxp9RWQ+7": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg?api-version=2026-07-01-preview+6": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9?api-version=2025-10-01-preview\u0026t=639096308828675840\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BIWkrzkAL7qvA1nV_CuqoOct-ObG-JwZnvD1zfVVb8s3GECMkCLKI1mNEXdxKV6zvvTAHxAdRy9Kg9jCodC-RM_odbcogOIecDtDuQmIlUCJqM_zcIuFcySh09YqpQQoQIt6_ASQdmKFtdTxBqzojJ3DUBNHiztbZrJmr_iiQke079CYhce9gyBKiJ1Gsg3KcFj3WjAR8t6D2tMOzcjOXk1okRYy-U359-GztTTttQk7zJf1MGKLKdlG_1z52oRIDoZxWQ-qEPnOR-1hvjZFEeEGrSSuHhfmhx_Mo4SqkQRP2cBu1tY5yAO9UAYYVkxKBR44D3Rh0b69DLZFj61LxA\u0026h=_IdQqPjXNgYQRSqJaIZ4XWwqLty0289PhjuRtxp9RWQ",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "8" ],
-        "x-ms-client-request-id": [ "fbd9deb4-9259-4a25-9644-a177b434fe20" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -279,128 +157,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "9ed3ebab-3c2d-49a3-9448-32be38f2b73a" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/21a817cd-e025-43ac-8fe9-8acf1da96880" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "9ed3ebab-3c2d-49a3-9448-32be38f2b73a" ],
-        "x-ms-correlation-request-id": [ "9ed3ebab-3c2d-49a3-9448-32be38f2b73a" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191519Z:9ed3ebab-3c2d-49a3-9448-32be38f2b73a" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 166A4492BA1441A88ACBA340E17FFD72 Ref B: MWH011020809060 Ref C: 2026-03-20T19:15:18Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:15:19 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:10 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "fca28e47-e04e-4ecf-b209-dce11b737d85" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "558" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "533" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjVhMzc5NjE4LTgyMmEtNDUxNC1iNDM4LWY2NGVhZWQ0MTZkNCJ9\",\"startTime\":\"2026-03-20T19:14:42.0000000Z\",\"endTime\":\"2026-03-20T19:14:56.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"3995e4ef-ac7f-42e8-b03c-8df36a770d0d\"},\"etag\":\"\\\"a2089982-0000-0800-0000-69fa6ebd0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg\",\"name\":\"psdnsresolverdomainlistforrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r?api-version=2025-10-01-preview+8": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "9" ],
-        "x-ms-client-request-id": [ "fbd9deb4-9259-4a25-9644-a177b434fe20" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "306a56b5-9633-46d9-a72a-a938c6e57870" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "306a56b5-9633-46d9-a72a-a938c6e57870" ],
-        "x-ms-correlation-request-id": [ "306a56b5-9633-46d9-a72a-a938c6e57870" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191520Z:306a56b5-9633-46d9-a72a-a938c6e57870" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: BDDF2F32425345269849979FADB3026E Ref B: MWH011020809060 Ref C: 2026-03-20T19:15:20Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:15:19 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "621" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"146830e9-12eb-4ff5-aaa9-bdd31a16a6e7\"},\"etag\":\"\\\"10005008-0000-0700-0000-69bd9cae0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r\",\"name\":\"domainlist-secrule-r\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T19:14:42.4925605Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:14:42.4925605Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview+9": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview+7": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "404" ]
+        "Content-Length": [ "437" ]
       }
     },
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:10 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "17c860fa-68e6-4875-a676-376621015bcc" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9?api-version=2025-10-01-preview\u0026t=639096309220434662\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EAx_rctaiim5HZKCbgyAwKEJWVrVGxEdjbeJMXxWGl0HndKyV8gCU5CwmRXRaNklPJzY0RJtFX20XJQtNxLrzsQkiDNLtexFec2cQCtJDEK692_83WFiapndicLycU7f8iKfHZm1TYfyJjkt4-qVZDRRlJOmnhmvjWiQlnRb8wvL01eBs9_YvqR4MFDqUYD8lezV70dOsei2NiGc1koXv2EK4_RcBQFzYiTSfHHLtj3OEMdyBxkZvsHCdpSV9qNg8o1Yu1OMgk61f57KwgzH9eubXmwmRV6B-55gk4UaQ9z9CzxPrstsOal2xXsLZSkJwFDKmdsx302V86FXoDOGiQ\u0026h=NzLd7e__QQPwLqxu7D6LLrwCGfDCJrlzRZ0F34jXRnU" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/695fc257-6d7a-4bcf-83c6-0324d8e9fab9" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "17c860fa-68e6-4875-a676-376621015bcc" ],
-        "x-ms-correlation-request-id": [ "17c860fa-68e6-4875-a676-376621015bcc" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191522Z:17c860fa-68e6-4875-a676-376621015bcc" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 37B87FBBD1B14A099E9D2E95C4CBC6EA Ref B: MWH011020809060 Ref C: 2026-03-20T19:15:20Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:15:21 GMT" ]
+        "x-ms-activity-id": [ "73d7009f-ee8f-4f2d-a6f7-5d5ee7be8f97" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImUzYjM1NThiLTRjOWQtNDk1Ny04YTE0LWUzZWYwZDY5ZjNkNyJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "861" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "802" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"d2003bc9-0000-0700-0000-69bd9cc90000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1\",\"name\":\"secrule-rm-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T19:15:21.5122067Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:15:21.5122067Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"12007157-0000-0800-0000-69fa6ebf0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg\",\"name\":\"psdnssecurityrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9?api-version=2025-10-01-preview\u0026t=639096309220434662\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EAx_rctaiim5HZKCbgyAwKEJWVrVGxEdjbeJMXxWGl0HndKyV8gCU5CwmRXRaNklPJzY0RJtFX20XJQtNxLrzsQkiDNLtexFec2cQCtJDEK692_83WFiapndicLycU7f8iKfHZm1TYfyJjkt4-qVZDRRlJOmnhmvjWiQlnRb8wvL01eBs9_YvqR4MFDqUYD8lezV70dOsei2NiGc1koXv2EK4_RcBQFzYiTSfHHLtj3OEMdyBxkZvsHCdpSV9qNg8o1Yu1OMgk61f57KwgzH9eubXmwmRV6B-55gk4UaQ9z9CzxPrstsOal2xXsLZSkJwFDKmdsx302V86FXoDOGiQ\u0026h=NzLd7e__QQPwLqxu7D6LLrwCGfDCJrlzRZ0F34jXRnU+10": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImUzYjM1NThiLTRjOWQtNDk1Ny04YTE0LWUzZWYwZDY5ZjNkNyJ9?api-version=2026-07-01-preview+8": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9?api-version=2025-10-01-preview\u0026t=639096309220434662\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EAx_rctaiim5HZKCbgyAwKEJWVrVGxEdjbeJMXxWGl0HndKyV8gCU5CwmRXRaNklPJzY0RJtFX20XJQtNxLrzsQkiDNLtexFec2cQCtJDEK692_83WFiapndicLycU7f8iKfHZm1TYfyJjkt4-qVZDRRlJOmnhmvjWiQlnRb8wvL01eBs9_YvqR4MFDqUYD8lezV70dOsei2NiGc1koXv2EK4_RcBQFzYiTSfHHLtj3OEMdyBxkZvsHCdpSV9qNg8o1Yu1OMgk61f57KwgzH9eubXmwmRV6B-55gk4UaQ9z9CzxPrstsOal2xXsLZSkJwFDKmdsx302V86FXoDOGiQ\u0026h=NzLd7e__QQPwLqxu7D6LLrwCGfDCJrlzRZ0F34jXRnU",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImUzYjM1NThiLTRjOWQtNDk1Ny04YTE0LWUzZWYwZDY5ZjNkNyJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "11" ],
-        "x-ms-client-request-id": [ "d6a4a791-be9e-47ed-a634-20b1cac2d729" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -408,43 +215,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "45422de5-c6df-480b-8f50-d10d059e5eb8" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/b27fecae-1aaf-41cf-a67d-41019048ed15" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "45422de5-c6df-480b-8f50-d10d059e5eb8" ],
-        "x-ms-correlation-request-id": [ "45422de5-c6df-480b-8f50-d10d059e5eb8" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191528Z:45422de5-c6df-480b-8f50-d10d059e5eb8" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: EE8092DCABBD45A6983EC79CA98792B5 Ref B: MWH011020809060 Ref C: 2026-03-20T19:15:27Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:15:28 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:15 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "9562d756-0963-4abf-9509-f8da9548bf2e" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "502" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9\",\"startTime\":\"2026-03-20T19:15:21.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImUzYjM1NThiLTRjOWQtNDk1Ny04YTE0LWUzZWYwZDY5ZjNkNyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImUzYjM1NThiLTRjOWQtNDk1Ny04YTE0LWUzZWYwZDY5ZjNkNyJ9\",\"startTime\":\"2026-05-05T22:27:11.0000000Z\",\"endTime\":\"2026-05-05T22:27:14.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9?api-version=2025-10-01-preview\u0026t=639096309220434662\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EAx_rctaiim5HZKCbgyAwKEJWVrVGxEdjbeJMXxWGl0HndKyV8gCU5CwmRXRaNklPJzY0RJtFX20XJQtNxLrzsQkiDNLtexFec2cQCtJDEK692_83WFiapndicLycU7f8iKfHZm1TYfyJjkt4-qVZDRRlJOmnhmvjWiQlnRb8wvL01eBs9_YvqR4MFDqUYD8lezV70dOsei2NiGc1koXv2EK4_RcBQFzYiTSfHHLtj3OEMdyBxkZvsHCdpSV9qNg8o1Yu1OMgk61f57KwgzH9eubXmwmRV6B-55gk4UaQ9z9CzxPrstsOal2xXsLZSkJwFDKmdsx302V86FXoDOGiQ\u0026h=NzLd7e__QQPwLqxu7D6LLrwCGfDCJrlzRZ0F34jXRnU+11": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview+9": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9?api-version=2025-10-01-preview\u0026t=639096309220434662\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=EAx_rctaiim5HZKCbgyAwKEJWVrVGxEdjbeJMXxWGl0HndKyV8gCU5CwmRXRaNklPJzY0RJtFX20XJQtNxLrzsQkiDNLtexFec2cQCtJDEK692_83WFiapndicLycU7f8iKfHZm1TYfyJjkt4-qVZDRRlJOmnhmvjWiQlnRb8wvL01eBs9_YvqR4MFDqUYD8lezV70dOsei2NiGc1koXv2EK4_RcBQFzYiTSfHHLtj3OEMdyBxkZvsHCdpSV9qNg8o1Yu1OMgk61f57KwgzH9eubXmwmRV6B-55gk4UaQ9z9CzxPrstsOal2xXsLZSkJwFDKmdsx302V86FXoDOGiQ\u0026h=NzLd7e__QQPwLqxu7D6LLrwCGfDCJrlzRZ0F34jXRnU",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "12" ],
-        "x-ms-client-request-id": [ "d6a4a791-be9e-47ed-a634-20b1cac2d729" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -452,86 +242,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "a8e2d257-7e72-4ca2-a362-312782f4cb53" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/62db19aa-0e43-4275-94a4-94fcaefbae9b" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "a8e2d257-7e72-4ca2-a362-312782f4cb53" ],
-        "x-ms-correlation-request-id": [ "a8e2d257-7e72-4ca2-a362-312782f4cb53" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191600Z:a8e2d257-7e72-4ca2-a362-312782f4cb53" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: B44BDBBC29134CB290BF8D5BCDB36D4D Ref B: MWH011020809060 Ref C: 2026-03-20T19:15:58Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:15:59 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:15 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "e12988a8-c2b0-4ca4-b221-497a48a83f50" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "542" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "803" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImY0YjA2NjQ5LWU4OWItNGMwMS05MTRkLTQ0ZTM3NDQxMTQxOSJ9\",\"startTime\":\"2026-03-20T19:15:21.0000000Z\",\"endTime\":\"2026-03-20T19:15:38.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename8y8cdzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900e52e-0000-0800-0000-69fa6ec10000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg\",\"name\":\"psdnssecurityrulename8y8cdzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview+12": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "13" ],
-        "x-ms-client-request-id": [ "d6a4a791-be9e-47ed-a634-20b1cac2d729" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "14aa2fe9-91a8-4f72-861a-c1806499df99" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "14aa2fe9-91a8-4f72-861a-c1806499df99" ],
-        "x-ms-correlation-request-id": [ "14aa2fe9-91a8-4f72-861a-c1806499df99" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191601Z:14aa2fe9-91a8-4f72-861a-c1806499df99" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: AE1957EB7E0B4FCDB6CE9B07B6A468F3 Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:00Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:01 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "862" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"c9005cfb-0000-0700-0000-69bd9cd70000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1\",\"name\":\"secrule-rm-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T19:15:21.5122067Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T19:15:21.5122067Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a security rule+$DELETE+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview+1": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$DELETE+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview+10": {
     "Request": {
       "Method": "DELETE",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "x-ms-unique-id": [ "14" ],
-        "x-ms-client-request-id": [ "ad1a5ae8-cbba-410a-aedb-ac06d4cf9a77" ],
-        "CommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule_Delete" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ],
-        "Authorization": [ "[Filtered]" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -539,45 +269,28 @@
     "Response": {
       "StatusCode": 202,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628667183\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BoVh_GcCFSwefSzypxIowQUUjR8COR0IPfktmyf7GOu7AozmwiM-fEVUsXWKXmaup7VGVoda9sdEsjY1rfVS9QEyEoUiAZ-5qhBO3Zn3dQd8k0RVSZnIx-AVs8wUbrUvy9vxNaarNviDyIIga3p1aWL5pHEoTwLLs1iAYUzHoCDglLQOAGaAUj8_G9hioeLFaDbFljoO4Oe-9IuWbYfyhono1PoLguOJknUBLGwSuLc_Ut3DRtZs5XxI0NkK0GStVKA1DRNLfkKi3pJ6DVoN30Z590jOiPuGQXTMdVCazFqunDIPPR4B1m-hpjJBA258Cn4mZykhN1OH3N902dkP8A\u0026h=oJ1L4OVEzF9jqhfHB5lsX15xu4oN-HtjhF8lfroWllE" ],
+        "Date": [ "Tue, 05 May 2026 22:27:16 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "e8722b88-7867-421f-b8ef-aae19406a993" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628510622\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FhOvE19CCmoIAenXEhpS4gR0sEKCOe2or9p9Yqh41jP3psz0_lKbcde4a-HfnbiBdGptKJwlKAHTgZmw1AJR3Sh07fHqkD14eI9ZqEH84mYoh7k409eCe4bHSkcs7NnYNSR9GWjNv5xHZ5p6kRcKiZ_0Zy-Fy410LbaOuoZjt3eOKPtq1oL_n7xlWDf3tEzrHzRc4so5ddE0kcAvXWsGT8aO7_hT5UhU_R8n3ZK2sxrybMNztvOULNOdyTnDTtyhN8oIMj_-98IDuHDPe8dFBcXTKkQmXfBBFDB-Hawg8em8XyzbqQHQzqUy4O2mOTXuJVj5u1DthnllCE_Y0bBOWw\u0026h=X6KaAl1lCajroJGZZXthuT7PlxuBw3PJmp7fr98iycs" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/a693ae5e-272c-43a5-bb62-f61b922566cf" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "e8722b88-7867-421f-b8ef-aae19406a993" ],
-        "x-ms-correlation-request-id": [ "e8722b88-7867-421f-b8ef-aae19406a993" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191602Z:e8722b88-7867-421f-b8ef-aae19406a993" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 5EC4CF0DB96E4E6C90408484C675B6F4 Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:02Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:02 GMT" ]
+        "x-ms-activity-id": [ "cfc57fe9-d2dc-4cfd-8c0d-390bb6e3ec4b" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Expires": [ "-1" ],
         "Content-Length": [ "0" ]
       },
       "Content": null,
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628510622\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FhOvE19CCmoIAenXEhpS4gR0sEKCOe2or9p9Yqh41jP3psz0_lKbcde4a-HfnbiBdGptKJwlKAHTgZmw1AJR3Sh07fHqkD14eI9ZqEH84mYoh7k409eCe4bHSkcs7NnYNSR9GWjNv5xHZ5p6kRcKiZ_0Zy-Fy410LbaOuoZjt3eOKPtq1oL_n7xlWDf3tEzrHzRc4so5ddE0kcAvXWsGT8aO7_hT5UhU_R8n3ZK2sxrybMNztvOULNOdyTnDTtyhN8oIMj_-98IDuHDPe8dFBcXTKkQmXfBBFDB-Hawg8em8XyzbqQHQzqUy4O2mOTXuJVj5u1DthnllCE_Y0bBOWw\u0026h=X6KaAl1lCajroJGZZXthuT7PlxuBw3PJmp7fr98iycs+2": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview+11": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628510622\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FhOvE19CCmoIAenXEhpS4gR0sEKCOe2or9p9Yqh41jP3psz0_lKbcde4a-HfnbiBdGptKJwlKAHTgZmw1AJR3Sh07fHqkD14eI9ZqEH84mYoh7k409eCe4bHSkcs7NnYNSR9GWjNv5xHZ5p6kRcKiZ_0Zy-Fy410LbaOuoZjt3eOKPtq1oL_n7xlWDf3tEzrHzRc4so5ddE0kcAvXWsGT8aO7_hT5UhU_R8n3ZK2sxrybMNztvOULNOdyTnDTtyhN8oIMj_-98IDuHDPe8dFBcXTKkQmXfBBFDB-Hawg8em8XyzbqQHQzqUy4O2mOTXuJVj5u1DthnllCE_Y0bBOWw\u0026h=X6KaAl1lCajroJGZZXthuT7PlxuBw3PJmp7fr98iycs",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "15" ],
-        "x-ms-client-request-id": [ "ad1a5ae8-cbba-410a-aedb-ac06d4cf9a77" ],
-        "CommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule_Delete" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -585,87 +298,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "cefae9b9-c5e5-403b-8241-f36df9f80e14" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/c7e20d16-70c6-4fdb-a395-c4600bb694bd" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "cefae9b9-c5e5-403b-8241-f36df9f80e14" ],
-        "x-ms-correlation-request-id": [ "cefae9b9-c5e5-403b-8241-f36df9f80e14" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191609Z:cefae9b9-c5e5-403b-8241-f36df9f80e14" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 49D1E5798FCC474482AFDA08AC1F4003 Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:08Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:08 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:21 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "cbd6caca-5f36-4bb8-be5c-9c1013063226" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "502" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9\",\"startTime\":\"2026-03-20T19:16:02.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9\",\"startTime\":\"2026-05-05T22:27:16.0000000Z\",\"endTime\":\"2026-05-05T22:27:19.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628510622\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FhOvE19CCmoIAenXEhpS4gR0sEKCOe2or9p9Yqh41jP3psz0_lKbcde4a-HfnbiBdGptKJwlKAHTgZmw1AJR3Sh07fHqkD14eI9ZqEH84mYoh7k409eCe4bHSkcs7NnYNSR9GWjNv5xHZ5p6kRcKiZ_0Zy-Fy410LbaOuoZjt3eOKPtq1oL_n7xlWDf3tEzrHzRc4so5ddE0kcAvXWsGT8aO7_hT5UhU_R8n3ZK2sxrybMNztvOULNOdyTnDTtyhN8oIMj_-98IDuHDPe8dFBcXTKkQmXfBBFDB-Hawg8em8XyzbqQHQzqUy4O2mOTXuJVj5u1DthnllCE_Y0bBOWw\u0026h=X6KaAl1lCajroJGZZXthuT7PlxuBw3PJmp7fr98iycs+3": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview+12": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628510622\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FhOvE19CCmoIAenXEhpS4gR0sEKCOe2or9p9Yqh41jP3psz0_lKbcde4a-HfnbiBdGptKJwlKAHTgZmw1AJR3Sh07fHqkD14eI9ZqEH84mYoh7k409eCe4bHSkcs7NnYNSR9GWjNv5xHZ5p6kRcKiZ_0Zy-Fy410LbaOuoZjt3eOKPtq1oL_n7xlWDf3tEzrHzRc4so5ddE0kcAvXWsGT8aO7_hT5UhU_R8n3ZK2sxrybMNztvOULNOdyTnDTtyhN8oIMj_-98IDuHDPe8dFBcXTKkQmXfBBFDB-Hawg8em8XyzbqQHQzqUy4O2mOTXuJVj5u1DthnllCE_Y0bBOWw\u0026h=X6KaAl1lCajroJGZZXthuT7PlxuBw3PJmp7fr98iycs",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjY5NzBiYzMyLTIwNDAtNDg4My04N2FhLTJhY2M4ZjkwMDQwMiJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "16" ],
-        "x-ms-client-request-id": [ "ad1a5ae8-cbba-410a-aedb-ac06d4cf9a77" ],
-        "CommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule_Delete" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "a4368d40-a5d6-4ddb-952f-3190a2e85b78" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/eb2f5e01-817b-4a1d-af79-eba2b1f6c7ce" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "a4368d40-a5d6-4ddb-952f-3190a2e85b78" ],
-        "x-ms-correlation-request-id": [ "a4368d40-a5d6-4ddb-952f-3190a2e85b78" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191640Z:a4368d40-a5d6-4ddb-952f-3190a2e85b78" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: E943C6772A2940DEA9F956E6E6E8B2D9 Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:39Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:40 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "542" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9\",\"startTime\":\"2026-03-20T19:16:02.0000000Z\",\"endTime\":\"2026-03-20T19:16:17.0000000Z\",\"status\":\"Succeeded\"}",
-      "isContentBase64": false
-    }
-  },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628667183\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BoVh_GcCFSwefSzypxIowQUUjR8COR0IPfktmyf7GOu7AozmwiM-fEVUsXWKXmaup7VGVoda9sdEsjY1rfVS9QEyEoUiAZ-5qhBO3Zn3dQd8k0RVSZnIx-AVs8wUbrUvy9vxNaarNviDyIIga3p1aWL5pHEoTwLLs1iAYUzHoCDglLQOAGaAUj8_G9hioeLFaDbFljoO4Oe-9IuWbYfyhono1PoLguOJknUBLGwSuLc_Ut3DRtZs5XxI0NkK0GStVKA1DRNLfkKi3pJ6DVoN30Z590jOiPuGQXTMdVCazFqunDIPPR4B1m-hpjJBA258Cn4mZykhN1OH3N902dkP8A\u0026h=oJ1L4OVEzF9jqhfHB5lsX15xu4oN-HtjhF8lfroWllE+4": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjZmYzYzNjE5LWQwNWMtNDk5Ni05YzI5LTZiMWU1YjhlNzA0NiJ9?api-version=2025-10-01-preview\u0026t=639096309628667183\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=BoVh_GcCFSwefSzypxIowQUUjR8COR0IPfktmyf7GOu7AozmwiM-fEVUsXWKXmaup7VGVoda9sdEsjY1rfVS9QEyEoUiAZ-5qhBO3Zn3dQd8k0RVSZnIx-AVs8wUbrUvy9vxNaarNviDyIIga3p1aWL5pHEoTwLLs1iAYUzHoCDglLQOAGaAUj8_G9hioeLFaDbFljoO4Oe-9IuWbYfyhono1PoLguOJknUBLGwSuLc_Ut3DRtZs5XxI0NkK0GStVKA1DRNLfkKi3pJ6DVoN30Z590jOiPuGQXTMdVCazFqunDIPPR4B1m-hpjJBA258Cn4mZykhN1OH3N902dkP8A\u0026h=oJ1L4OVEzF9jqhfHB5lsX15xu4oN-HtjhF8lfroWllE",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "17" ],
-        "x-ms-client-request-id": [ "ad1a5ae8-cbba-410a-aedb-ac06d4cf9a77" ],
-        "CommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Remove-AzDnsResolverPolicyDnsSecurityRule_Delete" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -673,41 +325,24 @@
     "Response": {
       "StatusCode": 204,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "911b5a8e-369f-4c3c-964e-8130e65976f5" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/be5b1a49-f6b2-4cce-80dd-84640b75b72d" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "911b5a8e-369f-4c3c-964e-8130e65976f5" ],
-        "x-ms-correlation-request-id": [ "911b5a8e-369f-4c3c-964e-8130e65976f5" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191641Z:911b5a8e-369f-4c3c-964e-8130e65976f5" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: CAEFDFED1F8F42BAB502A11618DA504F Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:40Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:41 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:21 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "e6f7f9ef-a800-49e2-b954-15d358a90efd" ]
       },
       "ContentHeaders": {
-        "Expires": [ "-1" ]
       },
       "Content": null,
       "isContentBase64": false
     }
   },
-  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a security rule+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview+5": {
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule by name, expected DNS security rule deleted+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview+13": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-rm-25662/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1?api-version=2025-10-01-preview",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/dnsSecurityRules/psdnssecurityrulename8y8cdzg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "x-ms-unique-id": [ "18" ],
-        "x-ms-client-request-id": [ "89821a10-034e-4f2c-bdee-c2a099cc5573" ],
-        "CommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Get-AzDnsResolverPolicyDnsSecurityRule_Get" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ],
-        "Authorization": [ "[Filtered]" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -715,24 +350,405 @@
     "Response": {
       "StatusCode": 404,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-failure-cause": [ "gateway" ],
-        "x-ms-request-id": [ "54f0cc63-7bf8-4195-8f0b-636382d51ce3" ],
-        "x-ms-correlation-request-id": [ "54f0cc63-7bf8-4195-8f0b-636382d51ce3" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T191642Z:54f0cc63-7bf8-4195-8f0b-636382d51ce3" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 8A1930AE99DD4647B242F39424703614 Ref B: MWH011020809060 Ref C: 2026-03-20T19:16:41Z" ],
-        "Date": [ "Fri, 20 Mar 2026 19:16:42 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:21 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "df80a3bc-1190-438f-9680-1cd9f1cc4654" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "275" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "324" ],
+        "Content-Type": [ "application/json" ]
       },
-      "Content": "{\"error\":{\"code\":\"ResourceNotFound\",\"message\":\"The Resource \u0027Microsoft.Network/dnsResolverPolicies/policy-secrule-r/dnsSecurityRules/secrule-rm-1\u0027 under resource group \u0027ps-secrule-rm-25662\u0027 was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix\"}}",
+      "Content": "{\"error\":{\"details\":null,\"code\":\"NotFound\",\"message\":\"Subscription not found in database. dnsSecurityRuleResourceId=/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/dnsResolverPolicies/psdnsresolverpolicyforrulename8y8cdzg/rules/psdnssecurityrulename8y8cdzg\",\"target\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg?api-version=2026-07-01-preview+1": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "29" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:21 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "2d81a8e0-bbda-46c6-a469-d0964bfbe01a" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmQ5MzdkYzktNzliNi00ZTUzLWFlZjItMjAyY2U5NmI4MTI2In0=?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "424" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"08000ab1-0000-0800-0000-69fa6ec90000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg\",\"name\":\"psdnsresolverpolicyforrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmQ5MzdkYzktNzliNi00ZTUzLWFlZjItMjAyY2U5NmI4MTI2In0=?api-version=2026-07-01-preview+2": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmQ5MzdkYzktNzliNi00ZTUzLWFlZjItMjAyY2U5NmI4MTI2In0=?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:26 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "5eed1556-a817-44bc-aadd-cab6fc141147" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "562" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmQ5MzdkYzktNzliNi00ZTUzLWFlZjItMjAyY2U5NmI4MTI2In0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiYmQ5MzdkYzktNzliNi00ZTUzLWFlZjItMjAyY2U5NmI4MTI2In0=\",\"startTime\":\"2026-05-05T22:27:21.0000000Z\",\"endTime\":\"2026-05-05T22:27:22.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg?api-version=2026-07-01-preview+3": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:26 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "7b46b1f4-d819-48dc-b078-8d7742af7a6e" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "459" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"6d8fc3b0-0742-41b2-91d7-225b94104ef3\"},\"etag\":\"\\\"12003b58-0000-0800-0000-69fa6eca0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg\",\"name\":\"psdnsresolverpolicyforrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg?api-version=2026-07-01-preview+4": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "105" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:26 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "642ad495-2cab-4720-ba93-c98d7f54f65e" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImFkMWFhMGFhLWQ5ZjktNDBmNi04MDg4LWM1ODY2MTI3NTQxMyJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "498" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080039b1-0000-0800-0000-69fa6ece0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\",\"name\":\"psdnsresolverdomainlistforrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImFkMWFhMGFhLWQ5ZjktNDBmNi04MDg4LWM1ODY2MTI3NTQxMyJ9?api-version=2026-07-01-preview+5": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImFkMWFhMGFhLWQ5ZjktNDBmNi04MDg4LWM1ODY2MTI3NTQxMyJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:31 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b1d6121b-c2d5-48cb-8962-dbbb2942de48" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "570" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImFkMWFhMGFhLWQ5ZjktNDBmNi04MDg4LWM1ODY2MTI3NTQxMyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImFkMWFhMGFhLWQ5ZjktNDBmNi04MDg4LWM1ODY2MTI3NTQxMyJ9\",\"startTime\":\"2026-05-05T22:27:26.0000000Z\",\"endTime\":\"2026-05-05T22:27:29.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg?api-version=2026-07-01-preview+6": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:31 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "4e9e1717-53b2-4bea-b118-7611be3ef2bb" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "533" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"d9f4bcf7-b04b-4bce-84ab-fc398126db7e\"},\"etag\":\"\\\"a2085886-0000-0800-0000-69fa6ed10000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\",\"name\":\"psdnsresolverdomainlistforrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "437" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:31 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "35997875-c015-4e46-80ee-419644e415fe" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjlmNDMxNjY1LWExY2MtNDFjYi1iM2IzLWQ5ZGQxNTM1M2Q1YyJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "802" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"1200d858-0000-0800-0000-69fa6ed30000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg\",\"name\":\"psdnssecurityrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjlmNDMxNjY1LWExY2MtNDFjYi1iM2IzLWQ5ZGQxNTM1M2Q1YyJ9?api-version=2026-07-01-preview+8": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjlmNDMxNjY1LWExY2MtNDFjYi1iM2IzLWQ5ZGQxNTM1M2Q1YyJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "6299630e-c7f1-4d34-9540-b25465a2e9e9" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjlmNDMxNjY1LWExY2MtNDFjYi1iM2IzLWQ5ZGQxNTM1M2Q1YyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjlmNDMxNjY1LWExY2MtNDFjYi1iM2IzLWQ5ZGQxNTM1M2Q1YyJ9\",\"startTime\":\"2026-05-05T22:27:31.0000000Z\",\"endTime\":\"2026-05-05T22:27:32.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview+9": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "4e9bae4c-e739-48ac-9249-33141063908f" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "803" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900f02e-0000-0800-0000-69fa6ed40000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg\",\"name\":\"psdnssecurityrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview+10": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "4f685fc1-b47e-4c5f-bd76-5dab5dd4e467" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "803" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename0j9ujzg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900f02e-0000-0800-0000-69fa6ed40000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg\",\"name\":\"psdnssecurityrulename0j9ujzg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$DELETE+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview+11": {
+    "Request": {
+      "Method": "DELETE",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 202,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:36 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "1f873c9f-2acf-4bee-adc5-5d72cf3b2be0" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "0" ]
+      },
+      "Content": null,
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview+12": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "5b59ecdd-e67d-4c88-8466-a70dfe6b79cc" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9\",\"startTime\":\"2026-05-05T22:27:37.0000000Z\",\"endTime\":\"2026-05-05T22:27:39.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview+13": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjM4NjFkZjAwLWE2NDEtNGQyYS05ZTY2LTE1NDIzYTU4ZTFiNSJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 204,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "cbd1f086-02bb-4131-934e-5dce412ae1c7" ]
+      },
+      "ContentHeaders": {
+      },
+      "Content": null,
+      "isContentBase64": false
+    }
+  },
+  "Remove-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Delete a DNS security rule via identity, expected DNS security rule deleted+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview+14": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/dnsSecurityRules/psdnssecurityrulename0j9ujzg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 404,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:27:41 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "e453d9fb-4dfa-4128-b00e-52c514ae5175" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "324" ],
+        "Content-Type": [ "application/json" ]
+      },
+      "Content": "{\"error\":{\"details\":null,\"code\":\"NotFound\",\"message\":\"Subscription not found in database. dnsSecurityRuleResourceId=/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-remove/dnsResolverPolicies/psdnsresolverpolicyforrulename0j9ujzg/rules/psdnssecurityrulename0j9ujzg\",\"target\":null}}",
       "isContentBase64": false
     }
   }

--- a/src/DnsResolver/DnsResolver.Autorest/test/Remove-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Remove-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
@@ -1,26 +1,64 @@
-$TestRecordingFile = Join-Path $PSScriptRoot 'Remove-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) { $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File; $currentPath = Split-Path -Path $currentPath -Parent }
-. ($mockingPath | Select-Object -First 1).FullName
+if(($null -eq $TestName) -or ($TestName -contains 'Remove-AzDnsResolverPolicyDnsSecurityRule'))
+{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)
+  $TestRecordingFile = Join-Path $PSScriptRoot 'Remove-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
+  $currentPath = $PSScriptRoot
+  while(-not $mockingPath) {
+      $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+      $currentPath = Split-Path -Path $currentPath -Parent
+  }
+  . ($mockingPath | Select-Object -First 1).FullName
+}
+
+# Load post-merge test helper for routing to Frontend endpoint
+. (Join-Path $PSScriptRoot 'postMergeTestHelper.ps1')
+if ($TestMode -ne 'playback') {
+    $postMergeStep = New-PostMergeTestHttpPipelineStep
+    $existingMock = $PSDefaultParameterValues["*:HttpPipelinePrepend"]
+    $PSDefaultParameterValues["*:HttpPipelinePrepend"] = [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep[]]@(
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$postMergeStep,
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$existingMock
+    )
+}
 
 Describe 'Remove-AzDnsResolverPolicyDnsSecurityRule' {
-    BeforeAll {
-        $subscriptionId = '97db216c-169d-4ea9-9d98-114adba0aa20'; $location = 'westus2'
-        $rgName = "ps-secrule-rm-25662"
-        if ($TestMode -ne 'playback') {
-            Select-AzSubscription -SubscriptionId $subscriptionId
-            New-AzResourceGroup -Name $rgName -Location $location
-            New-AzDnsResolverPolicy -Name "policy-secrule-r" -ResourceGroupName $rgName -Location $location
-            New-AzDnsResolverDomainList -Name "domainlist-secrule-r" -ResourceGroupName $rgName -Location $location -Domain @("contoso.com.")
-            $dlId = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-r"
-            New-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-rm-1" -DnsResolverPolicyName "policy-secrule-r" -ResourceGroupName $rgName -Location $location -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DnsResolverDomainList @(@{id = $dlId})
-        }
+    It 'Delete a DNS security rule by name, expected DNS security rule deleted' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename8y8cdzg";
+        $dnsSecurityRuleName = "psdnssecurityrulename8y8cdzg";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename8y8cdzg";
+        $resourceGroupName = "powershell-test-rg-debug-remove";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT
+        Remove-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName
+
+        # ASSERT
+        {Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -DnsSecurityRuleName $dnsSecurityRuleName -ResourceGroupName $resourceGroupName } | Should -Throw
     }
-    AfterAll {
-        if ($TestMode -ne 'playback') { Remove-AzResourceGroup -Name $rgName -ErrorAction SilentlyContinue -AsJob | Out-Null }
-    }
-    It 'Delete a security rule' {
-        Remove-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-rm-1" -DnsResolverPolicyName "policy-secrule-r" -ResourceGroupName $rgName
-        { Get-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-rm-1" -DnsResolverPolicyName "policy-secrule-r" -ResourceGroupName $rgName } | Should -Throw
+
+   It 'Delete a DNS security rule via identity, expected DNS security rule deleted' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename0j9ujzg";
+        $dnsSecurityRuleName = "psdnssecurityrulename0j9ujzg";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename0j9ujzg";
+        $resourceGroupName = "powershell-test-rg-debug-remove";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT
+        Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -DnsSecurityRuleName $dnsSecurityRuleName -ResourceGroupName $resourceGroupName | Remove-AzDnsResolverPolicyDnsSecurityRule
+
+        # ASSERT
+        {Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -DnsSecurityRuleName $dnsSecurityRuleName -ResourceGroupName $resourceGroupName } | Should -Throw
     }
 }

--- a/src/DnsResolver/DnsResolver.Autorest/test/Update-AzDnsResolverPolicyDnsSecurityRule.Recording.json
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Update-AzDnsResolverPolicyDnsSecurityRule.Recording.json
@@ -1,8 +1,8 @@
 {
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u?api-version=2025-10-01-preview+1": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg?api-version=2026-07-01-preview+1": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u?api-version=2025-10-01-preview",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg?api-version=2026-07-01-preview",
       "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
       "isContentBase64": false,
       "Headers": {
@@ -15,46 +15,29 @@
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:47 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "66f553ed-f8a7-4d7c-9003-60bf6cc1f095" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=?api-version=2025-10-01-preview\u0026t=639096337555494603\u0026c=MIIHwzCCBqugAwIBAgIQXVokCjoBy2ohckt4PAvhMjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEypDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBDVVMgQ0EgMDEwHhcNMjYwMTI4MTQ0MTQ1WhcNMjYwNzIzMjA0MTQ1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgivDnhK_iJT5EjNIU2QtasL0cHOcNgQ8WfzfGrxsHBk-T_-Vp2xK7WjEeU-7QYhGisaPiBuCBGJ1Ij4lv0CslNUMIP0XmlAueDccohU6R646GI0BNqXPc-JKntdxGRsgo2clxHImxy7S_aBExnsMD-gceRyeUyZLIPKh8WjqMb_H9zXdh7ZmFQRiB8BAIxbxnhMhzs7mgq6Ob5kC1i2ZumWN853Kc6mi0ZaKdloecRnSevaUpmpFxKvdMqJ762jdFhzzzoPdHc5eboHurBbz1XAsn_DT7F4U8FR2VRduQucYdJmRjOOEk-ras-QLqZPsuayuDVPPKJUb18ADQaXvUCAwEAAaOCBMIwggS-MIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFDSwQskzIdGT5SwO57YvjZibE5PQMB8GA1UdIwQYMBaAFPzkWgovhQ7nRLkHc3jg1EQHohkRMIIBygYDVR0fBIIBwTCCAb0wb6BtoGuGaWh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDBxoG-gbYZraHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNjUvY3VycmVudC5jcmwwYKBeoFyGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDB1oHOgcYZvaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxLzY1L2N1cnJlbnQuY3JsMIIBzwYIKwYBBQUHAQEEggHBMIIBvTByBggrBgEFBQcwAoZmaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHQGCCsGAQUFBzAChmhodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBjBggrBgEFBQcwAoZXaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMGwGCCsGAQUFBzAChmBodHRwOi8vY2NtZWNlbnRyYWx1c3BraS5jZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lY2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBABR95kOzyDSa3qXCgFt3xeWoDpaV6sKgGNAPryjMkDMPICfy_zjsgLph4V4HEwF5kFpQENtzNQc6I6cyzCEUCS5bUX9xDsDbLcXuBbwVBQz-lfiq79Vgc4ybyCRh7wSiF3SlYVz0p4wULJVQaQR0iUCIOzCKHA4eXQExg6_6KiUibNu8AGT9qHYSr6PRNafkGpilhCUZ2dFWf5c2iTeLFAHYslomMMPtFmb0Q2zCxSBTlwA7IbfVk1dkz2bNiHzzhqNm7J6-VlEeXpI4__EQ4JMp5yfyObUDHtsZCBLb-OrwI0GV0LevJOiTPSL373hO9aj8tuF1GfkB4svCkHn-mqQ\u0026s=V1QxJVv8-xEUS0VIVBFBcHSvgwzVBz0gapsMBr23upGnTu31yHqK8imeFgvfPe1zM86PJ-m35a-XxThx910hVFSqltBYIlzysII76aQKzWRcU5k9_wl3L1mzs9Rd8PkuzAsUSn9TJtO9BzpH8uPBq_ISWCN9YMPw2_E1PHeSt64GcoXfQ4mkWMQM_kvVCNtpg3bzs1LBEwHLizwR_zc_f6ZSRgcR9oTywwrJILlNkjP2mWZE82NhdVvubF15dSk4NDcNXwZ12ZL6SLr01kMLVlI6y2wcQq4dbSidpd-MMtOda7QWWRnS4oh2cFLFIzwMmoRaxOuR0gG8xukDXWPlHA\u0026h=DIZR8DTJAwbbBnXS3ugybUnG4nnXqveBYH5hUyWjmRw" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westcentralus/b941cca1-d150-43ce-839a-aee865ad9932" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "66f553ed-f8a7-4d7c-9003-60bf6cc1f095" ],
-        "x-ms-correlation-request-id": [ "66f553ed-f8a7-4d7c-9003-60bf6cc1f095" ],
-        "x-ms-routing-request-id": [ "WESTCENTRALUS:20260320T200235Z:66f553ed-f8a7-4d7c-9003-60bf6cc1f095" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: A4118F45D4164BF893E2834C1CE2E2FE Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:02:33Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:02:35 GMT" ]
+        "x-ms-activity-id": [ "83b1fa92-7510-4284-9ec0-ccff03047008" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjEyYmRmZjQtMmEzNS00ZDA0LWFjZDQtNzdmOTlkOWIzMWUzIn0=?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "528" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "424" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5a019258-0000-0700-0000-69bda7db0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u\",\"name\":\"policy-secrule-u\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T20:02:34.9557597Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:02:34.9557597Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080014b2-0000-0800-0000-69fa6ee40000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg\",\"name\":\"psdnsresolverpolicyforrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=?api-version=2025-10-01-preview\u0026t=639096337555494603\u0026c=MIIHwzCCBqugAwIBAgIQXVokCjoBy2ohckt4PAvhMjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEypDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBDVVMgQ0EgMDEwHhcNMjYwMTI4MTQ0MTQ1WhcNMjYwNzIzMjA0MTQ1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgivDnhK_iJT5EjNIU2QtasL0cHOcNgQ8WfzfGrxsHBk-T_-Vp2xK7WjEeU-7QYhGisaPiBuCBGJ1Ij4lv0CslNUMIP0XmlAueDccohU6R646GI0BNqXPc-JKntdxGRsgo2clxHImxy7S_aBExnsMD-gceRyeUyZLIPKh8WjqMb_H9zXdh7ZmFQRiB8BAIxbxnhMhzs7mgq6Ob5kC1i2ZumWN853Kc6mi0ZaKdloecRnSevaUpmpFxKvdMqJ762jdFhzzzoPdHc5eboHurBbz1XAsn_DT7F4U8FR2VRduQucYdJmRjOOEk-ras-QLqZPsuayuDVPPKJUb18ADQaXvUCAwEAAaOCBMIwggS-MIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFDSwQskzIdGT5SwO57YvjZibE5PQMB8GA1UdIwQYMBaAFPzkWgovhQ7nRLkHc3jg1EQHohkRMIIBygYDVR0fBIIBwTCCAb0wb6BtoGuGaWh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDBxoG-gbYZraHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNjUvY3VycmVudC5jcmwwYKBeoFyGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDB1oHOgcYZvaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxLzY1L2N1cnJlbnQuY3JsMIIBzwYIKwYBBQUHAQEEggHBMIIBvTByBggrBgEFBQcwAoZmaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHQGCCsGAQUFBzAChmhodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBjBggrBgEFBQcwAoZXaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMGwGCCsGAQUFBzAChmBodHRwOi8vY2NtZWNlbnRyYWx1c3BraS5jZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lY2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBABR95kOzyDSa3qXCgFt3xeWoDpaV6sKgGNAPryjMkDMPICfy_zjsgLph4V4HEwF5kFpQENtzNQc6I6cyzCEUCS5bUX9xDsDbLcXuBbwVBQz-lfiq79Vgc4ybyCRh7wSiF3SlYVz0p4wULJVQaQR0iUCIOzCKHA4eXQExg6_6KiUibNu8AGT9qHYSr6PRNafkGpilhCUZ2dFWf5c2iTeLFAHYslomMMPtFmb0Q2zCxSBTlwA7IbfVk1dkz2bNiHzzhqNm7J6-VlEeXpI4__EQ4JMp5yfyObUDHtsZCBLb-OrwI0GV0LevJOiTPSL373hO9aj8tuF1GfkB4svCkHn-mqQ\u0026s=V1QxJVv8-xEUS0VIVBFBcHSvgwzVBz0gapsMBr23upGnTu31yHqK8imeFgvfPe1zM86PJ-m35a-XxThx910hVFSqltBYIlzysII76aQKzWRcU5k9_wl3L1mzs9Rd8PkuzAsUSn9TJtO9BzpH8uPBq_ISWCN9YMPw2_E1PHeSt64GcoXfQ4mkWMQM_kvVCNtpg3bzs1LBEwHLizwR_zc_f6ZSRgcR9oTywwrJILlNkjP2mWZE82NhdVvubF15dSk4NDcNXwZ12ZL6SLr01kMLVlI6y2wcQq4dbSidpd-MMtOda7QWWRnS4oh2cFLFIzwMmoRaxOuR0gG8xukDXWPlHA\u0026h=DIZR8DTJAwbbBnXS3ugybUnG4nnXqveBYH5hUyWjmRw+2": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjEyYmRmZjQtMmEzNS00ZDA0LWFjZDQtNzdmOTlkOWIzMWUzIn0=?api-version=2026-07-01-preview+2": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=?api-version=2025-10-01-preview\u0026t=639096337555494603\u0026c=MIIHwzCCBqugAwIBAgIQXVokCjoBy2ohckt4PAvhMjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEypDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBDVVMgQ0EgMDEwHhcNMjYwMTI4MTQ0MTQ1WhcNMjYwNzIzMjA0MTQ1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgivDnhK_iJT5EjNIU2QtasL0cHOcNgQ8WfzfGrxsHBk-T_-Vp2xK7WjEeU-7QYhGisaPiBuCBGJ1Ij4lv0CslNUMIP0XmlAueDccohU6R646GI0BNqXPc-JKntdxGRsgo2clxHImxy7S_aBExnsMD-gceRyeUyZLIPKh8WjqMb_H9zXdh7ZmFQRiB8BAIxbxnhMhzs7mgq6Ob5kC1i2ZumWN853Kc6mi0ZaKdloecRnSevaUpmpFxKvdMqJ762jdFhzzzoPdHc5eboHurBbz1XAsn_DT7F4U8FR2VRduQucYdJmRjOOEk-ras-QLqZPsuayuDVPPKJUb18ADQaXvUCAwEAAaOCBMIwggS-MIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFDSwQskzIdGT5SwO57YvjZibE5PQMB8GA1UdIwQYMBaAFPzkWgovhQ7nRLkHc3jg1EQHohkRMIIBygYDVR0fBIIBwTCCAb0wb6BtoGuGaWh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDBxoG-gbYZraHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNjUvY3VycmVudC5jcmwwYKBeoFyGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDB1oHOgcYZvaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxLzY1L2N1cnJlbnQuY3JsMIIBzwYIKwYBBQUHAQEEggHBMIIBvTByBggrBgEFBQcwAoZmaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHQGCCsGAQUFBzAChmhodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBjBggrBgEFBQcwAoZXaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMGwGCCsGAQUFBzAChmBodHRwOi8vY2NtZWNlbnRyYWx1c3BraS5jZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lY2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBABR95kOzyDSa3qXCgFt3xeWoDpaV6sKgGNAPryjMkDMPICfy_zjsgLph4V4HEwF5kFpQENtzNQc6I6cyzCEUCS5bUX9xDsDbLcXuBbwVBQz-lfiq79Vgc4ybyCRh7wSiF3SlYVz0p4wULJVQaQR0iUCIOzCKHA4eXQExg6_6KiUibNu8AGT9qHYSr6PRNafkGpilhCUZ2dFWf5c2iTeLFAHYslomMMPtFmb0Q2zCxSBTlwA7IbfVk1dkz2bNiHzzhqNm7J6-VlEeXpI4__EQ4JMp5yfyObUDHtsZCBLb-OrwI0GV0LevJOiTPSL373hO9aj8tuF1GfkB4svCkHn-mqQ\u0026s=V1QxJVv8-xEUS0VIVBFBcHSvgwzVBz0gapsMBr23upGnTu31yHqK8imeFgvfPe1zM86PJ-m35a-XxThx910hVFSqltBYIlzysII76aQKzWRcU5k9_wl3L1mzs9Rd8PkuzAsUSn9TJtO9BzpH8uPBq_ISWCN9YMPw2_E1PHeSt64GcoXfQ4mkWMQM_kvVCNtpg3bzs1LBEwHLizwR_zc_f6ZSRgcR9oTywwrJILlNkjP2mWZE82NhdVvubF15dSk4NDcNXwZ12ZL6SLr01kMLVlI6y2wcQq4dbSidpd-MMtOda7QWWRnS4oh2cFLFIzwMmoRaxOuR0gG8xukDXWPlHA\u0026h=DIZR8DTJAwbbBnXS3ugybUnG4nnXqveBYH5hUyWjmRw",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjEyYmRmZjQtMmEzNS00ZDA0LWFjZDQtNzdmOTlkOWIzMWUzIn0=?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "3" ],
-        "x-ms-client-request-id": [ "eced07df-0a50-4774-95f0-3187e16986fe" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -62,43 +45,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "fa58985a-9f4b-42b4-a88e-8b8cb7efaa44" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/8137b326-735d-44f4-83c3-d3704dc7cf50" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "fa58985a-9f4b-42b4-a88e-8b8cb7efaa44" ],
-        "x-ms-correlation-request-id": [ "fa58985a-9f4b-42b4-a88e-8b8cb7efaa44" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200241Z:fa58985a-9f4b-42b4-a88e-8b8cb7efaa44" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: E84741A3D8BB4209A2F9C8BF8B7BBEF3 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:02:40Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:02:41 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:52 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b5e7ae59-50f3-4458-b189-8b363fb44cff" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "511" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "562" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=\",\"startTime\":\"2026-03-20T20:02:35.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjEyYmRmZjQtMmEzNS00ZDA0LWFjZDQtNzdmOTlkOWIzMWUzIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMjEyYmRmZjQtMmEzNS00ZDA0LWFjZDQtNzdmOTlkOWIzMWUzIn0=\",\"startTime\":\"2026-05-05T22:27:48.0000000Z\",\"endTime\":\"2026-05-05T22:27:49.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=?api-version=2025-10-01-preview\u0026t=639096337555494603\u0026c=MIIHwzCCBqugAwIBAgIQXVokCjoBy2ohckt4PAvhMjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEypDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBDVVMgQ0EgMDEwHhcNMjYwMTI4MTQ0MTQ1WhcNMjYwNzIzMjA0MTQ1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgivDnhK_iJT5EjNIU2QtasL0cHOcNgQ8WfzfGrxsHBk-T_-Vp2xK7WjEeU-7QYhGisaPiBuCBGJ1Ij4lv0CslNUMIP0XmlAueDccohU6R646GI0BNqXPc-JKntdxGRsgo2clxHImxy7S_aBExnsMD-gceRyeUyZLIPKh8WjqMb_H9zXdh7ZmFQRiB8BAIxbxnhMhzs7mgq6Ob5kC1i2ZumWN853Kc6mi0ZaKdloecRnSevaUpmpFxKvdMqJ762jdFhzzzoPdHc5eboHurBbz1XAsn_DT7F4U8FR2VRduQucYdJmRjOOEk-ras-QLqZPsuayuDVPPKJUb18ADQaXvUCAwEAAaOCBMIwggS-MIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFDSwQskzIdGT5SwO57YvjZibE5PQMB8GA1UdIwQYMBaAFPzkWgovhQ7nRLkHc3jg1EQHohkRMIIBygYDVR0fBIIBwTCCAb0wb6BtoGuGaWh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDBxoG-gbYZraHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNjUvY3VycmVudC5jcmwwYKBeoFyGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDB1oHOgcYZvaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxLzY1L2N1cnJlbnQuY3JsMIIBzwYIKwYBBQUHAQEEggHBMIIBvTByBggrBgEFBQcwAoZmaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHQGCCsGAQUFBzAChmhodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBjBggrBgEFBQcwAoZXaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMGwGCCsGAQUFBzAChmBodHRwOi8vY2NtZWNlbnRyYWx1c3BraS5jZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lY2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBABR95kOzyDSa3qXCgFt3xeWoDpaV6sKgGNAPryjMkDMPICfy_zjsgLph4V4HEwF5kFpQENtzNQc6I6cyzCEUCS5bUX9xDsDbLcXuBbwVBQz-lfiq79Vgc4ybyCRh7wSiF3SlYVz0p4wULJVQaQR0iUCIOzCKHA4eXQExg6_6KiUibNu8AGT9qHYSr6PRNafkGpilhCUZ2dFWf5c2iTeLFAHYslomMMPtFmb0Q2zCxSBTlwA7IbfVk1dkz2bNiHzzhqNm7J6-VlEeXpI4__EQ4JMp5yfyObUDHtsZCBLb-OrwI0GV0LevJOiTPSL373hO9aj8tuF1GfkB4svCkHn-mqQ\u0026s=V1QxJVv8-xEUS0VIVBFBcHSvgwzVBz0gapsMBr23upGnTu31yHqK8imeFgvfPe1zM86PJ-m35a-XxThx910hVFSqltBYIlzysII76aQKzWRcU5k9_wl3L1mzs9Rd8PkuzAsUSn9TJtO9BzpH8uPBq_ISWCN9YMPw2_E1PHeSt64GcoXfQ4mkWMQM_kvVCNtpg3bzs1LBEwHLizwR_zc_f6ZSRgcR9oTywwrJILlNkjP2mWZE82NhdVvubF15dSk4NDcNXwZ12ZL6SLr01kMLVlI6y2wcQq4dbSidpd-MMtOda7QWWRnS4oh2cFLFIzwMmoRaxOuR0gG8xukDXWPlHA\u0026h=DIZR8DTJAwbbBnXS3ugybUnG4nnXqveBYH5hUyWjmRw+3": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg?api-version=2026-07-01-preview+3": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=?api-version=2025-10-01-preview\u0026t=639096337555494603\u0026c=MIIHwzCCBqugAwIBAgIQXVokCjoBy2ohckt4PAvhMjANBgkqhkiG9w0BAQsFADA1MTMwMQYDVQQDEypDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBDVVMgQ0EgMDEwHhcNMjYwMTI4MTQ0MTQ1WhcNMjYwNzIzMjA0MTQ1WjBAMT4wPAYDVQQDEzVhc3luY29wZXJhdGlvbnNpZ25pbmdjZXJ0aWZpY2F0ZS5tYW5hZ2VtZW50LmF6dXJlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANgivDnhK_iJT5EjNIU2QtasL0cHOcNgQ8WfzfGrxsHBk-T_-Vp2xK7WjEeU-7QYhGisaPiBuCBGJ1Ij4lv0CslNUMIP0XmlAueDccohU6R646GI0BNqXPc-JKntdxGRsgo2clxHImxy7S_aBExnsMD-gceRyeUyZLIPKh8WjqMb_H9zXdh7ZmFQRiB8BAIxbxnhMhzs7mgq6Ob5kC1i2ZumWN853Kc6mi0ZaKdloecRnSevaUpmpFxKvdMqJ762jdFhzzzoPdHc5eboHurBbz1XAsn_DT7F4U8FR2VRduQucYdJmRjOOEk-ras-QLqZPsuayuDVPPKJUb18ADQaXvUCAwEAAaOCBMIwggS-MIGdBgNVHSAEgZUwgZIwDAYKKwYBBAGCN3sBATBmBgorBgEEAYI3ewICMFgwVgYIKwYBBQUHAgIwSh5IADMAMwBlADAAMQA5ADIAMQAtADQAZAA2ADQALQA0AGYAOABjAC0AYQAwADUANQAtADUAYgBkAGEAZgBmAGQANQBlADMAMwBkMAwGCisGAQQBgjd7AwIwDAYKKwYBBAGCN3sEAjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0OBBYEFDSwQskzIdGT5SwO57YvjZibE5PQMB8GA1UdIwQYMBaAFPzkWgovhQ7nRLkHc3jg1EQHohkRMIIBygYDVR0fBIIBwTCCAb0wb6BtoGuGaWh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDBxoG-gbYZraHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvY2VudHJhbHVzL2NybHMvY2NtZWNlbnRyYWx1c3BraS9jY21lY2VudHJhbHVzaWNhMDEvNjUvY3VycmVudC5jcmwwYKBeoFyGWmh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9jZW50cmFsdXMvY3Jscy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS82NS9jdXJyZW50LmNybDB1oHOgcYZvaHR0cDovL2NjbWVjZW50cmFsdXNwa2kuY2VudHJhbHVzLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWNlbnRyYWx1c2ljYTAxLzY1L2N1cnJlbnQuY3JsMIIBzwYIKwYBBQUHAQEEggHBMIIBvTByBggrBgEFBQcwAoZmaHR0cDovL3ByaW1hcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMHQGCCsGAQUFBzAChmhodHRwOi8vc2Vjb25kYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9jZW50cmFsdXMvY2FjZXJ0cy9jY21lY2VudHJhbHVzcGtpL2NjbWVjZW50cmFsdXNpY2EwMS9jZXJ0LmNlcjBjBggrBgEFBQcwAoZXaHR0cDovL2NybC5taWNyb3NvZnQuY29tL2NlbnRyYWx1cy9jYWNlcnRzL2NjbWVjZW50cmFsdXNwa2kvY2NtZWNlbnRyYWx1c2ljYTAxL2NlcnQuY2VyMGwGCCsGAQUFBzAChmBodHRwOi8vY2NtZWNlbnRyYWx1c3BraS5jZW50cmFsdXMucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lY2VudHJhbHVzaWNhMDEwDQYJKoZIhvcNAQELBQADggEBABR95kOzyDSa3qXCgFt3xeWoDpaV6sKgGNAPryjMkDMPICfy_zjsgLph4V4HEwF5kFpQENtzNQc6I6cyzCEUCS5bUX9xDsDbLcXuBbwVBQz-lfiq79Vgc4ybyCRh7wSiF3SlYVz0p4wULJVQaQR0iUCIOzCKHA4eXQExg6_6KiUibNu8AGT9qHYSr6PRNafkGpilhCUZ2dFWf5c2iTeLFAHYslomMMPtFmb0Q2zCxSBTlwA7IbfVk1dkz2bNiHzzhqNm7J6-VlEeXpI4__EQ4JMp5yfyObUDHtsZCBLb-OrwI0GV0LevJOiTPSL373hO9aj8tuF1GfkB4svCkHn-mqQ\u0026s=V1QxJVv8-xEUS0VIVBFBcHSvgwzVBz0gapsMBr23upGnTu31yHqK8imeFgvfPe1zM86PJ-m35a-XxThx910hVFSqltBYIlzysII76aQKzWRcU5k9_wl3L1mzs9Rd8PkuzAsUSn9TJtO9BzpH8uPBq_ISWCN9YMPw2_E1PHeSt64GcoXfQ4mkWMQM_kvVCNtpg3bzs1LBEwHLizwR_zc_f6ZSRgcR9oTywwrJILlNkjP2mWZE82NhdVvubF15dSk4NDcNXwZ12ZL6SLr01kMLVlI6y2wcQq4dbSidpd-MMtOda7QWWRnS4oh2cFLFIzwMmoRaxOuR0gG8xukDXWPlHA\u0026h=DIZR8DTJAwbbBnXS3ugybUnG4nnXqveBYH5hUyWjmRw",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "4" ],
-        "x-ms-client-request-id": [ "eced07df-0a50-4774-95f0-3187e16986fe" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -106,128 +72,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "2821283a-3032-4490-a3f1-0d6810012366" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/19e5852d-1cba-48d3-947e-b1162641f433" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "2821283a-3032-4490-a3f1-0d6810012366" ],
-        "x-ms-correlation-request-id": [ "2821283a-3032-4490-a3f1-0d6810012366" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200312Z:2821283a-3032-4490-a3f1-0d6810012366" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: E88B4F3E5ED34ACDA7EC05ED9BA9F26A Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:11Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:12 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:53 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "1c563854-b6b6-4fb2-924d-b48ebc2cb2b4" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "551" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "459" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiMGI3ZjhmODctNGQwOC00MDM2LWJhOTAtZDYzZTJlOTI0ZjRmIn0=\",\"startTime\":\"2026-03-20T20:02:35.0000000Z\",\"endTime\":\"2026-03-20T20:02:48.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"12bb64c1-bfc8-4508-b24a-06b18a9c1e6f\"},\"etag\":\"\\\"1200cf59-0000-0800-0000-69fa6ee50000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg\",\"name\":\"psdnsresolverpolicyforrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u?api-version=2025-10-01-preview+4": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "5" ],
-        "x-ms-client-request-id": [ "eced07df-0a50-4774-95f0-3187e16986fe" ],
-        "CommandName": [ "New-AzDnsResolverPolicy" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicy_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "9a636dfc-9e9c-484c-8e04-eead0c00b989" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "9a636dfc-9e9c-484c-8e04-eead0c00b989" ],
-        "x-ms-correlation-request-id": [ "9a636dfc-9e9c-484c-8e04-eead0c00b989" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200314Z:9a636dfc-9e9c-484c-8e04-eead0c00b989" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: E8D646F0EC0C4A81B0D1764D236C3589 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:12Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:13 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "563" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"394a2f25-7ccc-4766-b61d-598ef1286395\"},\"etag\":\"\\\"d400341e-0000-0700-0000-69bda7e60000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u\",\"name\":\"policy-secrule-u\",\"type\":\"Microsoft.Network/dnsResolverPolicies\",\"systemData\":{\"createdAt\":\"2026-03-20T20:02:34.9557597Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:02:34.9557597Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u?api-version=2025-10-01-preview+5": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg?api-version=2026-07-01-preview+4": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\" ]\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "89" ]
+        "Content-Length": [ "105" ]
       }
     },
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:53 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "16917625-3373-4093-be6a-56deba3ab9c5" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9?api-version=2025-10-01-preview\u0026t=639096337949756678\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=lPq0I70NhW_G1JmlpyfuEQZs_P1d4z2Dzbu27v_1KJiwa2n3JIdOJQmlEFr-hUtcZ5Q2ZSH5hE-ny-owkqQD5LwQxtsx1Mo7MQOO6FhBhAQnkXeYn9Jz5RSYg6G6KcTJcoVumsu240l3nX1OwVmBbShr7OivMaursigwn-or1uoQ2Lbbdw97x5V3dZmhCUMlHLKKNlCYZeqnPCRk39SkRvD2owL4AyhF2HiSItmP3z4aLL0KboFC96RFBPl0icPXryg7X64I7l2niF8kloPd7F8_Lgv1-34QJvDP6_72pmLMapdp_c6veSJNT9QWDkjgsECi1MCkr-HW2JErGd91xw\u0026h=DwfxxCjdg12YFx5atVbvEdXpxnPMD7g4pFIeA3LlhRc" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/2a3bf6e1-d996-411b-a79a-8bdb16fe29c8" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "16917625-3373-4093-be6a-56deba3ab9c5" ],
-        "x-ms-correlation-request-id": [ "16917625-3373-4093-be6a-56deba3ab9c5" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200314Z:16917625-3373-4093-be6a-56deba3ab9c5" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 134AD09E30FD421998D139EF9346FCC3 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:14Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:14 GMT" ]
+        "x-ms-activity-id": [ "592c26ec-0185-4422-93b1-8721f343c611" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImU5ZTc3MDExLTAyNGItNDcyZS1iMmFmLTg1ZjU4MWY4OGNiNyJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "587" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "498" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"5a01b75d-0000-0700-0000-69bda8020000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\",\"name\":\"domainlist-secrule-u\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T20:03:14.6319215Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:03:14.6319215Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080055b2-0000-0800-0000-69fa6ee90000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\",\"name\":\"psdnsresolverdomainlistforrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9?api-version=2025-10-01-preview\u0026t=639096337949756678\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=lPq0I70NhW_G1JmlpyfuEQZs_P1d4z2Dzbu27v_1KJiwa2n3JIdOJQmlEFr-hUtcZ5Q2ZSH5hE-ny-owkqQD5LwQxtsx1Mo7MQOO6FhBhAQnkXeYn9Jz5RSYg6G6KcTJcoVumsu240l3nX1OwVmBbShr7OivMaursigwn-or1uoQ2Lbbdw97x5V3dZmhCUMlHLKKNlCYZeqnPCRk39SkRvD2owL4AyhF2HiSItmP3z4aLL0KboFC96RFBPl0icPXryg7X64I7l2niF8kloPd7F8_Lgv1-34QJvDP6_72pmLMapdp_c6veSJNT9QWDkjgsECi1MCkr-HW2JErGd91xw\u0026h=DwfxxCjdg12YFx5atVbvEdXpxnPMD7g4pFIeA3LlhRc+6": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImU5ZTc3MDExLTAyNGItNDcyZS1iMmFmLTg1ZjU4MWY4OGNiNyJ9?api-version=2026-07-01-preview+5": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9?api-version=2025-10-01-preview\u0026t=639096337949756678\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=lPq0I70NhW_G1JmlpyfuEQZs_P1d4z2Dzbu27v_1KJiwa2n3JIdOJQmlEFr-hUtcZ5Q2ZSH5hE-ny-owkqQD5LwQxtsx1Mo7MQOO6FhBhAQnkXeYn9Jz5RSYg6G6KcTJcoVumsu240l3nX1OwVmBbShr7OivMaursigwn-or1uoQ2Lbbdw97x5V3dZmhCUMlHLKKNlCYZeqnPCRk39SkRvD2owL4AyhF2HiSItmP3z4aLL0KboFC96RFBPl0icPXryg7X64I7l2niF8kloPd7F8_Lgv1-34QJvDP6_72pmLMapdp_c6veSJNT9QWDkjgsECi1MCkr-HW2JErGd91xw\u0026h=DwfxxCjdg12YFx5atVbvEdXpxnPMD7g4pFIeA3LlhRc",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImU5ZTc3MDExLTAyNGItNDcyZS1iMmFmLTg1ZjU4MWY4OGNiNyJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "7" ],
-        "x-ms-client-request-id": [ "3668d235-6f1e-44cd-a27f-f8591834f315" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -235,43 +130,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "e659f722-c9d8-4706-868a-c27915e69855" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/73cd6417-ece0-4797-9e0b-4833f5a0da56" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "e659f722-c9d8-4706-868a-c27915e69855" ],
-        "x-ms-correlation-request-id": [ "e659f722-c9d8-4706-868a-c27915e69855" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200321Z:e659f722-c9d8-4706-868a-c27915e69855" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 63ED29A77925472CB8E9102524403533 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:20Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:20 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:58 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "9c717199-3894-4491-8a87-2c33796520ec" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "519" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "570" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9\",\"startTime\":\"2026-03-20T20:03:14.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImU5ZTc3MDExLTAyNGItNDcyZS1iMmFmLTg1ZjU4MWY4OGNiNyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6ImU5ZTc3MDExLTAyNGItNDcyZS1iMmFmLTg1ZjU4MWY4OGNiNyJ9\",\"startTime\":\"2026-05-05T22:27:53.0000000Z\",\"endTime\":\"2026-05-05T22:27:54.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9?api-version=2025-10-01-preview\u0026t=639096337949756678\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=lPq0I70NhW_G1JmlpyfuEQZs_P1d4z2Dzbu27v_1KJiwa2n3JIdOJQmlEFr-hUtcZ5Q2ZSH5hE-ny-owkqQD5LwQxtsx1Mo7MQOO6FhBhAQnkXeYn9Jz5RSYg6G6KcTJcoVumsu240l3nX1OwVmBbShr7OivMaursigwn-or1uoQ2Lbbdw97x5V3dZmhCUMlHLKKNlCYZeqnPCRk39SkRvD2owL4AyhF2HiSItmP3z4aLL0KboFC96RFBPl0icPXryg7X64I7l2niF8kloPd7F8_Lgv1-34QJvDP6_72pmLMapdp_c6veSJNT9QWDkjgsECi1MCkr-HW2JErGd91xw\u0026h=DwfxxCjdg12YFx5atVbvEdXpxnPMD7g4pFIeA3LlhRc+7": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg?api-version=2026-07-01-preview+6": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9?api-version=2025-10-01-preview\u0026t=639096337949756678\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=lPq0I70NhW_G1JmlpyfuEQZs_P1d4z2Dzbu27v_1KJiwa2n3JIdOJQmlEFr-hUtcZ5Q2ZSH5hE-ny-owkqQD5LwQxtsx1Mo7MQOO6FhBhAQnkXeYn9Jz5RSYg6G6KcTJcoVumsu240l3nX1OwVmBbShr7OivMaursigwn-or1uoQ2Lbbdw97x5V3dZmhCUMlHLKKNlCYZeqnPCRk39SkRvD2owL4AyhF2HiSItmP3z4aLL0KboFC96RFBPl0icPXryg7X64I7l2niF8kloPd7F8_Lgv1-34QJvDP6_72pmLMapdp_c6veSJNT9QWDkjgsECi1MCkr-HW2JErGd91xw\u0026h=DwfxxCjdg12YFx5atVbvEdXpxnPMD7g4pFIeA3LlhRc",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "8" ],
-        "x-ms-client-request-id": [ "3668d235-6f1e-44cd-a27f-f8591834f315" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -279,128 +157,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "993d5ff7-7401-4f32-9005-ed3aca374707" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/f976443e-e462-4418-bff2-71806eed30f5" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "993d5ff7-7401-4f32-9005-ed3aca374707" ],
-        "x-ms-correlation-request-id": [ "993d5ff7-7401-4f32-9005-ed3aca374707" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200352Z:993d5ff7-7401-4f32-9005-ed3aca374707" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: C7FA742025D54636B0BB2A70E60B3F41 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:51Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:52 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:27:58 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "b34a0f04-bdd8-473a-a142-28fb28b5943f" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "559" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "533" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjRjNzNjYzI1LWZiNTAtNGZlNy1hNGMwLTk4NWJjZTQ2NDAzNSJ9\",\"startTime\":\"2026-03-20T20:03:14.0000000Z\",\"endTime\":\"2026-03-20T20:03:28.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"87be22b0-80ab-4642-ae3c-9017a2f5801a\"},\"etag\":\"\\\"a2087e8a-0000-0800-0000-69fa6eea0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\",\"name\":\"psdnsresolverdomainlistforrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u?api-version=2025-10-01-preview+8": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "9" ],
-        "x-ms-client-request-id": [ "3668d235-6f1e-44cd-a27f-f8591834f315" ],
-        "CommandName": [ "New-AzDnsResolverDomainList" ],
-        "FullCommandName": [ "New-AzDnsResolverDomainList_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "0693b8ce-afec-4f10-8d35-91421f641c54" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "0693b8ce-afec-4f10-8d35-91421f641c54" ],
-        "x-ms-correlation-request-id": [ "0693b8ce-afec-4f10-8d35-91421f641c54" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200353Z:0693b8ce-afec-4f10-8d35-91421f641c54" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 6162528051CD4D50A1D58CB6576D0F50 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:52Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:03:52 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "622" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"10dfafa8-ff1a-4e56-a59f-8e13c0a5afbe\"},\"etag\":\"\\\"1000c912-0000-0700-0000-69bda80d0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\",\"name\":\"domainlist-secrule-u\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\",\"systemData\":{\"createdAt\":\"2026-03-20T20:03:14.6319215Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:03:14.6319215Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$PUT+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview+9": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview+7": {
     "Request": {
       "Method": "PUT",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "405" ]
+        "Content-Length": [ "437" ]
       }
     },
     "Response": {
       "StatusCode": 201,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview" ],
+        "Date": [ "Tue, 05 May 2026 22:27:58 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "04db3bd5-fe58-4565-8f28-b3a778948111" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9?api-version=2025-10-01-preview\u0026t=639096338406815961\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FR6XQQTTO7G1iuauYm6Nvh9i7WfTZRwLiLYfa_PHUbhyyiqbFL-Ii64eOuRPL9aUzvLNKQPrHhX5btk9dn6je2Zu7-qRBW4qwEnf9HxmfdHg4yMEttCAF6rw__AV7-m8n_rn5gpsB7VNDIFVMp8OQl4Xp9qfJ9uB7UyNnDYy_0kyWu6RNBgApK_xL9qvYoS4PIdO_LcetRVJtfIriliZrjn2FC061sRfH6HtFAaYDUizQ8t5xOKXnNrOZZSyzfBL_-N-wOSd7Sy3o_tVKQRyMTnGMcxWFeDq0wJoznURExAxO65lRK15mD-V0u6qiHO8MMOdybx56j3gu_iK7W6BIg\u0026h=1bSzgkYlYXBDOH0W9eTAV8bvyww1Ab7lw9BkG23aJRU" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/3b325296-7a4a-4843-9210-d1f4083898a6" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "04db3bd5-fe58-4565-8f28-b3a778948111" ],
-        "x-ms-correlation-request-id": [ "04db3bd5-fe58-4565-8f28-b3a778948111" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200400Z:04db3bd5-fe58-4565-8f28-b3a778948111" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: F7A37AE472084CF5AAD82E5E7876660A Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:03:53Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:00 GMT" ]
+        "x-ms-activity-id": [ "8f82577a-af77-4c02-bbb8-3dad90699a70" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjQwMzFiZjY0LWFiYzMtNDA4Yy05NWUyLTZiYjVkYjNiM2ZjMCJ9?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "865" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "802" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"d400db29-0000-0700-0000-69bda8300000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1\",\"name\":\"secrule-upd-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T20:03:59.8065877Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:03:59.8065877Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"1200515a-0000-0800-0000-69fa6eee0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg\",\"name\":\"psdnssecurityrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9?api-version=2025-10-01-preview\u0026t=639096338406815961\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FR6XQQTTO7G1iuauYm6Nvh9i7WfTZRwLiLYfa_PHUbhyyiqbFL-Ii64eOuRPL9aUzvLNKQPrHhX5btk9dn6je2Zu7-qRBW4qwEnf9HxmfdHg4yMEttCAF6rw__AV7-m8n_rn5gpsB7VNDIFVMp8OQl4Xp9qfJ9uB7UyNnDYy_0kyWu6RNBgApK_xL9qvYoS4PIdO_LcetRVJtfIriliZrjn2FC061sRfH6HtFAaYDUizQ8t5xOKXnNrOZZSyzfBL_-N-wOSd7Sy3o_tVKQRyMTnGMcxWFeDq0wJoznURExAxO65lRK15mD-V0u6qiHO8MMOdybx56j3gu_iK7W6BIg\u0026h=1bSzgkYlYXBDOH0W9eTAV8bvyww1Ab7lw9BkG23aJRU+10": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjQwMzFiZjY0LWFiYzMtNDA4Yy05NWUyLTZiYjVkYjNiM2ZjMCJ9?api-version=2026-07-01-preview+8": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9?api-version=2025-10-01-preview\u0026t=639096338406815961\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FR6XQQTTO7G1iuauYm6Nvh9i7WfTZRwLiLYfa_PHUbhyyiqbFL-Ii64eOuRPL9aUzvLNKQPrHhX5btk9dn6je2Zu7-qRBW4qwEnf9HxmfdHg4yMEttCAF6rw__AV7-m8n_rn5gpsB7VNDIFVMp8OQl4Xp9qfJ9uB7UyNnDYy_0kyWu6RNBgApK_xL9qvYoS4PIdO_LcetRVJtfIriliZrjn2FC061sRfH6HtFAaYDUizQ8t5xOKXnNrOZZSyzfBL_-N-wOSd7Sy3o_tVKQRyMTnGMcxWFeDq0wJoznURExAxO65lRK15mD-V0u6qiHO8MMOdybx56j3gu_iK7W6BIg\u0026h=1bSzgkYlYXBDOH0W9eTAV8bvyww1Ab7lw9BkG23aJRU",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjQwMzFiZjY0LWFiYzMtNDA4Yy05NWUyLTZiYjVkYjNiM2ZjMCJ9?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "11" ],
-        "x-ms-client-request-id": [ "fd1de427-2dc5-4af3-8401-8e613c4f3176" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -408,43 +215,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "e6423d59-f9b2-470e-b9ba-63651c36b19c" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/252040db-5d7c-477a-9842-3c6fdb2de247" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "e6423d59-f9b2-470e-b9ba-63651c36b19c" ],
-        "x-ms-correlation-request-id": [ "e6423d59-f9b2-470e-b9ba-63651c36b19c" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200407Z:e6423d59-f9b2-470e-b9ba-63651c36b19c" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 280BEDDDD25347888EE0CFEF07AB60E5 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:06Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:07 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:28:03 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "75577ffc-bd68-44cf-a351-1f95501581cd" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "503" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9\",\"startTime\":\"2026-03-20T20:04:00.0000000Z\",\"status\":\"InProgress\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjQwMzFiZjY0LWFiYzMtNDA4Yy05NWUyLTZiYjVkYjNiM2ZjMCJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjQwMzFiZjY0LWFiYzMtNDA4Yy05NWUyLTZiYjVkYjNiM2ZjMCJ9\",\"startTime\":\"2026-05-05T22:27:58.0000000Z\",\"endTime\":\"2026-05-05T22:27:59.0000000Z\",\"status\":\"Succeeded\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9?api-version=2025-10-01-preview\u0026t=639096338406815961\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FR6XQQTTO7G1iuauYm6Nvh9i7WfTZRwLiLYfa_PHUbhyyiqbFL-Ii64eOuRPL9aUzvLNKQPrHhX5btk9dn6je2Zu7-qRBW4qwEnf9HxmfdHg4yMEttCAF6rw__AV7-m8n_rn5gpsB7VNDIFVMp8OQl4Xp9qfJ9uB7UyNnDYy_0kyWu6RNBgApK_xL9qvYoS4PIdO_LcetRVJtfIriliZrjn2FC061sRfH6HtFAaYDUizQ8t5xOKXnNrOZZSyzfBL_-N-wOSd7Sy3o_tVKQRyMTnGMcxWFeDq0wJoznURExAxO65lRK15mD-V0u6qiHO8MMOdybx56j3gu_iK7W6BIg\u0026h=1bSzgkYlYXBDOH0W9eTAV8bvyww1Ab7lw9BkG23aJRU+11": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview+9": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9?api-version=2025-10-01-preview\u0026t=639096338406815961\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=FR6XQQTTO7G1iuauYm6Nvh9i7WfTZRwLiLYfa_PHUbhyyiqbFL-Ii64eOuRPL9aUzvLNKQPrHhX5btk9dn6je2Zu7-qRBW4qwEnf9HxmfdHg4yMEttCAF6rw__AV7-m8n_rn5gpsB7VNDIFVMp8OQl4Xp9qfJ9uB7UyNnDYy_0kyWu6RNBgApK_xL9qvYoS4PIdO_LcetRVJtfIriliZrjn2FC061sRfH6HtFAaYDUizQ8t5xOKXnNrOZZSyzfBL_-N-wOSd7Sy3o_tVKQRyMTnGMcxWFeDq0wJoznURExAxO65lRK15mD-V0u6qiHO8MMOdybx56j3gu_iK7W6BIg\u0026h=1bSzgkYlYXBDOH0W9eTAV8bvyww1Ab7lw9BkG23aJRU",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "12" ],
-        "x-ms-client-request-id": [ "fd1de427-2dc5-4af3-8401-8e613c4f3176" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -452,128 +242,57 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "f8eaf026-8630-40cb-8568-e2e111d3f343" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/58e5a5bc-f19d-4ec0-b7e8-0b7f7d20f312" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "f8eaf026-8630-40cb-8568-e2e111d3f343" ],
-        "x-ms-correlation-request-id": [ "f8eaf026-8630-40cb-8568-e2e111d3f343" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200439Z:f8eaf026-8630-40cb-8568-e2e111d3f343" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 48D043BB36044F68AB46F214A8E522D8 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:38Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:38 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:28:03 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "c1d9bcd5-6a94-4f33-a5ea-7cb70cd1ddf7" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "543" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "803" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6IjBjNjc5MjNhLTZkMzEtNGU2Zi04MDJhLTA2NTEyNTRhY2E4YSJ9\",\"startTime\":\"2026-03-20T20:04:00.0000000Z\",\"endTime\":\"2026-03-20T20:04:10.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900f92e-0000-0800-0000-69fa6eef0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg\",\"name\":\"psdnssecurityrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+[NoScenario]+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview+12": {
-    "Request": {
-      "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview",
-      "Content": null,
-      "isContentBase64": false,
-      "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "13" ],
-        "x-ms-client-request-id": [ "fd1de427-2dc5-4af3-8401-8e613c4f3176" ],
-        "CommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "New-AzDnsResolverPolicyDnsSecurityRule_CreateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
-      },
-      "ContentHeaders": {
-      }
-    },
-    "Response": {
-      "StatusCode": 200,
-      "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "af2b15d2-6b8b-46c3-8b21-91ff28cced0a" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "af2b15d2-6b8b-46c3-8b21-91ff28cced0a" ],
-        "x-ms-correlation-request-id": [ "af2b15d2-6b8b-46c3-8b21-91ff28cced0a" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200439Z:af2b15d2-6b8b-46c3-8b21-91ff28cced0a" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 65F1603CBCC346368B104EDFA9438420 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:39Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:39 GMT" ]
-      },
-      "ContentHeaders": {
-        "Content-Length": [ "866" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
-      },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"ca0095c7-0000-0700-0000-69bda8370000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1\",\"name\":\"secrule-upd-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T20:03:59.8065877Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:03:59.8065877Z\",\"lastModifiedByType\":\"User\"}}",
-      "isContentBase64": false
-    }
-  },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Update security rule tags+$PATCH+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview+1": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$PATCH+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview+10": {
     "Request": {
       "Method": "PATCH",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1?api-version=2025-10-01-preview",
-      "Content": "{\r\n  \"tags\": {\r\n    \"updated\": \"true\"\r\n  }\r\n}",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"properties\": {\r\n    \"priority\": 101\r\n  }\r\n}",
       "isContentBase64": false,
       "Headers": {
       },
       "ContentHeaders": {
         "Content-Type": [ "application/json" ],
-        "Content-Length": [ "45" ]
+        "Content-Length": [ "49" ]
       }
     },
     "Response": {
       "StatusCode": 202,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "Location": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815204768\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=PJxkAnLlhjPYVeg4P0anY4kkIEqvHgO2YBBPM1yT3kCWGrVxkdVc4HknaG7q4wbg9u7e_PbOgnaO4ohRr0oEnbmigAVNDQGx_rWilKBne1_kBieJoCeC7J5bMlDQmygj53yenhIukGPEigHQ4PksL-cbWJ3Gf8ZNDNEaDLqBdwTzXGkPnYM9tmsw7ts3XECyyXY-Y4EIGzXOspvbU_bRNUh01F96O4aJuPRuXwyc98czYgVfg0kD3p8ZfEoJ_O9dbBqy00m9L7X7KkPNtcJJAg51zwBFvkUBMrwKt0KVgOM5FUwwOkeDt1TQN9QEwiTcz_SBEGvGNuppOG1pXa-xMA\u0026h=6zUZoiu9eVUZ6y4NCCxU-RYxB2don9pMcXC7ODC3a_E" ],
+        "Date": [ "Tue, 05 May 2026 22:28:03 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview" ],
         "Retry-After": [ "5" ],
-        "x-ms-activity-id": [ "841b9d7f-775d-48ce-bff5-d65637fc8b32" ],
-        "Azure-AsyncOperation": [ "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815048555\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=ZS3W5Ax9F6HZ2f7ecrOAL2KAy6aS8f-Pt2xxVcOfLobYu1HAS4oemwj2FKRZ5odfZK1I0hGlFt8ZhCYBUn_dGG8TdaXMcmKVYB1Mp7sR2nDeVDhRzpkS4dYgfvJFMJ8bOceJVZ6yy16pkoeJ93obeycrQUAL6rTsXRTSmG5sm2OfFGrRhjnLh2HXz1MQg0O5ohZZZj0WyXMHDu1aa2PygB_EnSb9YEw1Nwoqxh2lVWZgJTaooGGGgTjtnYa-Qoa0toZ-0G3KRGDsn_C_-LcWW7G7ld_qON9C0WRdfJll2QbQydYj1JiBFrJofHm7dxywaVUtzGXUPKk5narJUXI3uw\u0026h=hNur36aDIM0jMr28YBdaRkLMzkmuWKJX4v3yXOHaJHg" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/16b4119a-1754-4478-8c8e-a429dbb7cc4f" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "799" ],
-        "x-ms-request-id": [ "841b9d7f-775d-48ce-bff5-d65637fc8b32" ],
-        "x-ms-correlation-request-id": [ "841b9d7f-775d-48ce-bff5-d65637fc8b32" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200441Z:841b9d7f-775d-48ce-bff5-d65637fc8b32" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 48F551E2DF3B455DB3647C213AFADE8A Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:39Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:41 GMT" ]
+        "x-ms-activity-id": [ "e7b6c6b4-7335-4cbe-8979-beb64af44e9a" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview" ]
       },
       "ContentHeaders": {
         "Content-Length": [ "59" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
       "Content": "{\"properties\":null,\"etag\":null,\"location\":null,\"tags\":null}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Update security rule tags+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815048555\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=ZS3W5Ax9F6HZ2f7ecrOAL2KAy6aS8f-Pt2xxVcOfLobYu1HAS4oemwj2FKRZ5odfZK1I0hGlFt8ZhCYBUn_dGG8TdaXMcmKVYB1Mp7sR2nDeVDhRzpkS4dYgfvJFMJ8bOceJVZ6yy16pkoeJ93obeycrQUAL6rTsXRTSmG5sm2OfFGrRhjnLh2HXz1MQg0O5ohZZZj0WyXMHDu1aa2PygB_EnSb9YEw1Nwoqxh2lVWZgJTaooGGGgTjtnYa-Qoa0toZ-0G3KRGDsn_C_-LcWW7G7ld_qON9C0WRdfJll2QbQydYj1JiBFrJofHm7dxywaVUtzGXUPKk5narJUXI3uw\u0026h=hNur36aDIM0jMr28YBdaRkLMzkmuWKJX4v3yXOHaJHg+2": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview+11": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815048555\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=ZS3W5Ax9F6HZ2f7ecrOAL2KAy6aS8f-Pt2xxVcOfLobYu1HAS4oemwj2FKRZ5odfZK1I0hGlFt8ZhCYBUn_dGG8TdaXMcmKVYB1Mp7sR2nDeVDhRzpkS4dYgfvJFMJ8bOceJVZ6yy16pkoeJ93obeycrQUAL6rTsXRTSmG5sm2OfFGrRhjnLh2HXz1MQg0O5ohZZZj0WyXMHDu1aa2PygB_EnSb9YEw1Nwoqxh2lVWZgJTaooGGGgTjtnYa-Qoa0toZ-0G3KRGDsn_C_-LcWW7G7ld_qON9C0WRdfJll2QbQydYj1JiBFrJofHm7dxywaVUtzGXUPKk5narJUXI3uw\u0026h=hNur36aDIM0jMr28YBdaRkLMzkmuWKJX4v3yXOHaJHg",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "15" ],
-        "x-ms-client-request-id": [ "c5dd60d1-cfd1-47dd-b7af-40d75f5a0764" ],
-        "CommandName": [ "Update-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Update-AzDnsResolverPolicyDnsSecurityRule_UpdateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -581,43 +300,26 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "46033612-fe15-4a08-9423-262eb9840bfa" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/9927b502-1b55-4f83-bb3d-5e70a51e7599" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "46033612-fe15-4a08-9423-262eb9840bfa" ],
-        "x-ms-correlation-request-id": [ "46033612-fe15-4a08-9423-262eb9840bfa" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200448Z:46033612-fe15-4a08-9423-262eb9840bfa" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 0FFE8341D54F405F96284D3E806A120B Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:46Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:47 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:28:08 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "4314354b-fe5b-4399-a132-e000bb77495b" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "543" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "514" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==\",\"startTime\":\"2026-03-20T20:04:41.0000000Z\",\"endTime\":\"2026-03-20T20:04:47.0000000Z\",\"status\":\"Succeeded\"}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==\",\"startTime\":\"2026-05-05T22:28:03.0000000Z\",\"status\":\"InProgress\"}",
       "isContentBase64": false
     }
   },
-  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Update security rule tags+$GET+https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815204768\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=PJxkAnLlhjPYVeg4P0anY4kkIEqvHgO2YBBPM1yT3kCWGrVxkdVc4HknaG7q4wbg9u7e_PbOgnaO4ohRr0oEnbmigAVNDQGx_rWilKBne1_kBieJoCeC7J5bMlDQmygj53yenhIukGPEigHQ4PksL-cbWJ3Gf8ZNDNEaDLqBdwTzXGkPnYM9tmsw7ts3XECyyXY-Y4EIGzXOspvbU_bRNUh01F96O4aJuPRuXwyc98czYgVfg0kD3p8ZfEoJ_O9dbBqy00m9L7X7KkPNtcJJAg51zwBFvkUBMrwKt0KVgOM5FUwwOkeDt1TQN9QEwiTcz_SBEGvGNuppOG1pXa-xMA\u0026h=6zUZoiu9eVUZ6y4NCCxU-RYxB2don9pMcXC7ODC3a_E+3": {
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview+12": {
     "Request": {
       "Method": "GET",
-      "RequestUri": "https://management.azure.com/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI4NTFkOGJjYS1lZmJmLTQxMDMtYjlhOC0zNWYxZjg5Njk5NTgifQ==?api-version=2025-10-01-preview\u0026t=639096338815204768\u0026c=MIIHlDCCBnygAwIBAgIQbRZBCnyTTrdKyx3sn6-cIjANBgkqhkiG9w0BAQsFADA2MTQwMgYDVQQDEytDQ01FIEcxIFRMUyBSU0EgMjA0OCBTSEEyNTYgMjA0OSBFVVMyIENBIDAxMB4XDTI2MDIyNDE4NDcwN1oXDTI2MDgyMDAwNDcwN1owQDE-MDwGA1UEAxM1YXN5bmNvcGVyYXRpb25zaWduaW5nY2VydGlmaWNhdGUubWFuYWdlbWVudC5henVyZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDLYIfsKK3BxfjRY95DQ7nTiHuQIybDAR8CX9yInjq_0E3Mb9YwMAQGJklR1lZJqg9M7got1ThcwNEpPovodQrXAzXRPqJ0JyNpNf1UNLgRs-3_mYbXxvSrBdgdZL4WUq9XCQ9WaH2aM3MAuLy8FL835sRe_Zx46G3TsI9Grsv5U-8gTr440L6nsopLTJJzQCpxou4KEuTMiG2GpVzxExJwvUDuutVCxXnsUwksDnhFUbqcJ7mVhhK5If25oHTNYUQwYylqvq_5eVdfEXEzpbP3XfDdKxljTnSMHaniaYcYW3OmhIMmdnHNFiPA9LQ2DtYs_7T68xnPVpbVO0EZ2Em5AgMBAAGjggSSMIIEjjCBnQYDVR0gBIGVMIGSMAwGCisGAQQBgjd7AQEwZgYKKwYBBAGCN3sCAjBYMFYGCCsGAQUFBwICMEoeSAAzADMAZQAwADEAOQAyADEALQA0AGQANgA0AC0ANABmADgAYwAtAGEAMAA1ADUALQA1AGIAZABhAGYAZgBkADUAZQAzADMAZDAMBgorBgEEAYI3ewMCMAwGCisGAQQBgjd7BAIwDAYDVR0TAQH_BAIwADAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDgYDVR0PAQH_BAQDAgWgMB0GA1UdDgQWBBQixmODlrY3K7hS01rA8V_TZUhMsjAfBgNVHSMEGDAWgBT87D7bqnwfgh4FuKEG-UPnArMKuTCCAbIGA1UdHwSCAakwggGlMGmgZ6BlhmNodHRwOi8vcHJpbWFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwa6BpoGeGZWh0dHA6Ly9zZWNvbmRhcnktY2RuLnBraS5jb3JlLndpbmRvd3MubmV0L2Vhc3R1czIvY3Jscy9jY21lZWFzdHVzMnBraS9jY21lZWFzdHVzMmljYTAxLzY1L2N1cnJlbnQuY3JsMFqgWKBWhlRodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vZWFzdHVzMi9jcmxzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvNjUvY3VycmVudC5jcmwwb6BtoGuGaWh0dHA6Ly9jY21lZWFzdHVzMnBraS5lYXN0dXMyLnBraS5jb3JlLndpbmRvd3MubmV0L2NlcnRpZmljYXRlQXV0aG9yaXRpZXMvY2NtZWVhc3R1czJpY2EwMS82NS9jdXJyZW50LmNybDCCAbcGCCsGAQUFBwEBBIIBqTCCAaUwbAYIKwYBBQUHMAKGYGh0dHA6Ly9wcmltYXJ5LWNkbi5wa2kuY29yZS53aW5kb3dzLm5ldC9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBuBggrBgEFBQcwAoZiaHR0cDovL3NlY29uZGFyeS1jZG4ucGtpLmNvcmUud2luZG93cy5uZXQvZWFzdHVzMi9jYWNlcnRzL2NjbWVlYXN0dXMycGtpL2NjbWVlYXN0dXMyaWNhMDEvY2VydC5jZXIwXQYIKwYBBQUHMAKGUWh0dHA6Ly9jcmwubWljcm9zb2Z0LmNvbS9lYXN0dXMyL2NhY2VydHMvY2NtZWVhc3R1czJwa2kvY2NtZWVhc3R1czJpY2EwMS9jZXJ0LmNlcjBmBggrBgEFBQcwAoZaaHR0cDovL2NjbWVlYXN0dXMycGtpLmVhc3R1czIucGtpLmNvcmUud2luZG93cy5uZXQvY2VydGlmaWNhdGVBdXRob3JpdGllcy9jY21lZWFzdHVzMmljYTAxMA0GCSqGSIb3DQEBCwUAA4IBAQBKY8uIen-4v_aGTptgf_04u1F6978whzIp4ZiTbOSXPwNnweOy6hCQUcuaqDgVZEiozCZ3DTEQooEcQdtH6WhiCDn5FLdHIVfLyo35uSdRGa9igGbbQ22s_ZI2_Sp17bV5_a-akDuAb6xVSZB_RbHXoicbUykmyHQ2aRb7wLI-YJ4X_aS00yjgBXHLbbbD1PGhTMYVk-5Qy8AYGA2_CTJ0ZS5toZF1EKxkz6ka6D_ROn4Sg7PthZX7Y3YpuVwnCelnvJvOgla_MQjpNDBcgmnVyU-ChBBd3TykrRxVWNXjEm54XPippvvwuKEdc4BCa38ZFVNgvDuK-tY_JpycugPZ\u0026s=PJxkAnLlhjPYVeg4P0anY4kkIEqvHgO2YBBPM1yT3kCWGrVxkdVc4HknaG7q4wbg9u7e_PbOgnaO4ohRr0oEnbmigAVNDQGx_rWilKBne1_kBieJoCeC7J5bMlDQmygj53yenhIukGPEigHQ4PksL-cbWJ3Gf8ZNDNEaDLqBdwTzXGkPnYM9tmsw7ts3XECyyXY-Y4EIGzXOspvbU_bRNUh01F96O4aJuPRuXwyc98czYgVfg0kD3p8ZfEoJ_O9dbBqy00m9L7X7KkPNtcJJAg51zwBFvkUBMrwKt0KVgOM5FUwwOkeDt1TQN9QEwiTcz_SBEGvGNuppOG1pXa-xMA\u0026h=6zUZoiu9eVUZ6y4NCCxU-RYxB2don9pMcXC7ODC3a_E",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview",
       "Content": null,
       "isContentBase64": false,
       "Headers": {
-        "Authorization": [ "[Filtered]" ],
-        "x-ms-unique-id": [ "16" ],
-        "x-ms-client-request-id": [ "c5dd60d1-cfd1-47dd-b7af-40d75f5a0764" ],
-        "CommandName": [ "Update-AzDnsResolverPolicyDnsSecurityRule" ],
-        "FullCommandName": [ "Update-AzDnsResolverPolicyDnsSecurityRule_UpdateExpanded" ],
-        "ParameterSetName": [ "__AllParameterSets" ],
-        "User-Agent": [ "AzurePowershell/v7.2.1", "PSVersion/v7.5.4", "Az.DnsResolver/1.1.1" ]
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
       },
       "ContentHeaders": {
       }
@@ -625,26 +327,436 @@
     "Response": {
       "StatusCode": 200,
       "Headers": {
-        "Cache-Control": [ "no-cache" ],
-        "Pragma": [ "no-cache" ],
-        "x-ms-activity-id": [ "b9ce9b54-8e5a-482d-975e-56d027f56bd7" ],
-        "x-ms-operation-identifier": [ "tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47,objectId=cea4c8a6-3bb9-4dc8-8eeb-e563fab740b1/westus2/6dfd0ae0-c3c9-4ae7-be95-b70aa3df2966" ],
-        "x-ms-ratelimit-remaining-subscription-resource-requests": [ "1099" ],
-        "x-ms-request-id": [ "b9ce9b54-8e5a-482d-975e-56d027f56bd7" ],
-        "x-ms-correlation-request-id": [ "b9ce9b54-8e5a-482d-975e-56d027f56bd7" ],
-        "x-ms-routing-request-id": [ "WESTUS2:20260320T200448Z:b9ce9b54-8e5a-482d-975e-56d027f56bd7" ],
-        "Strict-Transport-Security": [ "max-age=31536000; includeSubDomains" ],
-        "X-Content-Type-Options": [ "nosniff" ],
-        "X-Cache": [ "CONFIG_NOCACHE" ],
-        "X-MSEdge-Ref": [ "Ref A: 51B20EB6981B4F4385E84DA4B2F8D708 Ref B: CO6AA3150220021 Ref C: 2026-03-20T20:04:48Z" ],
-        "Date": [ "Fri, 20 Mar 2026 20:04:48 GMT" ]
+        "Date": [ "Tue, 05 May 2026 22:28:38 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "d10befd8-7274-489c-8163-826a8b60d676" ]
       },
       "ContentHeaders": {
-        "Content-Length": [ "911" ],
-        "Content-Type": [ "application/json; charset=utf-8" ],
-        "Expires": [ "-1" ]
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
       },
-      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\",\"blockResponseCode\":\"SERVFAIL\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"ca0090ca-0000-0700-0000-69bda85d0000\\\"\",\"location\":\"westus2\",\"tags\":{\"updated\":\"true\"},\"id\":\"/subscriptions/97db216c-169d-4ea9-9d98-114adba0aa20/resourceGroups/ps-secrule-upd-76480/providers/Microsoft.Network/dnsResolverPolicies/policy-secrule-u/dnsSecurityRules/secrule-upd-1\",\"name\":\"secrule-upd-1\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":\"2026-03-20T20:03:59.8065877Z\",\"createdByType\":\"User\",\"lastModifiedAt\":\"2026-03-20T20:04:41.2704619Z\",\"lastModifiedByType\":\"User\"}}",
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==\",\"startTime\":\"2026-05-05T22:28:03.0000000Z\",\"endTime\":\"2026-05-05T22:28:09.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview+13": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI5YmY3YTEyYi0wYjExLTQyYjktYjQ2YS1hYzhjMzAyMGM4ZmUifQ==?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:38 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "c19b5b8c-bb22-4b79-8edb-2fc12877492b" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "904" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":101,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900fb2e-0000-0800-0000-69fa6ef90000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg\",\"name\":\"psdnssecurityrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule priority+$GET+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview+14": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:38 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "af7a4ab1-f186-47ed-8c02-4aeee90745a8" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "904" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":101,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulename5cd8dcg\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900fb2e-0000-0800-0000-69fa6ef90000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulename5cd8dcg/dnsSecurityRules/psdnssecurityrulename5cd8dcg\",\"name\":\"psdnssecurityrulename5cd8dcg\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2?api-version=2026-07-01-preview+1": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\"\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "29" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:38 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "ab806a60-af70-4b3f-9901-374d1d5edead" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZWJlMjI0NWEtYTk0MS00ODcxLWJhMjEtZjcxMDk5ZGY4OWJmIn0=?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "418" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080017b4-0000-0800-0000-69fa6f170000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2\",\"name\":\"psdnsresolverpolicyforrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZWJlMjI0NWEtYTk0MS00ODcxLWJhMjEtZjcxMDk5ZGY4OWJmIn0=?api-version=2026-07-01-preview+2": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZWJlMjI0NWEtYTk0MS00ODcxLWJhMjEtZjcxMDk5ZGY4OWJmIn0=?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:43 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "101d2aae-705d-4d7b-8fe1-3634914d0142" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "562" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZWJlMjI0NWEtYTk0MS00ODcxLWJhMjEtZjcxMDk5ZGY4OWJmIn0=\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlclBvbGljeSIsIk9wZXJhdGlvbklkIjoiZWJlMjI0NWEtYTk0MS00ODcxLWJhMjEtZjcxMDk5ZGY4OWJmIn0=\",\"startTime\":\"2026-05-05T22:28:39.0000000Z\",\"endTime\":\"2026-05-05T22:28:41.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2?api-version=2026-07-01-preview+3": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:43 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "11881546-417e-4dce-9087-730582660fd2" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "453" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"69585595-28e0-42ee-81e2-3235e5fdc160\"},\"etag\":\"\\\"1200a25c-0000-0800-0000-69fa6f190000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2\",\"name\":\"psdnsresolverpolicyforrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverPolicies\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2?api-version=2026-07-01-preview+4": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"domains\": [ \"contoso.com.\", \"example.com.\" ]\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "105" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:43 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "2fc8af39-d4a2-411b-98c6-c80ea7c07f5c" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "492" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Creating\",\"resourceGuid\":null},\"etag\":\"\\\"080043b4-0000-0800-0000-69fa6f1c0000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\",\"name\":\"psdnsresolverdomainlistforrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9?api-version=2026-07-01-preview+5": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:28:48 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "a0f2e5eb-c2cb-4c12-98a7-0847154a9c73" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "530" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9\",\"startTime\":\"2026-05-05T22:28:44.0000000Z\",\"status\":\"InProgress\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9?api-version=2026-07-01-preview+6": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:18 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "ea3148bd-ea9e-42bb-89c4-4ba16c54b2c5" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "570" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNSZXNvbHZlckRvbWFpbkxpc3QiLCJPcGVyYXRpb25JZCI6IjU4OTU3NGE2LWQ1MzgtNDkzYi04MmRhLTFhZTFlYjUzOGI0YiJ9\",\"startTime\":\"2026-05-05T22:28:44.0000000Z\",\"endTime\":\"2026-05-05T22:28:49.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2?api-version=2026-07-01-preview+7": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:18 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "f957a98b-1d98-4ff9-9597-0f51c12d18bc" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "527" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"domains\":[\"contoso.com.\",\"example.com.\"],\"domainsUrl\":null,\"provisioningState\":\"Succeeded\",\"resourceGuid\":\"b3768946-213d-484c-84d6-0aa993d40a3e\"},\"etag\":\"\\\"a2088e94-0000-0800-0000-69fa6f210000\\\"\",\"location\":\"westus2\",\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\",\"name\":\"psdnsresolverdomainlistforrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverDomainLists\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$PUT+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview+8": {
+    "Request": {
+      "Method": "PUT",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"location\": \"westus2\",\r\n  \"properties\": {\r\n    \"action\": {\r\n      \"actionType\": \"Block\"\r\n    },\r\n    \"priority\": 100,\r\n    \"dnsResolverDomainLists\": [\r\n      {\r\n        \"id\": \"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\"\r\n      }\r\n    ],\r\n    \"dnsSecurityRuleState\": \"Enabled\"\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "434" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 201,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:18 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "82f47819-e8a7-45ba-b4f4-26eef1e48f7a" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImJmMjM2NzM1LTNkZTktNDlmMy04ZWJmLTZhYjg2YjI5NjhhNyJ9?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "790" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Creating\"},\"etag\":\"\\\"1200e25e-0000-0800-0000-69fa6f3f0000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2\",\"name\":\"psdnssecurityrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImJmMjM2NzM1LTNkZTktNDlmMy04ZWJmLTZhYjg2YjI5NjhhNyJ9?api-version=2026-07-01-preview+9": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImJmMjM2NzM1LTNkZTktNDlmMy04ZWJmLTZhYjg2YjI5NjhhNyJ9?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:23 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "1a167462-13e4-4734-90a8-0c673c09d203" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImJmMjM2NzM1LTNkZTktNDlmMy04ZWJmLTZhYjg2YjI5NjhhNyJ9\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiQ29udmVyZ2VEbnNTZWN1cml0eVJ1bGUiLCJPcGVyYXRpb25JZCI6ImJmMjM2NzM1LTNkZTktNDlmMy04ZWJmLTZhYjg2YjI5NjhhNyJ9\",\"startTime\":\"2026-05-05T22:29:19.0000000Z\",\"endTime\":\"2026-05-05T22:29:22.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview+10": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:23 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "8c0bd612-216c-42e7-8d1b-72a93ee3e760" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "791" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\"},\"etag\":\"\\\"0900182f-0000-0800-0000-69fa6f420000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2\",\"name\":\"psdnssecurityrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$PATCH+https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview+11": {
+    "Request": {
+      "Method": "PATCH",
+      "RequestUri": "https://management.azure.com/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2?api-version=2026-07-01-preview",
+      "Content": "{\r\n  \"properties\": {\r\n    \"disableCnameChainValidation\": true\r\n  }\r\n}",
+      "isContentBase64": false,
+      "Headers": {
+      },
+      "ContentHeaders": {
+        "Content-Type": [ "application/json" ],
+        "Content-Length": [ "69" ]
+      }
+    },
+    "Response": {
+      "StatusCode": 202,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:23 GMT" ],
+        "Server": [ "Kestrel" ],
+        "Location": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview" ],
+        "Retry-After": [ "5" ],
+        "x-ms-activity-id": [ "c866f591-f643-46bb-a9f4-7e40ed76788d" ],
+        "Azure-AsyncOperation": [ "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "59" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":null,\"etag\":null,\"location\":null,\"tags\":null}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview+12": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:28 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "949f5273-9c92-41ea-b8ed-51d460e50535" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "554" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverOperationStatuses/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==\",\"name\":\"eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==\",\"startTime\":\"2026-05-05T22:29:24.0000000Z\",\"endTime\":\"2026-05-05T22:29:29.0000000Z\",\"status\":\"Succeeded\"}",
+      "isContentBase64": false
+    }
+  },
+  "Update-AzDnsResolverPolicyDnsSecurityRule+[NoContext]+Updates a DNS Security Rule with DisableCnameChainValidation+$GET+https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview+13": {
+    "Request": {
+      "Method": "GET",
+      "RequestUri": "https://s1.westus2.test.azuremresolver.net/api/dnsresolverpolicy/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/locations/westus2/dnsResolverPolicyOperationResults/eyJPcGVyYXRpb25UeXBlIjoiVXBzZXJ0RG5zU2VjdXJpdHlSdWxlIiwiT3BlcmF0aW9uSWQiOiI3ZmM0M2ZmYS01MzZiLTQ3ZGYtODlmMi1lYjg0MjRlYTUzN2MifQ==?api-version=2026-07-01-preview",
+      "Content": null,
+      "isContentBase64": false,
+      "Headers": {
+        "x-ms-client-tenant-id": [ "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd", "f686d426-8d16-42db-81b7-ab578e110ccd" ]
+      },
+      "ContentHeaders": {
+      }
+    },
+    "Response": {
+      "StatusCode": 200,
+      "Headers": {
+        "Date": [ "Tue, 05 May 2026 22:29:28 GMT" ],
+        "Server": [ "Kestrel" ],
+        "x-ms-activity-id": [ "ec7c7a50-3f8d-4124-a765-638ff97161bf" ]
+      },
+      "ContentHeaders": {
+        "Content-Length": [ "927" ],
+        "Content-Type": [ "application/json; charset=utf-8" ]
+      },
+      "Content": "{\"properties\":{\"priority\":100,\"dnsResolverDomainLists\":[{\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverDomainLists/psdnsresolverdomainlistforrulenamedcv2\"}],\"managedDomainLists\":[],\"action\":{\"actionType\":\"Block\"},\"dnsSecurityRuleState\":\"Enabled\",\"provisioningState\":\"Succeeded\",\"disableCnameChainValidation\":true},\"etag\":\"\\\"09001a2f-0000-0800-0000-69fa6f490000\\\"\",\"location\":\"westus2\",\"tags\":null,\"id\":\"/subscriptions/c9b1134d-20dd-45a9-a350-bf55370c4502/resourceGroups/powershell-test-rg-debug-update/providers/Microsoft.Network/dnsResolverPolicies/psdnsresolverpolicyforrulenamedcv2/dnsSecurityRules/psdnssecurityrulenamedcv2\",\"name\":\"psdnssecurityrulenamedcv2\",\"type\":\"Microsoft.Network/dnsResolverPolicies/dnsSecurityRules\",\"systemData\":{\"createdAt\":null,\"createdByType\":null,\"lastModifiedAt\":null,\"lastModifiedByType\":null}}",
       "isContentBase64": false
     }
   }

--- a/src/DnsResolver/DnsResolver.Autorest/test/Update-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
+++ b/src/DnsResolver/DnsResolver.Autorest/test/Update-AzDnsResolverPolicyDnsSecurityRule.Tests.ps1
@@ -1,28 +1,65 @@
-$TestRecordingFile = Join-Path $PSScriptRoot 'Update-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) { $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File; $currentPath = Split-Path -Path $currentPath -Parent }
-. ($mockingPath | Select-Object -First 1).FullName
+if(($null -eq $TestName) -or ($TestName -contains 'Update-AzDnsResolverPolicyDnsSecurityRule'))
+{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)
+  $TestRecordingFile = Join-Path $PSScriptRoot 'Update-AzDnsResolverPolicyDnsSecurityRule.Recording.json'
+  $currentPath = $PSScriptRoot
+  while(-not $mockingPath) {
+      $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+      $currentPath = Split-Path -Path $currentPath -Parent
+  }
+  . ($mockingPath | Select-Object -First 1).FullName
+}
+
+# Load post-merge test helper for routing to Frontend endpoint
+. (Join-Path $PSScriptRoot 'postMergeTestHelper.ps1')
+if ($TestMode -ne 'playback') {
+    $postMergeStep = New-PostMergeTestHttpPipelineStep
+    $existingMock = $PSDefaultParameterValues["*:HttpPipelinePrepend"]
+    $PSDefaultParameterValues["*:HttpPipelinePrepend"] = [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep[]]@(
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$postMergeStep,
+        [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.SendAsyncStep]$existingMock
+    )
+}
 
 Describe 'Update-AzDnsResolverPolicyDnsSecurityRule' {
-    BeforeAll {
-        $subscriptionId = '97db216c-169d-4ea9-9d98-114adba0aa20'; $location = 'westus2'
-        $rgName = "ps-secrule-upd-76480"
-        if ($TestMode -ne 'playback') {
-            Select-AzSubscription -SubscriptionId $subscriptionId
-            New-AzResourceGroup -Name $rgName -Location $location
-            New-AzDnsResolverPolicy -Name "policy-secrule-u" -ResourceGroupName $rgName -Location $location
-            New-AzDnsResolverDomainList -Name "domainlist-secrule-u" -ResourceGroupName $rgName -Location $location -Domain @("contoso.com.")
-            $dlId = "/subscriptions/$subscriptionId/resourceGroups/$rgName/providers/Microsoft.Network/dnsResolverDomainLists/domainlist-secrule-u"
-            New-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-upd-1" -DnsResolverPolicyName "policy-secrule-u" -ResourceGroupName $rgName -Location $location -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100 -DnsResolverDomainList @(@{id = $dlId})
-        }
+    It 'Updates a DNS Security Rule priority' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulename5cd8dcg";
+        $dnsSecurityRuleName = "psdnssecurityrulename5cd8dcg";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulename5cd8dcg";
+        $resourceGroupName = "powershell-test-rg-debug-update";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT
+        $securityRule = Update-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Priority 101
+
+        # ASSERT
+        $updatedSecurityRule = Get-AzDnsResolverPolicyDnsSecurityRule -DnsResolverPolicyName $dnsResolverPolicyName -DnsSecurityRuleName $dnsSecurityRuleName -ResourceGroupName $resourceGroupName
+        $securityRule.Priority | Should -Be 101
     }
-    AfterAll {
-        if ($TestMode -ne 'playback') { Remove-AzResourceGroup -Name $rgName -ErrorAction SilentlyContinue -AsJob | Out-Null }
-    }
-    It 'Update security rule tags' {
-        $tag = @{ "updated" = "true" }
-        $rule = Update-AzDnsResolverPolicyDnsSecurityRule -Name "secrule-upd-1" -DnsResolverPolicyName "policy-secrule-u" -ResourceGroupName $rgName -Tag $tag
-        $rule.ProvisioningState | Should -Be "Succeeded"
-        $rule.Tag.Count | Should -Be 1
+
+    It 'Updates a DNS Security Rule with DisableCnameChainValidation' {
+        # ARRANGE
+        $dnsResolverPolicyName = "psdnsresolverpolicyforrulenamedcv2";
+        $dnsSecurityRuleName = "psdnssecurityrulenamedcv2";
+        $dnsResolverDomainListName = "psdnsresolverdomainlistforrulenamedcv2";
+        $resourceGroupName = "powershell-test-rg-debug-update";
+        $location = "westus2";
+        $resolverPolicy = New-AzDnsResolverPolicy -Name $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location
+        $domainList = New-AzDnsResolverDomainList -Name $dnsResolverDomainListName -ResourceGroupName $resourceGroupName -Location $location -Domain @("contoso.com.", "example.com.")
+        $securityRule = New-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -Location $location -DnsResolverDomainList @{id = $domainList.Id;} -DnsSecurityRuleState "Enabled" -ActionType "Block" -Priority 100
+
+        # ACT
+        $securityRule = Update-AzDnsResolverPolicyDnsSecurityRule -Name $dnsSecurityRuleName -DnsResolverPolicyName $dnsResolverPolicyName -ResourceGroupName $resourceGroupName -DisableCnameChainValidation
+
+        # ASSERT
+        $securityRule.DisableCnameChainValidation | Should -Be $true
     }
 }

--- a/src/DnsResolver/DnsResolver.Autorest/test/localEnv.json
+++ b/src/DnsResolver/DnsResolver.Autorest/test/localEnv.json
@@ -1,0 +1,15 @@
+{
+  "ResourceLocation": "westus2",
+  "Tenant": "f686d426-8d16-42db-81b7-ab578e110ccd",
+  "MalformedVirtualNetworkErrorMessage": "Resource ID is not a valid virtual network resource ID",
+  "ResourceGroupName": "ps-postmerge-test-rg",
+  "SubscriptionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "DnsResolverNamePrefix": "psdnsresolvername",
+  "VirtualNetworkNamePrefix": "psvirtualnetworkname",
+  "SuccessProvisioningState": "Succeeded",
+  "InboundEnpointNamePrefix": "psinboundendpointname",
+  "LocationForVirtualNetwork": "westus2",
+  "SubnetNamePrefix": "pssubnetname",
+  "InboundEndpointNamePrefix": "psinboundendpointname",
+  "AddressPrefix": "40.121.0.0/16"
+}

--- a/src/DnsResolver/DnsResolver.Autorest/test/postMergeTestHelper.ps1
+++ b/src/DnsResolver/DnsResolver.Autorest/test/postMergeTestHelper.ps1
@@ -1,0 +1,142 @@
+# Post-Merge Test Helper
+# Provides HTTP pipeline handler for routing PS cmdlet requests to the
+# post-merge test Managed Resolver Frontend endpoint with client certificate auth.
+# Uses a compiled C# class (PostMergeTestPipelineStep) with implicit conversion
+# to SendAsyncStep, matching the PipelineMock pattern.
+
+$script:PostMergeTestEndpoint = "https://s1.westus2.test.azuremresolver.net"
+$script:PostMergeTestCertSubjectName = "CN=tests.clients.test.azuremresolver.net"
+$script:PostMergeTestTenantId = "f686d426-8d16-42db-81b7-ab578e110ccd"
+
+function Get-PostMergeTestCertificate {
+    <#
+    .SYNOPSIS
+    Loads the post-merge test client certificate from the local certificate store.
+    Prefers non-expired certificates sorted by latest expiry.
+    #>
+    $allCerts = @()
+    $allCerts += Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object { $_.Subject -eq $script:PostMergeTestCertSubjectName }
+    $allCerts += Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Subject -eq $script:PostMergeTestCertSubjectName }
+
+    if ($allCerts.Count -eq 0) {
+        throw "Post-merge test client certificate '$($script:PostMergeTestCertSubjectName)' not found in certificate store. Please install the certificate first."
+    }
+
+    # Prefer non-expired certs, sorted by latest expiry
+    $now = [DateTime]::UtcNow
+    $cert = $allCerts | Where-Object { $_.NotAfter -gt $now } | Sort-Object NotAfter -Descending | Select-Object -First 1
+    if (-not $cert) {
+        $cert = $allCerts | Sort-Object NotAfter -Descending | Select-Object -First 1
+        Write-Warning "No valid (non-expired) post-merge test certificates found. Using expired cert with thumbprint $($cert.Thumbprint) (expired $($cert.NotAfter))."
+    }
+    return $cert
+}
+
+function Initialize-PostMergeTestType {
+    <#
+    .SYNOPSIS
+    Compiles the PostMergeTestPipelineStep C# class that implements the same
+    implicit-to-SendAsyncStep pattern as PipelineMock.
+    #>
+    if (-not ([System.Management.Automation.PSTypeName]'PostMergeTestPipelineStep').Type) {
+        $moduleAssembly = [Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime.PipelineMock].Assembly.Location
+        Add-Type -ReferencedAssemblies @(
+            $moduleAssembly,
+            'System.Net.Http',
+            'System.Threading.Tasks',
+            'netstandard'
+        ) -TypeDefinition @'
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.PowerShell.Cmdlets.DnsResolver.Runtime;
+
+public class PostMergeTestPipelineStep
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _endpoint;
+    private readonly string _tenantId;
+
+    public PostMergeTestPipelineStep(HttpClient httpClient, string endpoint, string tenantId)
+    {
+        _httpClient = httpClient;
+        _endpoint = endpoint.TrimEnd('/');
+        _tenantId = tenantId;
+    }
+
+    public static implicit operator SendAsyncStep(PostMergeTestPipelineStep step)
+    {
+        return step.SendAsync;
+    }
+
+    public async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        IEventListener callback,
+        ISendAsync next)
+    {
+        var originalUri = request.RequestUri;
+
+        // Only rewrite ARM URLs; LRO polling URLs already point to test endpoint
+        if (!originalUri.Host.Equals("management.azure.com", System.StringComparison.OrdinalIgnoreCase))
+        {
+            // Already targeting test endpoint (e.g., Azure-AsyncOperation polling)
+            request.Headers.Authorization = null;
+            request.Headers.TryAddWithoutValidation("x-ms-client-tenant-id", _tenantId);
+            return await _httpClient.SendAsync(request, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        var path = originalUri.PathAndQuery;
+
+        // Determine the route prefix based on the resource path
+        string routePrefix;
+        if (path.Contains("dnsResolverPolicies") || path.Contains("dnsResolverDomainLists"))
+        {
+            routePrefix = "api/dnsresolverpolicy";
+        }
+        else
+        {
+            routePrefix = "api/mresolver";
+        }
+
+        // Rewrite the URL: management.azure.com/{path} -> endpoint/{routePrefix}/{path}
+        request.RequestUri = new Uri($"{_endpoint}/{routePrefix}{path}");
+
+        // Remove bearer token auth - we use client cert instead
+        request.Headers.Authorization = null;
+        request.Headers.TryAddWithoutValidation("x-ms-client-tenant-id", _tenantId);
+
+        // Send via our cert-auth HttpClient, bypassing the default pipeline
+        return await _httpClient.SendAsync(request, CancellationToken.None).ConfigureAwait(false);
+    }
+}
+'@
+    }
+}
+
+function New-PostMergeTestHttpPipelineStep {
+    <#
+    .SYNOPSIS
+    Creates an HTTP pipeline step that rewrites ARM URLs to the post-merge test
+    Frontend endpoint and uses client certificate authentication.
+
+    .DESCRIPTION
+    Returns a PostMergeTestPipelineStep object that has implicit conversion to
+    SendAsyncStep (same pattern as PipelineMock). The step:
+    1. Rewrites the request URL from management.azure.com to the test Frontend
+    2. Prefixes the path with the appropriate controller route
+    3. Uses client certificate for authentication instead of bearer token
+    #>
+
+    Initialize-PostMergeTestType
+
+    $cert = Get-PostMergeTestCertificate
+
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $null = $handler.ClientCertificates.Add($cert)
+    $handler.ServerCertificateCustomValidationCallback = [System.Net.Http.HttpClientHandler]::DangerousAcceptAnyServerCertificateValidator
+    $httpClient = [System.Net.Http.HttpClient]::new($handler)
+
+    return [PostMergeTestPipelineStep]::new($httpClient, $script:PostMergeTestEndpoint, $script:PostMergeTestTenantId)
+}

--- a/src/DnsResolver/DnsResolver/ChangeLog.md
+++ b/src/DnsResolver/DnsResolver/ChangeLog.md
@@ -18,12 +18,13 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Upgraded API version from 2023-07-01-preview to 2025-10-01-preview
+* Upgraded API version from 2023-07-01-preview to 2026-07-01-preview
 * Added new cmdlet `Invoke-AzDnsResolverBulkDnsResolverDomainList`
 * Introduced various new features by upgrading code generator. Please see details [here](https://github.com/Azure/azure-powershell/blob/main/documentation/Autorest-powershell-v4-new-features.md).
 * [Breaking Change] Removed parameter `ActionBlockResponseCode` from `New-AzDnsResolverPolicyDnsSecurityRule` and `Update-AzDnsResolverPolicyDnsSecurityRule`. The block response code is no longer configurable.
 * [Breaking Change] Parameter `DnsResolverDomainList` is no longer mandatory on `New-AzDnsResolverPolicyDnsSecurityRule`. DNS security rules now support `ManagedDomainList` as an alternative.
 * [Breaking Change] Parameter `Domain` is no longer mandatory on `New-AzDnsResolverDomainList`. Domain lists now support bulk upload via `Invoke-AzDnsResolverBulkDnsResolverDomainList`.
+* Added parameter `DisableCnameChainValidation` to `New-AzDnsResolverPolicyDnsSecurityRule` and `Update-AzDnsResolverPolicyDnsSecurityRule`. When set, the resolver will not validate the full CNAME chain against domain lists and will match only on the queried domain name.
 
 
 ## Version 1.2.4


### PR DESCRIPTION
## Description

Adds the \DisableCnameChainValidation\ parameter to \New-AzDnsResolverPolicyDnsSecurityRule\ and \Update-AzDnsResolverPolicyDnsSecurityRule\ cmdlets. When set, the DNS resolver will not validate the full CNAME chain against domain lists and will match only on the queried domain name.

## Changes

- Updated API version references from \2025-10-01-preview\ to \2026-07-01-preview\
- Re-recorded security rule tests against post-merge test Frontend environment (cert-based auth)
- Added \postMergeTestHelper.ps1\ — HTTP pipeline handler for routing tests to the test Frontend
- Updated examples with \DisableCnameChainValidation\ usage
- Updated ChangeLog

## Testing

All 8 security rule tests pass in both record and playback modes:
- \New-AzDnsResolverPolicyDnsSecurityRule\ (2 tests: basic create + with DisableCnameChainValidation)
- \Get-AzDnsResolverPolicyDnsSecurityRule\ (2 tests)
- \Update-AzDnsResolverPolicyDnsSecurityRule\ (2 tests: priority update + DisableCnameChainValidation)
- \Remove-AzDnsResolverPolicyDnsSecurityRule\ (2 tests)