### PR TITLE
[SiteRecovery] Forward Private Disk Access parameters in AddDisks/Reprotect/ClusterReprotect

### DIFF
--- a/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
@@ -303,6 +303,19 @@ namespace RecoveryServices.SiteRecovery.Test
             Assert.Null(sdk.RecoveryPublicNetworkAccess);
         }
 
+        [Fact]
+        public void Helper_WithNullDisk_ThrowsArgumentNullException()
+        {
+            // The shared helper is called from three cmdlets that iterate over
+            // a user-supplied collection. A null element in that collection
+            // must surface as a clear ArgumentNullException naming the "disk"
+            // parameter, not a NullReferenceException from the first property
+            // dereference inside the initializer.
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => Utilities.CreateA2AVmManagedDiskInputDetails(null, includeDiskEncryption: false));
+            Assert.Equal("disk", ex.ParamName);
+        }
+
         // --- Per-cmdlet regression tests --------------------------------------
         //
         // The reviewer's concern is that a future edit to any one of the three
@@ -315,11 +328,8 @@ namespace RecoveryServices.SiteRecovery.Test
         public void AddDisks_AzureToAzureReplication_ForwardsPdaFieldsOntoAddDisksInput()
         {
             var disk = BuildAsrConfigWithPda(includeEncryption: false);
-            // AddDisks branches on IsManagedDisk. The property is readonly on
-            // the type (derived from DiskId being an ARM id) but the test
-            // must exercise the managed branch. Use the parameterised
-            // constructor when it exists; otherwise fall back to setting the
-            // backing state via the DiskId shape.
+            // AddDisks branches on IsManagedDisk to select the managed-disk
+            // mapping path that this test targets; force it on explicitly.
             disk.IsManagedDisk = true;
 
             var cmdlet = new AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk
@@ -416,7 +426,6 @@ namespace RecoveryServices.SiteRecovery.Test
                 nameof(Utilities.CreateA2AVmManagedDiskInputDetails),
                 BindingFlags.Public | BindingFlags.Static);
             Assert.NotNull(helper);
-            int helperToken = helper.MetadataToken;
 
             Assembly siteRecoveryAssembly = typeof(Utilities).Assembly;
 
@@ -452,8 +461,9 @@ namespace RecoveryServices.SiteRecovery.Test
                 $"Utilities.CreateA2AVmManagedDiskInputDetails is expected to be called from at " +
                 $"least three sites (AddDisks, Reprotect, ClusterReprotect) — found {callSiteCount}. " +
                 $"Callers detected: {string.Join(", ", offendingCallers)}. A missing call likely " +
-                $"means a cmdlet regressed to an inline mapping and may be silently dropping a " +
-                $"Private Disk Access field. See PR #29824 review comments.");
+                $"means a cmdlet regressed to an inline A2AVmManagedDiskInputDetails initializer " +
+                $"and may be silently dropping a Private Disk Access field; restore the shared " +
+                $"helper call in the affected cmdlet.");
         }
 
         private static bool MethodCallsHelperViaIL(MethodInfo method, MethodInfo helper)

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
@@ -215,6 +217,346 @@ namespace RecoveryServices.SiteRecovery.Test
 
             Assert.Empty(property.GetCustomAttributes<ValidateSetAttribute>(inherit: false));
             Assert.NotEmpty(property.GetCustomAttributes<ValidateNotNullOrEmptyAttribute>(inherit: false));
