### PR TITLE
Remove deprecated PostgreSql from CI selectModuleList

### DIFF
--- a/.ci-config.json
+++ b/.ci-config.json
@@ -327,7 +327,6 @@
     "KeyVault",
     "KubernetesConfiguration",
     "Network",
-    "PostgreSql",
     "Purview",
     "Resources",
     "Storage",


### PR DESCRIPTION
## Description

Remove `PostgreSql` from `.ci-config.json` `selectModuleList`.

`PostgreSql` was deprecated and removed in #29649, but it still remained in the CI-selected module list. When `CIFilterTask` includes `PostgreSql` in the test module set, builds can fail because `src/PostgreSql` no longer exists.

This change keeps CI from selecting a deleted module and prevents those build/test failures.

## Mandatory Checklist

- [ ] General release
- [ ] Public preview
- [ ] Private preview
- [ ] Engineering build
- [x] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change.
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
