### PR TITLE
Onboard HorizonDB to Private Link common cmdlets

### DIFF
--- a/src/Network/Network/ChangeLog.md
+++ b/src/Network/Network/ChangeLog.md
@@ -19,7 +19,7 @@
 --->
 
 ## Upcoming Release
-* Onboarded `Microsoft.HorizonDB/clusters` to Private Link Common Cmdlets.
+* Onboarded `Microsoft.HorizonDB/clusters` to Private Link Common Cmdlets
 
 ## Version 8.0.0
 * Added ChangeSafety Support

--- a/src/Network/Network/ChangeLog.md
+++ b/src/Network/Network/ChangeLog.md
@@ -19,6 +19,7 @@
 --->
 
 ## Upcoming Release
+* Onboarded `Microsoft.HorizonDB/clusters` to Private Link Common Cmdlets.
 
 ## Version 8.0.0
 * Added ChangeSafety Support

--- a/src/Network/Network/PrivateLinkService/PrivateLinkServiceProvider/ProviderConfiguration.cs
+++ b/src/Network/Network/PrivateLinkService/PrivateLinkServiceProvider/ProviderConfiguration.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Commands.Network.PrivateLinkService.PrivateLinkService
             RegisterConfiguration("Microsoft.HealthcareApis/services", "2020-03-30", false, true);
             RegisterConfiguration("Microsoft.HealthDataAIServices/deidServices", "2024-09-20", true, false);
             RegisterConfiguration("Microsoft.HDInsight/clusters", "2018-06-01-preview", true, true);
+            RegisterConfiguration("Microsoft.HorizonDB/clusters", "2026-01-20-preview", true, true);
             RegisterConfiguration("Microsoft.HybridCompute/privateLinkScopes", "2021-05-20", true, true);
             RegisterConfiguration("Microsoft.KubernetesConfiguration/privateLinkScopes", "2024-11-01-preview", true, true);
             RegisterConfiguration("Microsoft.Insights/privateLinkScopes", "2019-10-17-preview", true, true);


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Onboards HorizonDB clusters to the existing generic Az.Network Private Link common cmdlets by registering `Microsoft.HorizonDB/clusters` in the Private Link provider map.

This enables the generic cmdlet flows for HorizonDB cluster resource IDs:

```powershell
Get-AzPrivateLinkResource -PrivateLinkResourceId $clusterId
Get-AzPrivateEndpointConnection -PrivateLinkResourceId $clusterId
Approve-AzPrivateEndpointConnection -ResourceId $privateEndpointConnectionId
Deny-AzPrivateEndpointConnection -ResourceId $privateEndpointConnectionId
Remove-AzPrivateEndpointConnection -ResourceId $privateEndpointConnectionId
```

No new cmdlets, parameters, or markdown help regeneration are needed because this is provider-map-only onboarding for existing common cmdlets.

Validation performed:

- Built Az.Network successfully with `dotnet msbuild build.proj /p:Scope=Network`.
- Verified the built provider map contains `Microsoft.HorizonDB/clusters`, API version `2026-01-20-preview`, `HasConnectionsURI = true`, `SupportGetPrivateLinkResource = true`, and `SupportListPrivateLinkResource = true`.
- Validated read flows against a live HorizonDB cluster:
  - `Get-AzPrivateLinkResource -PrivateLinkResourceId $clusterId`
  - `Get-AzPrivateLinkResource -PrivateLinkResourceId $clusterId -Name DefaultPool`
  - `Get-AzPrivateEndpointConnection -PrivateLinkResourceId $clusterId`
  - `Get-AzPrivateEndpointConnection -ResourceId $privateEndpointConnectionId`
- Validated full disposable private endpoint lifecycle against a live HorizonDB cluster in UK South:
  - Created two manual private endpoints.
  - Approved one private endpoint connection.
  - Rejected one private endpoint connection.
  - Removed both validation private endpoint connections.
  - Confirmed no validation private endpoint connections remained.
  - Deleted and confirmed cleanup of the disposable validation resource group.

Note: HorizonDB approval and rejection complete asynchronously. The generic cmdlet returns immediately after PUT plus immediate GET, so the immediate output can still show `Pending`; follow-up `Get-AzPrivateEndpointConnection` reaches final `Approved` or `Rejected`.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense.
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
