### PR TITLE
Add diagnostics to ValidateFunctionAppNameAvailability for PS 5.1 debugging

### DIFF
--- a/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
+++ b/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
@@ -768,11 +768,39 @@ function ValidateFunctionAppNameAvailability
                               -Exception $exception
     }
 
-    $result = Az.Functions.internal\Test-AzNameAvailability -Type Site @PSBoundParameters
+    $nameCheckError = $null
+    $result = Az.Functions.internal\Test-AzNameAvailability -Type Site @PSBoundParameters -ErrorVariable nameCheckError -ErrorAction SilentlyContinue
+
+    if ($nameCheckError)
+    {
+        Write-Warning "Test-AzNameAvailability call failed with error: $nameCheckError"
+    }
+
+    if (-not $result)
+    {
+        $errorMessage = "Failed to check name availability for function app name '$Name'. The name availability check returned no result."
+        if ($nameCheckError)
+        {
+            $errorMessage += " Error details: $nameCheckError"
+        }
+        $exception = [System.InvalidOperationException]::New($errorMessage)
+        ThrowTerminatingError -ErrorId "FunctionAppNameAvailabilityCheckFailed" `
+                              -ErrorMessage $errorMessage `
+                              -ErrorCategory ([System.Management.Automation.ErrorCategory]::InvalidOperation) `
+                              -Exception $exception
+    }
 
     if (-not $result.NameAvailable)
     {
         $errorMessage = "Function app name '$Name' is not available.  Please try a different name."
+        if ($result.Reason)
+        {
+            $errorMessage += " Reason: $($result.Reason)."
+        }
+        if ($result.Message)
+        {
+            $errorMessage += " Message: $($result.Message)."
+        }
         $exception = [System.InvalidOperationException]::New($errorMessage)
         ThrowTerminatingError -ErrorId "FunctionAppNameIsNotAvailable" `
                               -ErrorMessage $errorMessage `


### PR DESCRIPTION
## Description

The Functions module live tests are failing on PS 5.1 Windows with misleading 'name not available' errors for randomly generated function app names. Investigation shows the AutoRest-generated \Test-AzNameAvailability\ cmdlet is silently returning \\\ on PS 5.1, and the wrapper code misinterprets this as 'name not available'.

## Changes

Improved error handling in \ValidateFunctionAppNameAvailability\ (HelperFunctions.ps1):

- **Capture errors** from \Test-AzNameAvailability\ via \-ErrorVariable\ and \-ErrorAction SilentlyContinue\
- **Log warnings** when the name check call fails
- **Distinguish null result from actual 'not available'** — throws a new \FunctionAppNameAvailabilityCheckFailed\ error with details when the cmdlet returns nothing
- **Include \Reason\ and \Message\** from the API response when the name truly isn't available

## Purpose

This is a diagnostic change to surface the actual root cause of the PS 5.1 live test failures. The next CI run will show the real error instead of the misleading message.