### PR TITLE
Remove DailyBuild in live test since it is already deprecated

### DIFF
--- a/.azure-pipelines/live-test.yml
+++ b/.azure-pipelines/live-test.yml
@@ -2,9 +2,8 @@ parameters:
   - name: GalleryName
     displayName: Gallery Name
     type: string
-    default: DailyBuild
+    default: Sign
     values:
-      - DailyBuild
       - Sign
       - PSGallery
   - name: PipelineBuildId

--- a/.azure-pipelines/util/live-test-steps.yml
+++ b/.azure-pipelines/util/live-test-steps.yml
@@ -46,25 +46,20 @@ jobs:
         New-Item -Name $(ArtifactsName) -Path $(Pipeline.Workspace) -ItemType Directory -Force
 
   - task: DownloadPipelineArtifact@2
-    condition: ${{ in(parameters.galleryName, 'DailyBuild', 'Sign') }}
+    condition: ${{ eq(parameters.galleryName, 'Sign') }}
     displayName: Download artifacts from ${{ parameters.galleryName }}
     inputs:
       buildType: 'specific'
-      ${{ if eq(parameters.galleryName, 'DailyBuild') }}:
-        project: $(BuildPipelineProject)
-        definition: $(BuildPipelineDefinitionId)
-        artifactName: 'artifacts'
-      ${{ elseif eq(parameters.galleryName, 'Sign') }}:
-        project: $(SignPipelineProject)
-        definition: $(SignPipelineDefinitionId)
-        artifactName: $(ArtifactName)
-        itemPattern: '**/artifacts/**'
+      project: $(SignPipelineProject)
+      definition: $(SignPipelineDefinitionId)
+      artifactName: $(ArtifactName)
+      itemPattern: '**/artifacts/**'
       ${{ if eq(replace(parameters.pipelineBuildId, ' ', ''), '') }}:
         buildVersionToDownload: 'latestFromBranch'
         branchName: refs/heads/$(PipelineBranchName)
       ${{ else }}:
         buildVersionToDownload: 'specific'
-        pipelineId: ${{ parameters.PipelineBuildId }}
+        pipelineId: ${{ parameters.pipelineBuildId }}
       targetPath: $(Pipeline.Workspace)
 
   - task: PowerShell@2

--- a/tools/TestFx/Live/InstallLiveTestAzModules.ps1
+++ b/tools/TestFx/Live/InstallLiveTestAzModules.ps1
@@ -1,6 +1,6 @@
 param (
     [Parameter(Mandatory)]
-    [ValidateSet("PSGallery", "DailyBuild", "Sign", IgnoreCase = $false)]
+    [ValidateSet("PSGallery", "Sign", IgnoreCase = $false)]
     [string] $Source,
 
     [Parameter()]
@@ -11,7 +11,7 @@ switch ($Source) {
     "PSGallery" {
         Set-PSRepository -Name $Source -InstallationPolicy Trusted
     }
-    { $_ -in "DailyBuild", "Sign" } {
+    "Sign" {
         Register-PSRepository -Name $Source -SourceLocation $AzPackagesLocation -PackageManagementProvider NuGet -InstallationPolicy Trusted
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This pull request removes support for the `DailyBuild` gallery/source from both the pipeline configuration and the PowerShell script used for installing test modules. Now, only `Sign` and `PSGallery` are valid options for the relevant parameters and logic.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [ ] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [ ] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
