### PR TITLE
Fix ContainerInstance and Functions live test failures

### DIFF
--- a/src/ContainerInstance/LiveTests/ContainerInstance.Autorest/TestLiveScenarios.ps1
+++ b/src/ContainerInstance/LiveTests/ContainerInstance.Autorest/TestLiveScenarios.ps1
@@ -5,7 +5,7 @@ Invoke-LiveTestScenario -Name "Create ContainerGroup" -Description "Test New-AzC
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:mariner-2'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:azurelinux-3.0'
     $actual = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     Assert-AreEqual $cgName $actual.Name
     Assert-AreEqual $cgLocation $actual.Location
@@ -19,7 +19,7 @@ Invoke-LiveTestScenario -Name "List ContainerGroup" -Description "Test listing C
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:ubuntu-22.04'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:ubuntu-24.04'
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName
     Assert-True { $actual.Count -ge 1 }
@@ -33,7 +33,7 @@ Invoke-LiveTestScenario -Name "Get ContainerGroup" -Description "Test getting on
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:ubi-9'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23'
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName -Name $cgName
     Assert-AreEqual $cgName $actual.Name
@@ -48,7 +48,7 @@ Invoke-LiveTestScenario -Name "Update ContainerGroup" -Description "Test Updatin
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
     $tag = @{'key' = 'v' }
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.17'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23'
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $null = Update-AzContainerGroup -Name $cgName -ResourceGroupName $rgName -Tag $tag
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName -Name $cgName

--- a/src/Functions/LiveTests/Functions.Autorest/TestLiveScenarios.ps1
+++ b/src/Functions/LiveTests/Functions.Autorest/TestLiveScenarios.ps1
@@ -31,7 +31,7 @@ Invoke-LiveTestScenario -Name "Update function app" -Description "Test updating 
     New-AzStorageAccount -ResourceGroupName $rgName -Name $saName -Location $location -SkuName Standard_LRS
     $funcApp = New-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName -Location $location -FunctionsVersion 4 -StorageAccountName $saName -OSType Windows -Runtime PowerShell -RuntimeVersion 7.4
     $funcApp | Update-AzFunctionApp -Tag @{ "key" = "value" } -Force
-    Update-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName -IdentityType SystemAssigned -Force
+    Update-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName -EnableSystemAssignedIdentity $true -Force
 
     $actual = Get-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName
     Assert-NotNull $actual


### PR DESCRIPTION
## Description

Fix live test failures in **ContainerInstance** and **Functions** modules that are failing across multiple CI/CD environments.

## ContainerInstance — Obsolete Container Image Tags

Container image tags referenced in live tests no longer exist on mcr.microsoft.com/azure-powershell, causing test failures.

### Changes
- Create ContainerGroup: `mariner-2` → `azurelinux-3.0`
- List ContainerGroup: `ubuntu-22.04` → `ubuntu-24.04`
- Get ContainerGroup: `ubi-9` → `alpine-3.23`
- Update ContainerGroup: `alpine-3.17` → `alpine-3.23`
- Remove ContainerGroup: `debian-12` (unchanged, already passing)

## Functions — Removed `-IdentityType` Parameter

The `Update-AzFunctionApp` cmdlet removed the `-IdentityType` parameter in favor of `-EnableSystemAssignedIdentity`. The live test was still using the old parameter, causing failures in **all 10 environments**.

On PS 5.1 specifically, this caused a cascade failure: the test created a function app before hitting the parameter error, leaving orphaned resources that exhausted subscription quota. This made the subsequent ''Remove function app'' and ''Operate function app'' tests also fail with a misleading ''name not available'' error.

### Changes
- `Update-AzFunctionApp -IdentityType SystemAssigned` → `Update-AzFunctionApp -EnableSystemAssignedIdentity $true`

### Environments affected
| Environment | Failed Scenarios |
|---|---|
| ps_5_1_windows | Update, Remove, Operate (cascade) |
| ps_7_4/7_5/7_6 (win/linux/mac) | Update only |

## Testing
These are live test scripts — validation requires running in the CI/CD pipeline with live Azure resources.