+        }
+
+        // --- Utilities.CreateA2AVmManagedDiskInputDetails helper ---------------
+        //
+        // The helper centralises the ASRAzuretoAzureDiskReplicationConfig ->
+        // A2AVmManagedDiskInputDetails mapping used by AddDisks, Reprotect
+        // and ClusterReprotect. Tests below pin the contract so a future
+        // refactor cannot silently drop any Private Disk Access field.
+
+        private static ASRAzuretoAzureDiskReplicationConfig BuildAsrConfigWithPda(bool includeEncryption)
+        {
+            var cfg = new ASRAzuretoAzureDiskReplicationConfig
+            {
+                DiskId = "/subscriptions/sub-1/resourceGroups/src-rg/providers/Microsoft.Compute/disks/osdisk-1",
+                RecoveryResourceGroupId = "/subscriptions/sub-1/resourceGroups/target-rg",
+                LogStorageAccountId = "/subscriptions/sub-1/resourceGroups/staging-rg/providers/Microsoft.Storage/storageAccounts/staging",
+                RecoveryReplicaDiskAccountType = "Premium_LRS",
+                RecoveryTargetDiskAccountType = "Premium_LRS",
+                RecoveryDiskEncryptionSetId = "/subscriptions/sub-1/resourceGroups/target-rg/providers/Microsoft.Compute/diskEncryptionSets/des-1",
+                RecoveryNetworkAccessPolicy = "AllowPrivate",
+                RecoveryDiskAccessId = "/subscriptions/sub-1/resourceGroups/net-rg/providers/Microsoft.Compute/diskAccesses/da-1",
+                RecoveryPublicNetworkAccess = "Disabled",
+            };
+            if (includeEncryption)
+            {
+                cfg.DiskEncryptionSecretUrl = "https://kv.vault.azure.net/secrets/secret/abcdef";
+                cfg.DiskEncryptionVaultId = "/subscriptions/sub-1/resourceGroups/kv-rg/providers/Microsoft.KeyVault/vaults/kv";
+            }
+            return cfg;
+        }
+
+        [Fact]
+        public void Helper_WithoutEncryption_ForwardsAllPdaFieldsAndSkipsDiskEncryptionInfo()
+        {
+            var disk = BuildAsrConfigWithPda(includeEncryption: true);
+
+            var sdk = Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: false);
+
+            Assert.Equal(disk.DiskId, sdk.DiskId);
+            Assert.Equal(disk.RecoveryResourceGroupId, sdk.RecoveryResourceGroupId);
+            Assert.Equal(disk.LogStorageAccountId, sdk.PrimaryStagingAzureStorageAccountId);
+            Assert.Equal(disk.RecoveryReplicaDiskAccountType, sdk.RecoveryReplicaDiskAccountType);
+            Assert.Equal(disk.RecoveryTargetDiskAccountType, sdk.RecoveryTargetDiskAccountType);
+            Assert.Equal(disk.RecoveryDiskEncryptionSetId, sdk.RecoveryDiskEncryptionSetId);
+            Assert.Equal("AllowPrivate", sdk.RecoveryNetworkAccessPolicy);
+            Assert.Equal(disk.RecoveryDiskAccessId, sdk.RecoveryDiskAccessId);
+            Assert.Equal("Disabled", sdk.RecoveryPublicNetworkAccess);
+            // AddDisks does not surface encryption inputs, so DiskEncryptionInfo
+            // must remain null even when the config carries encryption fields.
+            Assert.Null(sdk.DiskEncryptionInfo);
+        }
+
+        [Fact]
+        public void Helper_WithEncryption_ForwardsAllPdaFieldsAndPopulatesDiskEncryptionInfo()
+        {
+            var disk = BuildAsrConfigWithPda(includeEncryption: true);
+
+            var sdk = Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: true);
+
+            Assert.Equal("AllowPrivate", sdk.RecoveryNetworkAccessPolicy);
+            Assert.Equal(disk.RecoveryDiskAccessId, sdk.RecoveryDiskAccessId);
+            Assert.Equal("Disabled", sdk.RecoveryPublicNetworkAccess);
+            Assert.NotNull(sdk.DiskEncryptionInfo);
+            Assert.Equal(disk.DiskEncryptionSecretUrl, sdk.DiskEncryptionInfo.DiskEncryptionKeyInfo.SecretIdentifier);
+            Assert.Equal(disk.DiskEncryptionVaultId, sdk.DiskEncryptionInfo.DiskEncryptionKeyInfo.KeyVaultResourceArmId);
+        }
+
+        [Fact]
+        public void Helper_WithNullPdaInputs_PropagatesNullsOnSdk()
+        {
+            // Backward-compat: when PDA fields are not supplied on the ASR
+            // config, the SDK object must carry nulls (so the wire request
+            // does not send empty strings or accidental defaults).
+            var disk = new ASRAzuretoAzureDiskReplicationConfig
+            {
+                DiskId = "/subscriptions/sub-1/disks/osdisk-1",
+                RecoveryResourceGroupId = "/subscriptions/sub-1/resourceGroups/target-rg",
+            };
+
+            var sdk = Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: false);
+
+            Assert.Null(sdk.RecoveryNetworkAccessPolicy);
+            Assert.Null(sdk.RecoveryDiskAccessId);
+            Assert.Null(sdk.RecoveryPublicNetworkAccess);
+        }
+
+        // --- Per-cmdlet regression tests --------------------------------------
+        //
+        // The reviewer's concern is that a future edit to any one of the three
+        // cmdlets could re-introduce an inline mapping that silently drops a
+        // PDA field again. These tests invoke each cmdlet's private mapping
+        // code with an input configuration that carries PDA values and assert
+        // the outgoing SDK object retains them.
+
+        [Fact]
+        public void AddDisks_AzureToAzureReplication_ForwardsPdaFieldsOntoAddDisksInput()
+        {
+            var disk = BuildAsrConfigWithPda(includeEncryption: false);
+            // AddDisks branches on IsManagedDisk. The property is readonly on
+            // the type (derived from DiskId being an ARM id) but the test
+            // must exercise the managed branch. Use the parameterised
+            // constructor when it exists; otherwise fall back to setting the
+            // backing state via the DiskId shape.
+            disk.IsManagedDisk = true;
+
+            var cmdlet = new AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk
+            {
+                AzureToAzureDiskReplicationConfiguration = new[] { disk },
+            };
+
+            var input = new AddDisksInput
+            {
+                Properties = new AddDisksInputProperties
+                {
+                    ProviderSpecificDetails = new AddDisksProviderSpecificInput(),
+                },
+            };
+
+            MethodInfo method = typeof(AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk)
+                .GetMethod("AzureToAzureReplication",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            method.Invoke(cmdlet, new object[] { input });
+
+            var providerSettings = Assert.IsType<A2AAddDisksInput>(input.Properties.ProviderSpecificDetails);
+            var managed = Assert.Single(providerSettings.VMManagedDisks);
+            Assert.Equal("AllowPrivate", managed.RecoveryNetworkAccessPolicy);
+            Assert.Equal(disk.RecoveryDiskAccessId, managed.RecoveryDiskAccessId);
+            Assert.Equal("Disabled", managed.RecoveryPublicNetworkAccess);
+            // AddDisks path does not surface encryption inputs.
+            Assert.Null(managed.DiskEncryptionInfo);
+        }
+
+        [Fact]
+        public void Reprotect_PopulateManagedDiskInputDetails_ForwardsPdaFieldsOntoA2ASwitchInput()
+        {
+            var disk = BuildAsrConfigWithPda(includeEncryption: true);
+
+            var cmdlet = new UpdateAzureRmRecoveryServicesAsrProtection
+            {
+                AzureToAzureDiskReplicationConfiguration = new[] { disk },
+            };
+
+            var a2aSwitchInput = new A2ASwitchProtectionInput
+            {
+                VMDisks = new List<A2AVmDiskInputDetails>(),
+                VMManagedDisks = new List<A2AVmManagedDiskInputDetails>(),
+            };
+
+            MethodInfo method = typeof(UpdateAzureRmRecoveryServicesAsrProtection)
+                .GetMethod("populateManagedDiskInputDetails",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            // With AzureToAzureDiskReplicationConfiguration supplied the "else"
+            // branch runs and does not touch the second parameter, so passing
+            // null is safe.
+            method.Invoke(cmdlet, new object[] { a2aSwitchInput, null });
+
+            var managed = Assert.Single(a2aSwitchInput.VMManagedDisks);
+            Assert.Equal("AllowPrivate", managed.RecoveryNetworkAccessPolicy);
+            Assert.Equal(disk.RecoveryDiskAccessId, managed.RecoveryDiskAccessId);
+            Assert.Equal("Disabled", managed.RecoveryPublicNetworkAccess);
+            Assert.NotNull(managed.DiskEncryptionInfo);
+        }
+
+        [Fact]
+        public void ClusterReprotect_A2ARPCReprotect_DelegatesDiskMappingToSharedHelper()
+        {
+            // The cluster-reprotect mapping is embedded inside the large
+            // A2ARPCReprotect orchestration method and is impractical to
+            // invoke in isolation. Two complementary checks give strong
+            // regression coverage without invoking the orchestration:
+            //
+            //   1. Structural (compiled IL) — the containing type must call
+            //      Utilities.CreateA2AVmManagedDiskInputDetails somewhere. A
+            //      refactor that reverts the cluster site to an inline
+            //      mapping (silently dropping a PDA field) will fail this
+            //      check because only three call sites are expected across
+            //      the whole assembly and removing one drops the count.
+            //   2. Semantic (source) — when the source tree is co-located
+            //      with the test binaries (as in a CI checkout), also
+            //      inspect the source to confirm the call sits inside the
+            //      cluster's per-item disk-config loop.
+            //
+            // The two together make it structurally hard to regress this
+            // path silently.
+
+            AssertHelperIsCalledAtLeastThreeTimesInAssembly();
+            TryAssertClusterSourceCallsHelper();
+        }
+
+        private static void AssertHelperIsCalledAtLeastThreeTimesInAssembly()
+        {
+            MethodInfo helper = typeof(Utilities).GetMethod(
+                nameof(Utilities.CreateA2AVmManagedDiskInputDetails),
+                BindingFlags.Public | BindingFlags.Static);
+            Assert.NotNull(helper);
+            int helperToken = helper.MetadataToken;
+
+            Assembly siteRecoveryAssembly = typeof(Utilities).Assembly;
+
+            int callSiteCount = 0;
+            var offendingCallers = new List<string>();
+
+            foreach (Type type in siteRecoveryAssembly.GetTypes())
+            {
+                MethodInfo[] methods;
+                try
+                {
+                    methods = type.GetMethods(
+                        BindingFlags.Public | BindingFlags.NonPublic |
+                        BindingFlags.Instance | BindingFlags.Static |
+                        BindingFlags.DeclaredOnly);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (MethodInfo m in methods)
+                {
+                    if (MethodCallsHelperViaIL(m, helper))
+                    {
+                        callSiteCount++;
+                        offendingCallers.Add($"{type.FullName}.{m.Name}");
+                    }
+                }
+            }
+
+            Assert.True(callSiteCount >= 3,
+                $"Utilities.CreateA2AVmManagedDiskInputDetails is expected to be called from at " +
+                $"least three sites (AddDisks, Reprotect, ClusterReprotect) — found {callSiteCount}. " +
+                $"Callers detected: {string.Join(", ", offendingCallers)}. A missing call likely " +
+                $"means a cmdlet regressed to an inline mapping and may be silently dropping a " +
+                $"Private Disk Access field. See PR #29824 review comments.");
+        }
+
+        private static bool MethodCallsHelperViaIL(MethodInfo method, MethodInfo helper)
+        {
+            MethodBody body;
+            try
+            {
+                body = method.GetMethodBody();
+            }
+            catch
+            {
+                return false;
+            }
+            if (body == null)
+            {
+                return false;
+            }
+            byte[] il = body.GetILAsByteArray();
+            if (il == null || il.Length < 5)
+            {
+                return false;
+            }
+            Module module = method.Module;
+            Type[] gt = method.DeclaringType != null && method.DeclaringType.IsGenericType
+                ? method.DeclaringType.GetGenericArguments() : null;
+            Type[] gm = method.IsGenericMethod
+                ? method.GetGenericArguments() : null;
+
+            const byte OpCodeCall = 0x28;
+            const byte OpCodeCallvirt = 0x6F;
+
+            for (int i = 0; i <= il.Length - 5; i++)
+            {
+                if (il[i] != OpCodeCall && il[i] != OpCodeCallvirt)
+                {
+                    continue;
+                }
+                int token = BitConverter.ToInt32(il, i + 1);
+                try
+                {
+                    MethodBase resolved = module.ResolveMethod(token, gt, gm);
+                    if (resolved != null &&
+                        resolved.DeclaringType == helper.DeclaringType &&
+                        resolved.Name == helper.Name)
+                    {
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Not every 4-byte payload after 0x28/0x6F is a metadata
+                    // token — most are operands of other opcodes. Skip.
+                }
+            }
+            return false;
+        }
+
+        private static void TryAssertClusterSourceCallsHelper()
+        {
+            // Locate the source file relative to the test assembly. When the
+            // assembly is executed outside a source checkout (e.g. a shipped
+            // NuGet), skip this half of the check silently — the IL-level
+            // assertion above still provides regression coverage.
+            string sourcePath = TryLocateRepoFile(
+                "src", "RecoveryServices", "RecoveryServices.SiteRecovery",
+                "ProtectionCluster",
+                "UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs");
+            if (sourcePath == null)
+            {
+                return;
+            }
+
+            string source = System.IO.File.ReadAllText(sourcePath);
+
+            int loopIdx = source.IndexOf(
+                "foreach (ASRAzuretoAzureDiskReplicationConfig disk in rpi.AzureToAzureDiskReplicationConfiguration)",
+                StringComparison.Ordinal);
+            Assert.True(loopIdx >= 0,
+                "Could not locate the per-item disk-config foreach loop in ClusterProtection " +
+                "source — the source layout has changed. Review this test and adjust the anchor.");
+
+            // Look at the ~1 KB window immediately following the loop header.
+            int windowEnd = Math.Min(source.Length, loopIdx + 1024);
+            string window = source.Substring(loopIdx, windowEnd - loopIdx);
+
+            Assert.Contains("Utilities.CreateA2AVmManagedDiskInputDetails", window);
+        }
+
+        private static string TryLocateRepoFile(params string[] relativeSegments)
+        {
+            string current = System.IO.Path.GetDirectoryName(
+                typeof(A2APrivateDiskAccessUnitTests).Assembly.Location);
+            for (int depth = 0; depth < 10 && current != null; depth++)
+            {
+                string candidate = System.IO.Path.Combine(
+                    new[] { current }.Concat(relativeSegments).ToArray());
+                if (System.IO.File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                current = System.IO.Path.GetDirectoryName(current);
+            }
+            return null;
         }
     }
 }

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery.Test/A2APrivateDiskAccessUnitTests.cs
@@ -430,7 +430,7 @@ namespace RecoveryServices.SiteRecovery.Test
             Assembly siteRecoveryAssembly = typeof(Utilities).Assembly;
 
             int callSiteCount = 0;
-            var offendingCallers = new List<string>();
+            var callersDetected = new List<string>();
 
             foreach (Type type in siteRecoveryAssembly.GetTypes())
             {
@@ -452,7 +452,7 @@ namespace RecoveryServices.SiteRecovery.Test
                     if (MethodCallsHelperViaIL(m, helper))
                     {
                         callSiteCount++;
-                        offendingCallers.Add($"{type.FullName}.{m.Name}");
+                        callersDetected.Add($"{type.FullName}.{m.Name}");
                     }
                 }
             }
@@ -460,7 +460,7 @@ namespace RecoveryServices.SiteRecovery.Test
             Assert.True(callSiteCount >= 3,
                 $"Utilities.CreateA2AVmManagedDiskInputDetails is expected to be called from at " +
                 $"least three sites (AddDisks, Reprotect, ClusterReprotect) — found {callSiteCount}. " +
-                $"Callers detected: {string.Join(", ", offendingCallers)}. A missing call likely " +
+                $"Callers detected: {string.Join(", ", callersDetected)}. A missing call likely " +
                 $"means a cmdlet regressed to an inline A2AVmManagedDiskInputDetails initializer " +
                 $"and may be silently dropping a Private Disk Access field; restore the shared " +
                 $"helper call in the affected cmdlet.");

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ProtectionCluster/UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ProtectionCluster/UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs
@@ -336,7 +336,10 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
                                     disk.DiskEncryptionSecretUrl,
                                     disk.DiskEncryptionVaultId,
                                     disk.KeyEncryptionKeyUrl,
-                                    disk.KeyEncryptionVaultId)
+                                    disk.KeyEncryptionVaultId),
+                                    RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
+                                    RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
+                                    RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
                                 });
                             }
                         }

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ProtectionCluster/UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ProtectionCluster/UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs
@@ -324,23 +324,8 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
                         {
                             foreach (ASRAzuretoAzureDiskReplicationConfig disk in rpi.AzureToAzureDiskReplicationConfiguration)
                             {
-                                diskInput.Add(new A2AVmManagedDiskInputDetails
-                                {
-                                    DiskId = disk.DiskId,
-                                    RecoveryResourceGroupId = disk.RecoveryResourceGroupId,
-                                    RecoveryReplicaDiskAccountType = disk.RecoveryReplicaDiskAccountType,
-                                    RecoveryTargetDiskAccountType = disk.RecoveryTargetDiskAccountType,
-                                    PrimaryStagingAzureStorageAccountId = disk.LogStorageAccountId,
-                                    RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId,
-                                    DiskEncryptionInfo = Utilities.A2AEncryptionDetails(
-                                    disk.DiskEncryptionSecretUrl,
-                                    disk.DiskEncryptionVaultId,
-                                    disk.KeyEncryptionKeyUrl,
-                                    disk.KeyEncryptionVaultId),
-                                    RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
-                                    RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
-                                    RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
-                                });
+                                diskInput.Add(
+                                    Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: true));
                             }
                         }
                         else

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk.cs
@@ -109,7 +109,10 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
                         PrimaryStagingAzureStorageAccountId = disk.LogStorageAccountId,
                         RecoveryReplicaDiskAccountType = disk.RecoveryReplicaDiskAccountType,
                         RecoveryTargetDiskAccountType = disk.RecoveryTargetDiskAccountType,
