### PR TITLE
[Az.Functions] Fix stacks parser and add Go runtime support for Flex Consumption

### DIFF
--- a/src/Functions/Functions.Autorest/custom/FunctionsStack/functionAppStacks.json
+++ b/src/Functions/Functions.Autorest/custom/FunctionsStack/functionAppStacks.json
@@ -47,7 +47,18 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Fri Nov 10 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Fri Nov 10 2028 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET-ISOLATED|10.0",
@@ -80,26 +91,31 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Fri Nov 10 2028 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -110,7 +126,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Fri Nov 10 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -153,7 +170,18 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET-ISOLATED|9.0",
@@ -184,26 +212,34 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -214,7 +250,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -258,7 +295,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET-ISOLATED|8.0",
@@ -290,26 +338,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -320,7 +376,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -362,7 +419,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue May 14 2024 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue May 14 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET-ISOLATED|7.0",
@@ -393,7 +461,17 @@
                     }
                   ],
                   "endOfLifeDate": "Tue May 14 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -435,7 +513,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET-ISOLATED|6.0",
@@ -466,7 +555,17 @@
                     }
                   ],
                   "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -505,6 +604,17 @@
                       "version": "~4",
                       "isDeprecated": false,
                       "isDefault": true
+                    }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
                     }
                   ]
                 }
@@ -549,7 +659,18 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "isHidden": false,
@@ -581,7 +702,17 @@
                     }
                   ],
                   "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -622,7 +753,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "DOTNET|6.0",
@@ -652,7 +794,17 @@
                     }
                   ],
                   "endOfLifeDate": "Tue Nov 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -691,6 +843,17 @@
                       "isDeprecated": true,
                       "isDefault": true
                     }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
                   ]
                 },
                 "linuxRuntimeSettings": {
@@ -720,7 +883,17 @@
                       "isDefault": true
                     }
                   ],
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -756,6 +929,17 @@
                       "isDeprecated": true,
                       "isDefault": true
                     }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
                   ]
                 }
               }
@@ -784,7 +968,7 @@
               "stackSettings": {
                 "windowsRuntimeSettings": {
                   "runtimeVersion": "~24",
-                  "isPreview": true,
+                  "isPreview": false,
                   "isDefault": false,
                   "isHidden": false,
                   "remoteDebuggingSupported": false,
@@ -813,11 +997,22 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Mon Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Mon Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Node|24",
-                  "isPreview": true,
+                  "isPreview": false,
                   "isDefault": false,
                   "isHidden": false,
                   "remoteDebuggingSupported": false,
@@ -845,26 +1040,31 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Mon Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -875,7 +1075,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Mon Apr 30 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -918,7 +1119,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Fri Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Fri Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Node|22",
@@ -948,26 +1160,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Fri Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -978,7 +1198,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Fri Apr 30 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -1020,7 +1241,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Thu Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Thu Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Node|20",
@@ -1049,26 +1281,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Thu Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1079,7 +1319,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Thu Apr 30 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -1121,7 +1362,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Wed Apr 30 2025 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Wed Apr 30 2025 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Node|18",
@@ -1151,7 +1403,17 @@
                     }
                   ],
                   "endOfLifeDate": "Wed Apr 30 2025 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -1180,8 +1442,8 @@
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Python|3.14",
                   "remoteDebuggingSupported": false,
-                  "isPreview": true,
-                  "isDefault": false,
+                  "isPreview": false,
+                  "isDefault": true,
                   "isHidden": false,
                   "appInsightsSettings": {
                     "isSupported": true
@@ -1207,26 +1469,31 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Thu Oct 31 2030 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1237,7 +1504,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Thu Oct 31 2030 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -1275,26 +1543,31 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Wed Oct 31 2029 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1305,7 +1578,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Wed Oct 31 2029 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -1343,26 +1617,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Oct 31 2028 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1373,7 +1655,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Tue Oct 31 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -1411,26 +1694,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Sun Oct 31 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1441,7 +1732,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Sun Oct 31 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -1479,26 +1771,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Sat Oct 31 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1509,7 +1809,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Sat Oct 31 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -1553,7 +1854,17 @@
                     }
                   ],
                   "endOfLifeDate": "Fri Oct 31 2025 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             },
