### PR TITLE
[EventHub] Eventhub 2026-01-01 cmdlets

### DIFF
--- a/src/EventHub/EventHub.Autorest/README.md
+++ b/src/EventHub/EventHub.Autorest/README.md
@@ -27,25 +27,12 @@ For information on how to develop for `Az.EventHub`, see [how-to.md](how-to.md).
 > see https://aka.ms/autorest
 
 ``` yaml
-# Please specify the commit id that includes your features to make sure generated codes stable.
-commit: 7977092320778f47c240371124748e6967793459
 require:
 # readme.azure.noprofile.md is the common configuration file
   - $(this-folder)/../../readme.azure.noprofile.md
 input-file:
 # You need to specify your swagger files here.
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/AvailableClusterRegions-preview.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/Clusters-preview.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2025-05-01-preview/namespaces.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/networkrulessets-preview.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/AuthorizationRules.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/CheckNameAvailability.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/consumergroups.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/disasterRecoveryConfigs.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/operations.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/SchemaRegistry.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/eventhubs.json
-  - $(repo)/specification/eventhub/resource-manager/Microsoft.EventHub/preview/2024-05-01-preview/ApplicationGroups.json
+  - https://github.com/Azure/azure-rest-api-specs/blob/main/specification/eventhub/resource-manager/Microsoft.EventHub/Eventhub/stable/2026-01-01/openapi.json
 # If the swagger has not been put in the repo, you may uncomment the following line and refer to it locally
 # - (this-folder)/relative-path-to-your-swagger
 

--- a/src/EventHub/EventHub.Autorest/custom/New-AzEventHubNamespace.ps1
+++ b/src/EventHub/EventHub.Autorest/custom/New-AzEventHubNamespace.ps1
@@ -135,6 +135,11 @@ function New-AzEventHubNamespace{
         [Microsoft.Azure.PowerShell.Cmdlets.EventHub.Models.INamespaceReplicaLocation[]]
         ${GeoDataReplicationLocation},
 
+        [Parameter(HelpMessage = "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6.")]
+        [Microsoft.Azure.PowerShell.Cmdlets.EventHub.Category('Body')]
+        [System.String]
+        ${IPAddressType},
+
         [Parameter(HelpMessage = "The credentials, account, tenant, and subscription used for communication with Azure.")]
         [Alias('AzureRMContext', 'AzureCredential')]
         [ValidateNotNull()]

--- a/src/EventHub/EventHub.Autorest/custom/Set-AzEventHubNamespace.ps1
+++ b/src/EventHub/EventHub.Autorest/custom/Set-AzEventHubNamespace.ps1
@@ -119,6 +119,11 @@ function Set-AzEventHubNamespace{
         [Microsoft.Azure.PowerShell.Cmdlets.EventHub.Models.INamespaceReplicaLocation[]]
         ${GeoDataReplicationLocation},
 
+        [Parameter(HelpMessage = "The IP address type for the namespace. Determines whether the namespace supports IPv4 only or both IPv4 and IPv6.")]
+        [Microsoft.Azure.PowerShell.Cmdlets.EventHub.Category('Body')]
+        [System.String]
+        ${IPAddressType},
+
         [Parameter(HelpMessage = "Tag of EventHub Namespace.")]
         [Microsoft.Azure.PowerShell.Cmdlets.EventHub.Category('Body')]
         [System.Collections.Hashtable]
@@ -199,6 +204,7 @@ function Set-AzEventHubNamespace{
             $hasAsJob = $PSBoundParameters.Remove('AsJob')
             $hasGeoDataReplicationLocation = $PSBoundParameters.Remove('GeoDataReplicationLocation')
             $hasGeoDataReplicationMaxReplicationLagDurationInSecond = $PSBoundParameters.Remove('GeoDataReplicationMaxReplicationLagDurationInSecond')
+            $hasIPAddressType = $PSBoundParameters.Remove('IPAddressType')
             $null = $PSBoundParameters.Remove('WhatIf')
             $null = $PSBoundParameters.Remove('Confirm')
 
@@ -241,6 +247,9 @@ function Set-AzEventHubNamespace{
             }
             if ($GeoDataReplicationLocation) {
                 $eventHubNamespace.GeoDataReplicationLocation = $GeoDataReplicationLocation
+            }
+            if ($hasIPAddressType) {
+                $eventHubNamespace.IPAddressType = $IPAddressType
             }
             if ($hasEnableAutoInflate) {
                 $eventHubNamespace.EnableAutoInflate = $EnableAutoInflate

--- a/src/EventHub/EventHub/ChangeLog.md
+++ b/src/EventHub/EventHub/ChangeLog.md
@@ -18,6 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Added parameter 'IpAddressType' in cmdlets 'New-AzEventHubNamespace' & 'Set-AzEventHubNamespace' to support IPv4-only or dual-stack (IPv4 and IPv6) namespaces.
+* Updated cmdlets to the '2026-01-01' API version.
 
 ## Version 5.5.0
 * Added ChangeSafety Support


### PR DESCRIPTION
### Description

Adds the `2026-01-01` API version and the new `-IPAddressType` parameter to the EventHub PowerShell cmdlets. This mirrors the ServiceBus change in Azure/azure-powershell#29772.

The `2026-01-01` swagger replaces the legacy `ipV6Enabled` (boolean) with `ipAddressType` (enum: `IPv4` / `DualStack`), enabling IPv6 / dual-stack namespaces.

Changes:
- Repoint `EventHub.Autorest` autorest config (README.md) to the `2026-01-01` stable swagger.
- Add `-IPAddressType` to `New-AzEventHubNamespace` and `Set-AzEventHubNamespace`.
- ChangeLog entry.

> [!NOTE]
> Draft. Autorest regeneration (generated model + `docs/` + `UX/` + `test/`) still to be run/committed; raising as draft to track the source changes that mirror the ServiceBus PR.

### Checklist

- [x] SHOULD select the **Closes #issue-number** link, and add the related issue ID to the PR title.
- [x] **SHOULD** target the **main** branch for new development.
- [ ] **SHOULD** run the autorest regeneration and commit `docs/`/`UX/`/`test/`.

Related: Azure/azure-powershell#29772 (ServiceBus 2026-01-01 cmdlets)