-                        RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId
+                        RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId,
+                        RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
+                        RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
+                        RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
                     });
                 }
                 else

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk.cs
@@ -102,18 +102,8 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
             {
                 if (disk.IsManagedDisk)
                 {
-                    providerSettings.VMManagedDisks.Add(new A2AVmManagedDiskInputDetails
-                    {
-                        DiskId = disk.DiskId,
-                        RecoveryResourceGroupId = disk.RecoveryResourceGroupId,
-                        PrimaryStagingAzureStorageAccountId = disk.LogStorageAccountId,
-                        RecoveryReplicaDiskAccountType = disk.RecoveryReplicaDiskAccountType,
-                        RecoveryTargetDiskAccountType = disk.RecoveryTargetDiskAccountType,
-                        RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId,
-                        RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
-                        RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
-                        RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
-                    });
+                    providerSettings.VMManagedDisks.Add(
+                        Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: false));
                 }
                 else
                 {

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/UpdateAzureRmRecoveryServicesAsrProtectionDirection.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/UpdateAzureRmRecoveryServicesAsrProtectionDirection.cs
@@ -903,23 +903,8 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
             {
                 foreach (ASRAzuretoAzureDiskReplicationConfig disk in this.AzureToAzureDiskReplicationConfiguration)
                 {
-                    a2aSwitchInput.VMManagedDisks.Add(new A2AVmManagedDiskInputDetails
-                    {
-                        DiskId = disk.DiskId,
-                        RecoveryResourceGroupId = disk.RecoveryResourceGroupId,
-                        RecoveryReplicaDiskAccountType = disk.RecoveryReplicaDiskAccountType,
-                        RecoveryTargetDiskAccountType = disk.RecoveryTargetDiskAccountType,
-                        PrimaryStagingAzureStorageAccountId = disk.LogStorageAccountId,
-                        RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId,
-                        DiskEncryptionInfo = Utilities.A2AEncryptionDetails(
-                            disk.DiskEncryptionSecretUrl,
-                            disk.DiskEncryptionVaultId,
-                            disk.KeyEncryptionKeyUrl,
-                            disk.KeyEncryptionVaultId),
-                        RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
-                        RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
-                        RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
-                    });
+                    a2aSwitchInput.VMManagedDisks.Add(
+                        Utilities.CreateA2AVmManagedDiskInputDetails(disk, includeDiskEncryption: true));
                 }
             }
         }

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/UpdateAzureRmRecoveryServicesAsrProtectionDirection.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/ReplicationProtectedItem/UpdateAzureRmRecoveryServicesAsrProtectionDirection.cs
@@ -915,7 +915,10 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
                             disk.DiskEncryptionSecretUrl,
                             disk.DiskEncryptionVaultId,
                             disk.KeyEncryptionKeyUrl,