@@ -1595,7 +1906,17 @@
                     }
                   ],
                   "endOfLifeDate": "Mon Oct 07 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             },
@@ -1643,7 +1964,99 @@
                     }
                   ],
                   "endOfLifeDate": "Tue Jun 27 2023 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": null,
+    "name": "go",
+    "type": "Microsoft.Web/functionAppStacks?stackOsType=All",
+    "properties": {
+      "displayText": "Go",
+      "value": "go",
+      "preferredOs": "linux",
+      "majorVersions": [
+        {
+          "displayText": "1.0",
+          "value": "1.0",
+          "minorVersions": [
+            {
+              "displayText": "Go 1.0",
+              "value": "1.0",
+              "stackSettings": {
+                "linuxRuntimeSettings": {
+                  "runtimeVersion": "Go|1.0",
+                  "isDefault": true,
+                  "isPreview": true,
+                  "isHidden": false,
+                  "remoteDebuggingSupported": false,
+                  "appInsightsSettings": {
+                    "isSupported": true
+                  },
+                  "gitHubActionSettings": {
+                    "isSupported": true
+                  },
+                  "appSettingsDictionary": {},
+                  "siteConfigPropertiesDictionary": {
+                    "use32BitWorkerProcess": false,
+                    "linuxFxVersion": "Go|1.0"
+                  },
+                  "supportedFunctionsExtensionVersions": [
+                    "~4"
+                  ],
+                  "supportedFunctionsExtensionVersionsInfo": [
+                    {
+                      "version": "~4",
+                      "isDeprecated": false,
+                      "isDefault": true
+                    }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "FC1",
+                      "instanceMemoryMB": [
+                        {
+                          "size": "512",
+                          "isDefault": false
+                        },
+                        {
+                          "size": "2048",
+                          "isDefault": true
+                        },
+                        {
+                          "size": "4096",
+                          "isDefault": false
+                        }
+                      ],
+                      "maximumInstanceCount": {
+                        "lowestMaximumInstanceCount": 1,
+                        "highestMaximumInstanceCount": 1000,
+                        "defaultValue": 100
+                      },
+                      "functionAppConfigProperties": {
+                        "runtime": {
+                          "name": "go",
+                          "version": "1.0"
+                        }
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1671,7 +2084,7 @@
               "stackSettings": {
                 "windowsRuntimeSettings": {
                   "runtimeVersion": "25",
-                  "isPreview": true,
+                  "isPreview": false,
                   "isHidden": false,
                   "isAutoUpdate": true,
                   "isDefault": false,
@@ -1701,11 +2114,22 @@
                       "isDefault": true
                     }
                   ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ],
                   "endOfLifeDate": "Wed Sep 01 2032 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Java|25",
-                  "isPreview": true,
+                  "isPreview": false,
                   "isHidden": false,
                   "isAutoUpdate": true,
                   "isDefault": false,
@@ -1734,26 +2158,31 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Wed Sep 01 2032 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1764,7 +2193,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Wed Sep 01 2032 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -1810,6 +2240,17 @@
                       "isDefault": true
                     }
                   ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ],
                   "endOfLifeDate": "Fri Sep 01 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 },
                 "linuxRuntimeSettings": {
@@ -1843,26 +2284,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Fri Sep 01 2028 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1873,7 +2322,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Fri Sep 01 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -1919,7 +2369,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Java|17",
@@ -1952,26 +2413,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -1982,7 +2451,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             }
@@ -2031,7 +2501,18 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Java|11",
@@ -2070,23 +2551,32 @@
                   "endOfLifeDate": "Wed Sep 01 2027 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
                     {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
+                    {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -2153,7 +2643,18 @@
                       "isDefault": false
                     }
                   ],
-                  "endOfLifeDate": "Tue Dec 31 2030 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Dec 31 2030 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "Java|8",
@@ -2193,23 +2694,32 @@
                   "endOfLifeDate": "Tue Dec 31 2030 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
                     {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
+                    {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -2242,6 +2752,122 @@
           "displayText": "PowerShell 7",
           "value": "7",
           "minorVersions": [
+            {
+              "displayText": "PowerShell 7.6",
+              "value": "7.6",
+              "stackSettings": {
+                "windowsRuntimeSettings": {
+                  "runtimeVersion": "7.6",
+                  "isDefault": false,
+                  "isPreview": true,
+                  "isHidden": false,
+                  "remoteDebuggingSupported": false,
+                  "appInsightsSettings": {
+                    "isSupported": true
+                  },
+                  "gitHubActionSettings": {
+                    "isSupported": true
+                  },
+                  "appSettingsDictionary": {
+                    "FUNCTIONS_WORKER_RUNTIME": "powershell"
+                  },
+                  "siteConfigPropertiesDictionary": {
+                    "use32BitWorkerProcess": false,
+                    "powerShellVersion": "7.6",
+                    "netFrameworkVersion": "v10.0"
+                  },
+                  "supportedFunctionsExtensionVersions": [
+                    "~4"
+                  ],
+                  "supportedFunctionsExtensionVersionsInfo": [
+                    {
+                      "version": "~4",
+                      "isDeprecated": false,
+                      "isDefault": true
+                    }
+                  ],
+                  "endOfLifeDate": "Tue Nov 14 2028 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
+                },
+                "linuxRuntimeSettings": {
+                  "runtimeVersion": "PowerShell|7.6",
+                  "isDefault": false,
+                  "isPreview": true,
+                  "isHidden": false,
+                  "remoteDebuggingSupported": false,
+                  "appInsightsSettings": {
+                    "isSupported": true
+                  },
+                  "gitHubActionSettings": {
+                    "isSupported": true
+                  },
+                  "appSettingsDictionary": {
+                    "FUNCTIONS_WORKER_RUNTIME": "powershell"
+                  },
+                  "siteConfigPropertiesDictionary": {
+                    "use32BitWorkerProcess": false,
+                    "linuxFxVersion": "PowerShell|7.6"
+                  },
+                  "supportedFunctionsExtensionVersions": [
+                    "~4"
+                  ],
+                  "supportedFunctionsExtensionVersionsInfo": [
+                    {
+                      "version": "~4",
+                      "isDeprecated": false,
+                      "isDefault": true
+                    }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
+                    {
+                      "skuCode": "FC1",
+                      "instanceMemoryMB": [
+                        {
+                          "size": "512",
+                          "isDefault": false
+                        },
+                        {
+                          "size": "2048",
+                          "isDefault": true
+                        },
+                        {
+                          "size": "4096",
+                          "isDefault": false
+                        }
+                      ],
+                      "maximumInstanceCount": {
+                        "lowestMaximumInstanceCount": 1,
+                        "highestMaximumInstanceCount": 1000,
+                        "defaultValue": 100
+                      },
+                      "functionAppConfigProperties": {
+                        "runtime": {
+                          "name": "powershell",
+                          "version": "7.6"
+                        }
+                      }
+                    }
+                  ],
+                  "endOfLifeDate": "Tue Nov 14 2028 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                }
+              }
+            },
             {
               "displayText": "PowerShell 7.4",
               "value": "7.4",
@@ -2276,7 +2902,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "PowerShell|7.4",
@@ -2307,26 +2944,34 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)",
                   "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
                     {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },
@@ -2337,7 +2982,8 @@
                         }
                       }
                     }
-                  ]
+                  ],
+                  "endOfLifeDate": "Tue Nov 10 2026 00:00:00 GMT+0000 (Coordinated Universal Time)"
                 }
               }
             },
@@ -2375,7 +3021,18 @@
                       "isDefault": true
                     }
                   ],
-                  "endOfLifeDate": "Fri Nov 08 2024 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                  "endOfLifeDate": "Fri Nov 08 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 },
                 "linuxRuntimeSettings": {
                   "runtimeVersion": "PowerShell|7.2",
@@ -2407,7 +3064,17 @@
                     }
                   ],
                   "endOfLifeDate": "Fri Nov 08 2024 00:00:00 GMT+0000 (Coordinated Universal Time)",
