### PR TITLE
Fix ContainerInstance live test missing resource requests

### DIFF
--- a/src/ContainerInstance/LiveTests/ContainerInstance.Autorest/TestLiveScenarios.ps1
+++ b/src/ContainerInstance/LiveTests/ContainerInstance.Autorest/TestLiveScenarios.ps1
@@ -5,7 +5,7 @@ Invoke-LiveTestScenario -Name "Create ContainerGroup" -Description "Test New-AzC
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:azurelinux-3.0'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:azurelinux-3.0' -RequestCpu 1 -RequestMemoryInGb 1.5
     $actual = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     Assert-AreEqual $cgName $actual.Name
     Assert-AreEqual $cgLocation $actual.Location
@@ -19,7 +19,7 @@ Invoke-LiveTestScenario -Name "List ContainerGroup" -Description "Test listing C
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:ubuntu-24.04'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:ubuntu-24.04' -RequestCpu 1 -RequestMemoryInGb 1.5
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName
     Assert-True { $actual.Count -ge 1 }
@@ -33,7 +33,7 @@ Invoke-LiveTestScenario -Name "Get ContainerGroup" -Description "Test getting on
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23' -RequestCpu 1 -RequestMemoryInGb 1.5
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName -Name $cgName
     Assert-AreEqual $cgName $actual.Name
@@ -48,11 +48,11 @@ Invoke-LiveTestScenario -Name "Update ContainerGroup" -Description "Test Updatin
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
     $tag = @{'key' = 'v' }
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:alpine-3.23' -RequestCpu 1 -RequestMemoryInGb 1.5
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $null = Update-AzContainerGroup -Name $cgName -ResourceGroupName $rgName -Tag $tag
     $actual = Get-AzContainerGroup -ResourceGroupName $rgName -Name $cgName
-    Assert-AreEqual $actual.tag.Count 1
+    Assert-AreEqual 1 $actual.Tag.Count
 }
 
 Invoke-LiveTestScenario -Name "Remove ContainerGroup" -Description "Test Removing ContainerGroup" -ScenarioScript `
@@ -62,7 +62,7 @@ Invoke-LiveTestScenario -Name "Remove ContainerGroup" -Description "Test Removin
     $containerName = New-LiveTestResourceName
     $cgName = New-LiveTestResourceName
     $cgLocation = "westus"
-    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:debian-12'
+    $container = New-AzContainerInstanceObject -Name $containerName -Image 'mcr.microsoft.com/azure-powershell:debian-12' -RequestCpu 1 -RequestMemoryInGb 1.5
     $null = New-AzContainerGroup -ResourceGroupName $rgName -Name $cgName -Location $cgLocation -Container $container
     $null = Remove-AzContainerGroup -ResourceGroupName $rgName -Name $cgName
     $GetServiceList = Get-AzContainerGroup -ResourceGroupName $rgName


### PR DESCRIPTION
## Description

Fix ContainerInstance live test failures caused by missing CPU/memory resource requests.

### Root Cause
The Azure Container Instance API requires \cpu\ and \memoryInGB\ resource requests since API version \2017-07-01-preview\. All \New-AzContainerInstanceObject\ calls in the live test were missing \-RequestCpu\ and \-RequestMemoryInGb\ parameters, causing \ResourceRequestsNotSpecified\ errors that made \New-AzContainerGroup\ fail silently, which cascaded into assertion failures across all 5 test scenarios.

### Changes
- Added \-RequestCpu 1 -RequestMemoryInGb 1.5\ to all 5 \New-AzContainerInstanceObject\ calls
- Fixed \Assert-AreEqual\ argument order in Update test (expected value should be first parameter)

### Testing
Parameters align with the existing playback tests in \	est/New-AzContainerGroup.Tests.ps1\ which correctly use \-RequestCpu 1 -RequestMemoryInGb 1.5\.