-                            disk.KeyEncryptionVaultId)
+                            disk.KeyEncryptionVaultId),
+                        RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
+                        RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
+                        RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess
                     });
                 }
             }

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/Utilities/Utilities.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/Utilities/Utilities.cs
@@ -627,6 +627,52 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
         }
 
         /// <summary>
+        /// Builds an <see cref="A2AVmManagedDiskInputDetails"/> from the PS
+        /// disk-replication configuration used by AddDisks / Reprotect /
+        /// ClusterReprotect. The mapping was previously duplicated inline in
+        /// three cmdlets; centralising it prevents fields (notably Private
+        /// Disk Access properties: <c>RecoveryNetworkAccessPolicy</c>,
+        /// <c>RecoveryDiskAccessId</c>, <c>RecoveryPublicNetworkAccess</c>)
+        /// from being silently dropped in one call site while being forwarded
+        /// in another.
+        /// </summary>
+        /// <param name="disk">The PS disk-replication configuration.</param>
+        /// <param name="includeDiskEncryption">
+        /// When <c>true</c>, populates <see cref="A2AVmManagedDiskInputDetails.DiskEncryptionInfo"/>
+        /// from the disk-encryption fields on <paramref name="disk"/> (used by the
+        /// reprotect / cluster-reprotect paths). AddDisks does not surface encryption
+        /// inputs and passes <c>false</c>.
+        /// </param>
+        public static A2AVmManagedDiskInputDetails CreateA2AVmManagedDiskInputDetails(
+            ASRAzuretoAzureDiskReplicationConfig disk,
+            bool includeDiskEncryption)
+        {
+            var details = new A2AVmManagedDiskInputDetails
+            {
+                DiskId = disk.DiskId,
+                RecoveryResourceGroupId = disk.RecoveryResourceGroupId,
+                PrimaryStagingAzureStorageAccountId = disk.LogStorageAccountId,
+                RecoveryReplicaDiskAccountType = disk.RecoveryReplicaDiskAccountType,
+                RecoveryTargetDiskAccountType = disk.RecoveryTargetDiskAccountType,
+                RecoveryDiskEncryptionSetId = disk.RecoveryDiskEncryptionSetId,
+                RecoveryNetworkAccessPolicy = disk.RecoveryNetworkAccessPolicy,
+                RecoveryDiskAccessId = disk.RecoveryDiskAccessId,
+                RecoveryPublicNetworkAccess = disk.RecoveryPublicNetworkAccess,
+            };
+
+            if (includeDiskEncryption)
+            {
+                details.DiskEncryptionInfo = A2AEncryptionDetails(
+                    disk.DiskEncryptionSecretUrl,
+                    disk.DiskEncryptionVaultId,
+                    disk.KeyEncryptionKeyUrl,
+                    disk.KeyEncryptionVaultId);
+            }
+
+            return details;
+        }
+
+        /// <summary>
         ///    Get the cluster recovery point.
         /// </summary>
         /// <param name="recoveryServicesClient">Recovery Service Client.</param>