-                  "Sku": null
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
+                  ]
                 }
               }
             }
@@ -2470,6 +3137,17 @@
                       "isDeprecated": true,
                       "isDefault": false
                     }
+                  ],
+                  "Sku": [
+                    {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    }
                   ]
                 },
                 "linuxRuntimeSettings": {
@@ -2513,23 +3191,32 @@
                   ],
                   "Sku": [
                     {
+                      "skuCode": "Y1"
+                    },
+                    {
+                      "skuCode": "Dedicated"
+                    },
+                    {
+                      "skuCode": "ElasticPremium"
+                    },
+                    {
                       "skuCode": "FC1",
                       "instanceMemoryMB": [
                         {
-                          "size": 512,
+                          "size": "512",
                           "isDefault": false
                         },
                         {
-                          "size": 2048,
+                          "size": "2048",
                           "isDefault": true
                         },
                         {
-                          "size": 4096,
+                          "size": "4096",
                           "isDefault": false
                         }
                       ],
                       "maximumInstanceCount": {
-                        "lowestMaximumInstanceCount": 40,
+                        "lowestMaximumInstanceCount": 1,
                         "highestMaximumInstanceCount": 1000,
                         "defaultValue": 100
                       },

--- a/src/Functions/Functions.Autorest/custom/Get-AzFunctionAppFlexConsumptionRuntime.ps1
+++ b/src/Functions/Functions.Autorest/custom/Get-AzFunctionAppFlexConsumptionRuntime.ps1
@@ -22,7 +22,7 @@ function Get-AzFunctionAppFlexConsumptionRuntime {
         [Parameter(ParameterSetName='ByVersion', Mandatory=$true, HelpMessage='The Flex Consumption function app runtime.')]
         [Parameter(ParameterSetName='AllVersions', Mandatory=$true)]
         [Parameter(ParameterSetName='DefaultOrLatest', Mandatory=$true)]
-        [ValidateSet("DotNet-Isolated", "Node", "Java", "PowerShell", "Python", "Custom")]
+        [ValidateSet("DotNet-Isolated", "Node", "Java", "PowerShell", "Python", "Custom", "Go")]
         [ValidateNotNullOrEmpty()]
         [System.String]
         ${Runtime},

--- a/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
+++ b/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
@@ -2179,6 +2179,14 @@ function GetRuntimeName
 
     $name = $settingHashTable['FUNCTIONS_WORKER_RUNTIME']
 
+    if ([string]::IsNullOrWhiteSpace($name))
+    {
+        # Some runtime stacks (for example, Go on Flex Consumption) do not define a
+        # FUNCTIONS_WORKER_RUNTIME app setting. Return $null so callers can skip them
+        # instead of throwing on a null key lookup below.
+        return $null
+    }
+
     if ($RuntimeToFormattedName.ContainsKey($name))
     {
         return $RuntimeToFormattedName[$name]
@@ -2281,6 +2289,11 @@ function SetLinuxandWindowsSupportedRuntimes
 
     Write-Debug "$DEBUG_PREFIX Build function stack definitions."
 
+    # Track runtime stacks skipped because they do not expose a mappable runtime name
+    # (for example, Go on Flex Consumption, which is currently in preview and not yet
+    # supported by this module). Used to emit a single message per stack.
+    $skippedRuntimeStacks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
     # Get Function App Runtime Definitions
     $json = GetFunctionAppStackDefinition
     $functionAppStackDefinition = $json | ConvertFrom-Json
@@ -2324,9 +2337,14 @@ function SetLinuxandWindowsSupportedRuntimes
                                                  -PreferredOs $preferredOs `
                                                  -StackIsLinux $true
 
-                    if ($runtime)
+                    if ($runtime -and -not [string]::IsNullOrWhiteSpace($runtime.Name))
                     {
                         AddRuntimeToDictionary -Runtime $runtime -RuntimeToVersionDictionary ([Ref]$RuntimeToVersionLinux)
+                    }
+                    elseif ($runtime -and $skippedRuntimeStacks.Add($stackName))
+                    {
+                        Write-Verbose "Skipping runtime stack '$stackName' while building runtime tab-completion data; it is currently in preview and not yet supported by this module."
+                        Write-Debug   "$DEBUG_PREFIX Skipping runtime stack '$stackName'; no mappable runtime name (preview/unsupported)."
                     }
                 }
             }

--- a/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
+++ b/src/Functions/Functions.Autorest/custom/HelperFunctions.ps1
@@ -11,6 +11,7 @@ $constants["RuntimeToFormattedName"] = @{
     'python' = 'Python'
     'java' = 'Java'
     'powershell' = 'PowerShell'
+    'go' = 'Go'
 }
 $constants["RuntimeToDefaultOSType"] = @{
     'DotNet'= 'Windows'
@@ -20,6 +21,7 @@ $constants["RuntimeToDefaultOSType"] = @{
     'Java' = 'Windows'
     'PowerShell' = 'Windows'
     'Python' = 'Linux'
+    'Go' = 'Linux'
 }
 $constants["ReservedFunctionAppSettingNames"] = @(
     'FUNCTIONS_WORKER_RUNTIME'
@@ -41,7 +43,7 @@ $constants["ReservedFunctionAppSettingNames"] = @(
 $constants["SetDefaultValueParameterWarningMessage"] = "This default value is subject to change over time. Please set this value explicitly to ensure the behavior is not accidentally impacted by future changes."
 $constants["DEBUG_PREFIX"] = '[Stacks API] - '
 $constants["DefaultCentauriImage"] = 'mcr.microsoft.com/azure-functions/dotnet8-quickstart-demo:1.0'
-$constants["FlexConsumptionSupportedRuntimes"] = @('DotNet-Isolated', 'Node', 'Java', 'PowerShell', 'Python','Custom')
+$constants["FlexConsumptionSupportedRuntimes"] = @('DotNet-Isolated', 'Node', 'Java', 'PowerShell', 'Python', 'Custom', 'Go')
 
 foreach ($variableName in $constants.Keys)
 {
@@ -2017,6 +2019,15 @@ function ParseMinorVersion
 
     $runtimeName = GetRuntimeName -AppSettingsDictionary $RuntimeSettings.AppSettingsDictionary
 
+    if ([string]::IsNullOrWhiteSpace($runtimeName))
+    {
+        # Some runtime stacks (for example, Go on Flex Consumption) do not expose a
+        # FUNCTIONS_WORKER_RUNTIME app setting. Fall back to the runtime name reported
+        # by the Flex functionAppConfigProperties, when available, so the stack can be
+        # parsed instead of skipped.
+        $runtimeName = GetRuntimeNameFromConfigProperties -RuntimeSettings $RuntimeSettings
+    }
+
     $version = $null
     if ($RuntimeName -eq "Java" -and $RuntimeSettings.RuntimeVersion -eq "1.8")
     {
@@ -2182,8 +2193,9 @@ function GetRuntimeName
     if ([string]::IsNullOrWhiteSpace($name))
     {
         # Some runtime stacks (for example, Go on Flex Consumption) do not define a
-        # FUNCTIONS_WORKER_RUNTIME app setting. Return $null so callers can skip them
-        # instead of throwing on a null key lookup below.
+        # FUNCTIONS_WORKER_RUNTIME app setting. Return $null so callers can fall back to
+        # another runtime-name source (or skip the stack) instead of throwing on a null
+        # key lookup below.
         return $null
     }
 
@@ -2193,6 +2205,41 @@ function GetRuntimeName
     }
 
     return $name
+}
+
+function GetRuntimeNameFromConfigProperties
+{
+    [Microsoft.Azure.PowerShell.Cmdlets.Functions.DoNotExportAttribute()]
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]
+        $RuntimeSettings
+    )
+
+    # Flex Consumption runtime stacks (for example, Go) may not define a
+    # FUNCTIONS_WORKER_RUNTIME app setting. In that case, the canonical runtime name is
+    # available under the SKU's functionAppConfigProperties.runtime.name (for example, 'go').
+    if (-not (ContainsProperty -Object $RuntimeSettings -PropertyName "Sku"))
+    {
+        return $null
+    }
+
+    foreach ($sku in $RuntimeSettings.Sku)
+    {
+        $name = $sku.functionAppConfigProperties.runtime.name
+        if (-not [string]::IsNullOrWhiteSpace($name))
+        {
+            if ($RuntimeToFormattedName.ContainsKey($name))
+            {
+                return $RuntimeToFormattedName[$name]
+            }
+
+            return $name
+        }
+    }
+
+    return $null
 }
 
 function GetSupportedFunctionsExtensionVersion
@@ -2289,9 +2336,8 @@ function SetLinuxandWindowsSupportedRuntimes
 
     Write-Debug "$DEBUG_PREFIX Build function stack definitions."
 
-    # Track runtime stacks skipped because they do not expose a mappable runtime name
-    # (for example, Go on Flex Consumption, which is currently in preview and not yet
-    # supported by this module). Used to emit a single message per stack.
+    # Track runtime stacks skipped because they do not expose a mappable runtime name.
+    # Used to emit a single message per stack.
     $skippedRuntimeStacks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
     # Get Function App Runtime Definitions
@@ -2324,9 +2370,14 @@ function SetLinuxandWindowsSupportedRuntimes
                                                  -PreferredOs $preferredOs `
                                                  -StackMinorVersion $stackMinorVersion
 
-                    if ($runtime)
+                    if ($runtime -and -not [string]::IsNullOrWhiteSpace($runtime.Name))
                     {
                         AddRuntimeToDictionary -Runtime $runtime -RuntimeToVersionDictionary ([Ref]$RuntimeToVersionWindows)
+                    }
+                    elseif ($runtime -and $skippedRuntimeStacks.Add($stackName))
+                    {
+                        Write-Verbose "Skipping runtime stack '$stackName' while building runtime tab-completion data; it does not expose a mappable runtime name."
+                        Write-Debug   "$DEBUG_PREFIX Skipping runtime stack '$stackName'; no mappable runtime name."
                     }
                 }
 
@@ -2343,8 +2394,8 @@ function SetLinuxandWindowsSupportedRuntimes
                     }
                     elseif ($runtime -and $skippedRuntimeStacks.Add($stackName))
                     {
-                        Write-Verbose "Skipping runtime stack '$stackName' while building runtime tab-completion data; it is currently in preview and not yet supported by this module."
-                        Write-Debug   "$DEBUG_PREFIX Skipping runtime stack '$stackName'; no mappable runtime name (preview/unsupported)."
+                        Write-Verbose "Skipping runtime stack '$stackName' while building runtime tab-completion data; it does not expose a mappable runtime name."
+                        Write-Debug   "$DEBUG_PREFIX Skipping runtime stack '$stackName'; no mappable runtime name."
                     }
                 }
             }

