### PR TITLE
Fix Functions live test failures on PS 5.1

### DIFF
--- a/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
+++ b/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
@@ -768,39 +768,11 @@ function ValidateFunctionAppNameAvailability
                               -Exception $exception
     }
 
-    $nameCheckError = $null
-    $result = Az.Functions.internal\Test-AzNameAvailability -Type Site @PSBoundParameters -ErrorVariable nameCheckError -ErrorAction SilentlyContinue
-
-    if ($nameCheckError)
-    {
-        Write-Warning "Test-AzNameAvailability call failed with error: $nameCheckError"
-    }
-
-    if (-not $result)
-    {
-        $errorMessage = "Failed to check name availability for function app name '$Name'. The name availability check returned no result."
-        if ($nameCheckError)
-        {
-            $errorMessage += " Error details: $nameCheckError"
-        }
-        $exception = [System.InvalidOperationException]::New($errorMessage)
-        ThrowTerminatingError -ErrorId "FunctionAppNameAvailabilityCheckFailed" `
-                              -ErrorMessage $errorMessage `
-                              -ErrorCategory ([System.Management.Automation.ErrorCategory]::InvalidOperation) `
-                              -Exception $exception
-    }
+    $result = Az.Functions.internal\Test-AzNameAvailability -Type Site @PSBoundParameters
 
     if (-not $result.NameAvailable)
     {
         $errorMessage = "Function app name '$Name' is not available.  Please try a different name."
-        if ($result.Reason)
-        {
-            $errorMessage += " Reason: $($result.Reason)."
-        }
-        if ($result.Message)
-        {
-            $errorMessage += " Message: $($result.Message)."
-        }
         $exception = [System.InvalidOperationException]::New($errorMessage)
         ThrowTerminatingError -ErrorId "FunctionAppNameIsNotAvailable" `
                               -ErrorMessage $errorMessage `

--- a/src/Functions/LiveTests/Functions.Autorest/TestLiveScenarios.ps1
+++ b/src/Functions/LiveTests/Functions.Autorest/TestLiveScenarios.ps1
@@ -26,7 +26,7 @@ Invoke-LiveTestScenario -Name "Update function app" -Description "Test updating 
     $rgName = $rg.ResourceGroupName
     $saName = New-LiveTestStorageAccountName
     $funcAppName = New-LiveTestResourceName
-    $location = "eastus"
+    $location = "westus"
 
     New-AzStorageAccount -ResourceGroupName $rgName -Name $saName -Location $location -SkuName Standard_LRS
     $funcApp = New-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName -Location $location -FunctionsVersion 4 -StorageAccountName $saName -OSType Windows -Runtime PowerShell -RuntimeVersion 7.4
@@ -49,7 +49,7 @@ Invoke-LiveTestScenario -Name "Remove function app" -Description "Test removing 
     $rgName = $rg.ResourceGroupName
     $saName = New-LiveTestStorageAccountName
     $funcAppName = New-LiveTestResourceName
-    $location = "centralus"
+    $location = "westus"
 
     New-AzStorageAccount -ResourceGroupName $rgName -Name $saName -Location $location -SkuName Standard_LRS
     New-AzFunctionApp -ResourceGroupName $rgName -Name $funcAppName -Location $location -FunctionsVersion 4 -StorageAccountName $saName -OSType Windows -Runtime PowerShell -RuntimeVersion 7.4


### PR DESCRIPTION
## Description
- **Fix GetRuntimeName null key crash**: `FUNCTIONS_WORKER_RUNTIME` may not exist in AppSettingsDictionary, causing `ContainsKey(\)` to throw. Added null check.
- **Add null guard at caller**: Skip runtime entries where runtime name cannot be resolved.
- **Revert diagnostic code**: Remove temporary diagnostics from `ValidateFunctionAppNameAvailability`.
- **Fix TestLiveScenarios**: Use `westus` for all scenarios and fix `IdentityType` → `EnableSystemAssignedIdentity` parameter.

## Root Cause
The `GetRuntimeName` function calls `\.ContainsKey(\)` where `\` can be `\` when `FUNCTIONS_WORKER_RUNTIME` is missing from app settings. This throws: *Value cannot be null. (Parameter 'key')*