--- a/src/RecoveryServices/RecoveryServices.SiteRecovery/Utilities/Utilities.cs
+++ b/src/RecoveryServices/RecoveryServices.SiteRecovery/Utilities/Utilities.cs
@@ -647,6 +647,11 @@ namespace Microsoft.Azure.Commands.RecoveryServices.SiteRecovery
             ASRAzuretoAzureDiskReplicationConfig disk,
             bool includeDiskEncryption)
         {
+            if (disk == null)
+            {
+                throw new ArgumentNullException(nameof(disk));
+            }
+
             var details = new A2AVmManagedDiskInputDetails
             {
                 DiskId = disk.DiskId,

--- a/src/RecoveryServices/RecoveryServices/ChangeLog.md
+++ b/src/RecoveryServices/RecoveryServices/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 
 ## Upcoming Release
+* Fixed Private Disk Access parameters being silently dropped in Azure-to-Azure managed-disk cmdlets: `Add-AzRecoveryServicesAsrReplicationProtectedItemDisk`, `Update-AzRecoveryServicesAsrProtectionDirection` (reprotect) and `Update-AzRecoveryServicesAsrClusterProtectionDirection` (cluster reprotect) now forward `RecoveryNetworkAccessPolicy`, `RecoveryDiskAccessId` and `RecoveryPublicNetworkAccess` from the disk replication configuration to the AddDisks / Reprotect REST calls.
 
 ## Version 7.13.0
 * Updated `System.Security.Cryptography.Cng` dependency from `4.4.0` to `5.0.0`.

--- a/src/RecoveryServices/RecoveryServices/ChangeLog.md
+++ b/src/RecoveryServices/RecoveryServices/ChangeLog.md
@@ -19,7 +19,10 @@
 -->
 
 ## Upcoming Release
-* Fixed Private Disk Access parameters being silently dropped in Azure-to-Azure managed-disk cmdlets: `Add-AzRecoveryServicesAsrReplicationProtectedItemDisk`, `Update-AzRecoveryServicesAsrProtectionDirection` (reprotect) and `Update-AzRecoveryServicesAsrClusterProtectionDirection` (cluster reprotect) now forward `RecoveryNetworkAccessPolicy`, `RecoveryDiskAccessId` and `RecoveryPublicNetworkAccess` from the disk replication configuration to the AddDisks / Reprotect REST calls.
+* Fixed Private Disk Access parameters being silently dropped when adding disks to, reprotecting, or cluster-reprotecting an Azure-to-Azure managed-disk replication
+    - `Add-AzRecoveryServicesAsrReplicationProtectedItemDisk` now honors `-RecoveryNetworkAccessPolicy`, `-RecoveryDiskAccessId` and `-RecoveryPublicNetworkAccess` supplied on the disk replication configuration
+    - `Update-AzRecoveryServicesAsrProtectionDirection` (reprotect) forwards the same three fields on the switch-protection call
+    - `Update-AzRecoveryServicesAsrClusterProtectionDirection` (cluster reprotect) forwards the same three fields on the cluster switch-protection call
 
 ## Version 7.13.0
 * Updated `System.Security.Cryptography.Cng` dependency from `4.4.0` to `5.0.0`.


### PR DESCRIPTION
## Description

Fixes a silent regression in **Az.RecoveryServices 7.13.0** where three Azure-to-Azure managed-disk cmdlets built `A2AVmManagedDiskInputDetails` object initializers that omitted the three Private Disk Access properties from the disk replication configuration:

| Cmdlet | Path in code | Wire operation |
|---|---|---|
| `Add-AzRecoveryServicesAsrReplicationProtectedItemDisk` | `ReplicationProtectedItem/AddAzureRmRecoveryServicesAsrReplicationProtectedItemDisk.cs` | `ReplicationProtectedItems - AddDisks` (`A2AAddDisksInput`) |
| `Update-AzRecoveryServicesAsrProtectionDirection` (A2A) | `ReplicationProtectedItem/UpdateAzureRmRecoveryServicesAsrProtectionDirection.cs` | `ReplicationProtectedItems - Reprotect` (`A2ASwitchProtectionInput`) |
| `Update-AzRecoveryServicesAsrClusterProtectionDirection` (A2A) | `ProtectionCluster/UpdateAzureRmRecoveryServicesAsrClusterProtectionDirection.cs` | `ReplicationProtectionClusters - Reprotect` (`A2AProtectedItemDetail`) |

Only the enable-protection cmdlet forwarded `RecoveryNetworkAccessPolicy`, `RecoveryDiskAccessId` and `RecoveryPublicNetworkAccess` even though the REST spec (`stable/2026-02-01`) accepts them on all four A2A operations that consume `A2AVmManagedDiskInputDetails` and the generated SDK model already exposes the setters.

## Customer impact

**None - the Private Disk Access (PDA) feature has not shipped yet**, so no customer is affected by this drop. This fix lands the correct behavior ahead of the feature being enabled end-to-end.

For reference, once the feature ships the affected paths would be: PowerShell customers who set the PDA parameters via `New-AzRecoveryServicesAsrAzureToAzureDiskReplicationConfig` and then called:

- `Add-AzRecoveryServicesAsrReplicationProtectedItemDisk` (adding a new disk to a protected VM), or
- `Update-AzRecoveryServicesAsrProtectionDirection` (reprotect after failover), or
- `Update-AzRecoveryServicesAsrClusterProtectionDirection` (cluster reprotect)

...would have their `RecoveryNetworkAccessPolicy` / `RecoveryDiskAccessId` / `RecoveryPublicNetworkAccess` **silently dropped** on the wire, creating replica disks with the default `AllowAll` / public-enabled network access policy.

## Fix

Forward the three PDA fields from each user-supplied `ASRAzuretoAzureDiskReplicationConfig` into the corresponding `A2AVmManagedDiskInputDetails` object initializer in all three cmdlets, matching the existing pattern in `New-AzRecoveryServicesAsrReplicationProtectedItem`. The auto-populate initializers used when the user does not pass a per-disk configuration are intentionally left unchanged - server-side inheritance handles those cases.

## Verification

- `dotnet build src/RecoveryServices/RecoveryServices.SiteRecovery/RecoveryServices.SiteRecovery.csproj -c Debug` -> 0 warnings, 0 errors.
- REST spec cross-check on `specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/stable/2026-02-01/service.json` confirms `A2AVmManagedDiskInputDetails` carries the three PDA properties and is referenced by `A2AAddDisksInput`, `A2AEnableProtectionInput`, `A2ASwitchProtectionInput` and `A2AProtectedItemDetail`.
- Follow-up: unit tests for the three cmdlets do not currently exercise the PDA fields; adding them will be a separate change.

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/Azure/azure-powershell/blob/main/CONTRIBUTING.md), and the PR I'm opening is not autogenerated.
- [x] I have run the `platyPS` cmdlet `Update-MarkdownHelpModule` on the module's `help` folder. -- N/A (no cmdlet parameter surface changes; only body fields being forwarded).
- [x] Change is generally covered by a changelog entry in the module's `ChangeLog.md` under `## Upcoming Release`.
- [x] Change is backwards compatible.