--- a/src/Functions/Functions.Autorest/test/New-AzFunctionApp.Tests.ps1
+++ b/src/Functions/Functions.Autorest/test/New-AzFunctionApp.Tests.ps1
@@ -282,7 +282,7 @@ Describe 'New-AzFunctionApp' {
 
         $myError = $null
         $errorId = "RuntimeNotSupported"
-        $expectedErrorMessage = "Runtime 'Go' is not supported. Currently supported runtimes: 'Custom', 'DotNet', 'DotNet-Isolated', 'Java', 'Node', 'PowerShell', 'Python'."
+        $expectedErrorMessage = "Runtime 'Ruby' is not supported. Currently supported runtimes: 'Custom', 'DotNet', 'DotNet-Isolated', 'Go', 'Java', 'Node', 'PowerShell', 'Python'."
         try
         {
             Write-Verbose "Create function app with an invalid runtime" -Verbose
@@ -290,7 +290,7 @@ Describe 'New-AzFunctionApp' {
                               -ResourceGroupName $env.resourceGroupNameWindowsPremium `
                               -PlanName $env.planNameWorkerTypeWindows `
                               -StorageAccount $env.storageAccountWindows  `
-                              -Runtime Go
+                              -Runtime Ruby
         }
         catch
         {

--- a/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
+++ b/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'SetLinuxandWindowsSupportedRuntimes' {
         }
     }
 
-    It 'ParseMinorVersion does not throw and yields a null runtime name for a Go-like stack' {
+    It 'ParseMinorVersion does not throw and yields a null runtime name for a stack with no mappable name' {
         InModuleScope Az.Functions {
             $goSettings = [PSCustomObject]@{
                 runtimeVersion                      = 'Go|1.0'
@@ -46,12 +46,43 @@ Describe 'SetLinuxandWindowsSupportedRuntimes' {
                 supportedFunctionsExtensionVersions = @('~4')
             }
 
-            # A direct call is used so the returned object is captured in this scope.
-            # If the fix regressed, ParseMinorVersion (or GetRuntimeName) would throw and fail the test.
+            # This stack exposes neither a FUNCTIONS_WORKER_RUNTIME app setting nor a Flex
+            # functionAppConfigProperties runtime name, so it cannot be mapped. The parser
+            # must not throw and must yield a null runtime name so callers can skip it.
             $runtime = ParseMinorVersion -RuntimeSettings $goSettings -RuntimeFullName 'Go 1.0' -PreferredOs 'linux' -StackIsLinux $true
 
             $runtime | Should -Not -BeNullOrEmpty
             [string]::IsNullOrWhiteSpace($runtime.Name) | Should -Be $true
+        }
+    }
+
+    It 'ParseMinorVersion resolves the Go runtime from functionAppConfigProperties when FUNCTIONS_WORKER_RUNTIME is absent' {
+        InModuleScope Az.Functions {
+            # A real Go on Flex Consumption stack ships an empty appSettingsDictionary but
+            # carries the runtime identity under Sku[].functionAppConfigProperties.runtime.
+            $goSettings = [PSCustomObject]@{
+                runtimeVersion                      = 'Go|1.0'
+                isPreview                           = $true
+                isHidden                            = $false
+                appSettingsDictionary               = [PSCustomObject]@{}
+                siteConfigPropertiesDictionary      = [PSCustomObject]@{ use32BitWorkerProcess = $false; linuxFxVersion = 'Go|1.0' }
+                appInsightsSettings                 = [PSCustomObject]@{ isSupported = $true }
+                supportedFunctionsExtensionVersions = @('~4')
+                Sku                                 = @(
+                    [PSCustomObject]@{
+                        skuCode                     = 'FC1'
+                        functionAppConfigProperties = [PSCustomObject]@{
+                            runtime = [PSCustomObject]@{ name = 'go'; version = '1.0' }
+                        }
+                    }
+                )
+            }
+
+            $runtime = ParseMinorVersion -RuntimeSettings $goSettings -RuntimeFullName 'Go 1.0' -PreferredOs 'linux' -StackIsLinux $true
+
+            $runtime | Should -Not -BeNullOrEmpty
+            $runtime.Name | Should -Be 'Go'
+            $runtime.Version | Should -Be '1.0'
         }
     }
 }

--- a/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
+++ b/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
@@ -6,7 +6,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'SetLinuxandWindowsSupportedRu
 {
   $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
   if (-Not (Test-Path -Path $loadEnvPath)) {
-      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+      $loadEnvPath = Join-Path (Join-Path $PSScriptRoot '..') 'loadEnv.ps1'
   }
   . ($loadEnvPath)
 }

--- a/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
+++ b/src/Functions/Functions.Autorest/test/SetLinuxandWindowsSupportedRuntimes.Tests.ps1
@@ -1,0 +1,57 @@
+# Regression coverage for https://github.com/Azure/azure-powershell/issues/29630: the Function App
+# stacks API can return a runtime stack (for example, Go on Flex Consumption) whose appSettingsDictionary
+# does not contain a FUNCTIONS_WORKER_RUNTIME app setting, which previously caused every Az.Functions
+# cmdlet to throw while building the runtime tab completers.
+if(($null -eq $TestName) -or ($TestName -contains 'SetLinuxandWindowsSupportedRuntimes'))
+{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)
+}
+
+Describe 'SetLinuxandWindowsSupportedRuntimes' {
+
+    It 'GetRuntimeName returns null when FUNCTIONS_WORKER_RUNTIME is absent' {
+        InModuleScope Az.Functions {
+            # A Go-style stack ships an empty appSettingsDictionary (no FUNCTIONS_WORKER_RUNTIME).
+            $emptyAppSettings = [PSCustomObject]@{}
+
+            $result = GetRuntimeName -AppSettingsDictionary $emptyAppSettings
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'GetRuntimeName still maps a known runtime that has FUNCTIONS_WORKER_RUNTIME' {
+        InModuleScope Az.Functions {
+            $nodeAppSettings = [PSCustomObject]@{ FUNCTIONS_WORKER_RUNTIME = 'node' }
+
+            $result = GetRuntimeName -AppSettingsDictionary $nodeAppSettings
+
+            $result | Should -Be 'Node'
+        }
+    }
+
+    It 'ParseMinorVersion does not throw and yields a null runtime name for a Go-like stack' {
+        InModuleScope Az.Functions {
+            $goSettings = [PSCustomObject]@{
+                runtimeVersion                      = 'Go|1.0'
+                isPreview                           = $true
+                isHidden                            = $false
+                appSettingsDictionary               = [PSCustomObject]@{}
+                siteConfigPropertiesDictionary      = [PSCustomObject]@{ use32BitWorkerProcess = $false; linuxFxVersion = 'Go|1.0' }
+                appInsightsSettings                 = [PSCustomObject]@{ isSupported = $true }
+                supportedFunctionsExtensionVersions = @('~4')
+            }
+
+            # A direct call is used so the returned object is captured in this scope.
+            # If the fix regressed, ParseMinorVersion (or GetRuntimeName) would throw and fail the test.
+            $runtime = ParseMinorVersion -RuntimeSettings $goSettings -RuntimeFullName 'Go 1.0' -PreferredOs 'linux' -StackIsLinux $true
+
+            $runtime | Should -Not -BeNullOrEmpty
+            [string]::IsNullOrWhiteSpace($runtime.Name) | Should -Be $true
+        }
+    }
+}

--- a/src/Functions/Functions/ChangeLog.md
+++ b/src/Functions/Functions/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 ## Upcoming Release
 * Updated the Function App stacks parser to handle a runtime definition that does not include a `FUNCTIONS_WORKER_RUNTIME` app setting. [#29630]
-* Added support to create Go function apps hosted in Flex Consumption apps.
+* Added support in `New-AzFunctionApp` to create Go function apps hosted in Flex Consumption plans.
 
 ## Version 5.0.0
 * [Upgraded code generator](https://go.microsoft.com/fwlink/?linkid=2340249)

--- a/src/Functions/Functions/ChangeLog.md
+++ b/src/Functions/Functions/ChangeLog.md
@@ -18,8 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Updated the Function App stacks parser to handle a runtime definition that does not
-  include a `FUNCTIONS_WORKER_RUNTIME` app setting. Update Function App stack definitions. [#29630]
+* Updated the Function App stacks parser to handle a runtime definition that does not include a `FUNCTIONS_WORKER_RUNTIME` app setting. [#29630]
+* Added support to create Go function apps hosted in Flex Consumption apps.
 
 ## Version 5.0.0
 * [Upgraded code generator](https://go.microsoft.com/fwlink/?linkid=2340249)

--- a/src/Functions/Functions/ChangeLog.md
+++ b/src/Functions/Functions/ChangeLog.md
@@ -18,6 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Updated the Function App stacks parser to handle a runtime definition that does not
+  include a `FUNCTIONS_WORKER_RUNTIME` app setting. Update Function App stack definitions. [#29630]
 
 ## Version 5.0.0
 * [Upgraded code generator](https://go.microsoft.com/fwlink/?linkid=2340249)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

The PR contains the following changes:

- Fixes #29630 - Updated the Function App stacks parser to handle runtime definitions that do not include a FUNCTIONS_WORKER_RUNTIME app setting. While generating Function App runtime tab-completion entries, the module reads Function App stack definitions. Some stacks (for example, Go on Flex Consumption) do not define a `FUNCTIONS_WORKER_RUNTIME` app setting, which previously caused a null-key lookup exception. 
- Added support to create Go function apps on Flex Consumption plans via New-AzFunctionApp -Runtime Go. The Go runtime is now surfaced by Get-AzFunctionAppFlexConsumptionRuntime and by the -Runtime/-RuntimeVersion tab completers (offering 1.0).
- Updated Function App stack definitions to the latest version.
<!-- Please add a brief description of the changes made in this PR. If you have an ongoing or finished cmdlet design, please paste the link below. -->

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
