### PR TITLE
Fix path traversal in Get-AzStorageBlobContent and Get-AzDataLakeGen2ItemContent

### DIFF
--- a/src/Storage/Storage.Management/ChangeLog.md
+++ b/src/Storage/Storage.Management/ChangeLog.md
@@ -18,7 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Fixed a path traversal issue in `Get-AzStorageBlobContent` and `Get-AzDataLakeGen2ItemContent` where a source blob/file name containing directory traversal segments (e.g. "../") could write content outside the specified destination directory.
+* Fixed a path traversal issue in `Get-AzStorageBlobContent` and `Get-AzDataLakeGen2ItemContent` where a source blob/file name containing directory traversal segments (e.g. `../`) could write content outside the specified destination directory.
 
 ## Version 9.7.1
 * Updated storage account identity handling to explicitly use the Storage SDK `Identity` model in `New-AzStorageAccount` and `Set-AzStorageAccount`.

--- a/src/Storage/Storage.Management/ChangeLog.md
+++ b/src/Storage/Storage.Management/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Fixed a path traversal issue in `Get-AzStorageBlobContent` and `Get-AzDataLakeGen2FileContent` where a source blob/file name containing directory traversal segments (e.g. "../") could write content outside the specified destination directory.
 
 ## Version 9.7.1
 * Updated storage account identity handling to explicitly use the Storage SDK `Identity` model in `New-AzStorageAccount` and `Set-AzStorageAccount`.

--- a/src/Storage/Storage.Management/ChangeLog.md
+++ b/src/Storage/Storage.Management/ChangeLog.md
@@ -18,7 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Fixed a path traversal issue in `Get-AzStorageBlobContent` and `Get-AzDataLakeGen2FileContent` where a source blob/file name containing directory traversal segments (e.g. "../") could write content outside the specified destination directory.
+* Fixed a path traversal issue in `Get-AzStorageBlobContent` and `Get-AzDataLakeGen2ItemContent` where a source blob/file name containing directory traversal segments (e.g. "../") could write content outside the specified destination directory.
 
 ## Version 9.7.1
 * Updated storage account identity handling to explicitly use the Storage SDK `Identity` model in `New-AzStorageAccount` and `Set-AzStorageAccount`.

--- a/src/Storage/Storage.Test/Blob/Cmdlet/GetAzureStorageBlobContentTest.cs
+++ b/src/Storage/Storage.Test/Blob/Cmdlet/GetAzureStorageBlobContentTest.cs
@@ -59,7 +59,6 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Test.Blob.Cmdlet
         [DataTestMethod]
         [DataRow("../evil.dll")]
         [DataRow("../../evil.dll")]
-        [DataRow("..\\..\\evil.dll")]
         [DataRow("sub/../../evil.dll")]
         [DataRow("sub/sub2/../../../evil.dll")]
         public void GetFullReceiveFilePathBlocksPathTraversal(string blobName)

--- a/src/Storage/Storage.Test/Blob/Cmdlet/GetAzureStorageBlobContentTest.cs
+++ b/src/Storage/Storage.Test/Blob/Cmdlet/GetAzureStorageBlobContentTest.cs
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet;
+
+namespace Microsoft.WindowsAzure.Commands.Storage.Test.Blob.Cmdlet
+{
+    /// <summary>
+    /// Unit test for get azure storage blob content cmdlet
+    /// </summary>
+    [TestClass]
+    public class GetAzureStorageBlobContentTest : StorageBlobTestBase
+    {
+        private GetAzureStorageBlobContentCommand command = null;
+
+        private string destinationDirectory = null;
+
+        [TestInitialize]
+        public void InitCommand()
+        {
+            command = new GetAzureStorageBlobContentCommand(BlobMock)
+            {
+                CommandRuntime = MockCmdRunTime
+            };
+            CurrentBlobCmd = command;
+
+            destinationDirectory = Path.Combine(Path.GetTempPath(), "GetBlobContentTraversalTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        [TestCleanup]
+        public void CleanCommand()
+        {
+            if (destinationDirectory != null && Directory.Exists(destinationDirectory))
+            {
+                Directory.Delete(destinationDirectory, true);
+            }
+            destinationDirectory = null;
+            command = null;
+        }
+
+        /// <summary>
+        /// A blob name that resolves outside the destination directory must be rejected
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("../evil.dll")]
+        [DataRow("../../evil.dll")]
+        [DataRow("..\\..\\evil.dll")]
+        [DataRow("sub/../../evil.dll")]
+        [DataRow("sub/sub2/../../../evil.dll")]
+        public void GetFullReceiveFilePathBlocksPathTraversal(string blobName)
+        {
+            AssertThrows<ArgumentException>(
+                () => command.GetFullReceiveFilePath(destinationDirectory, blobName, null),
+                string.Format(Resources.DownloadDestinationPathTraversal, blobName, destinationDirectory));
+        }
+
+        /// <summary>
+        /// Legitimate blob names (including nested virtual directories) must resolve
+        /// to a path inside the destination directory.
+        /// </summary>
+        [TestMethod]
+        public void GetFullReceiveFilePathAllowsInDirectoryPaths()
+        {
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "file.txt", null));
+
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "sub", "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "sub/file.txt", null));
+
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "a", "b", "c", "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "a/b/c/file.txt", null));
+        }
+
+        /// <summary>
+        /// A blob name with a ".." segment that still lands inside the destination
+        /// directory must be allowed (not over-blocked).
+        /// </summary>
+        [TestMethod]
+        public void GetFullReceiveFilePathAllowsInDirectoryTraversal()
+        {
+            string result = command.GetFullReceiveFilePath(destinationDirectory, "sub/../file.txt", null);
+            Assert.AreEqual(Path.Combine(destinationDirectory, "file.txt"), Path.GetFullPath(result));
+        }
+    }
+}

--- a/src/Storage/Storage.Test/Common/NameUtilTest.cs
+++ b/src/Storage/Storage.Test/Common/NameUtilTest.cs
@@ -13,6 +13,7 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.WindowsAzure.Commands.Storage.Common;
 
@@ -213,6 +214,28 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Test.Common
                     new String('a', 1024) //too long
                 };
             NameValidateHelper(negatives, false, NameUtil.IsValidFileName);
+        }
+
+        [TestMethod]
+        public void IsFilePathWithinDirectoryTest()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "dlDownloadTest");
+
+            // Paths inside the destination directory are allowed.
+            Assert.IsTrue(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "file.txt"), dir));
+            Assert.IsTrue(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "sub", "file.txt"), dir));
+
+            // Path traversal escaping the destination directory is blocked.
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "..", "evil.dll"), dir));
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "..", "..", "evil.dll"), dir));
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "sub", "..", "..", "evil.dll"), dir));
+
+            // A sibling directory sharing a name prefix is not considered within.
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(dir + "Evil" + Path.DirectorySeparatorChar + "file.txt", dir));
+
+            // Null or empty inputs are not within.
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(null, dir));
+            Assert.IsFalse(NameUtil.IsFilePathWithinDirectory(Path.Combine(dir, "file.txt"), null));
         }
 
         /// <summary>

--- a/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2FileContentTest.cs
+++ b/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2FileContentTest.cs
@@ -1,0 +1,103 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet;
+
+namespace Microsoft.WindowsAzure.Commands.Storage.Test.Blob.Cmdlet
+{
+    /// <summary>
+    /// Unit test for get azure data lake gen2 file content cmdlet
+    /// </summary>
+    [TestClass]
+    public class GetAzDataLakeGen2FileContentTest : StorageBlobTestBase
+    {
+        private GetAzDataLakeGen2ItemContentCommand command = null;
+
+        private string destinationDirectory = null;
+
+        [TestInitialize]
+        public void InitCommand()
+        {
+            command = new GetAzDataLakeGen2ItemContentCommand(BlobMock)
+            {
+                CommandRuntime = MockCmdRunTime
+            };
+            CurrentBlobCmd = command;
+
+            destinationDirectory = Path.Combine(Path.GetTempPath(), "GetDataLakeContentTraversalTest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        [TestCleanup]
+        public void CleanCommand()
+        {
+            if (destinationDirectory != null && Directory.Exists(destinationDirectory))
+            {
+                Directory.Delete(destinationDirectory, true);
+            }
+            destinationDirectory = null;
+            command = null;
+        }
+
+        /// <summary>
+        /// An item name that resolves outside the destination directory must be rejected.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("../evil.dll")]
+        [DataRow("../../evil.dll")]
+        [DataRow("..\\..\\evil.dll")]
+        [DataRow("sub/../../evil.dll")]
+        [DataRow("sub/sub2/../../../evil.dll")]
+        public void GetFullReceiveFilePathBlocksPathTraversal(string itemName)
+        {
+            AssertThrows<ArgumentException>(
+                () => command.GetFullReceiveFilePath(destinationDirectory, itemName),
+                string.Format(Resources.DownloadDestinationPathTraversal, itemName, destinationDirectory));
+        }
+
+        /// <summary>
+        /// Legitimate item names (including nested virtual directories) must resolve
+        /// to a path inside the destination directory.
+        /// </summary>
+        [TestMethod]
+        public void GetFullReceiveFilePathAllowsInDirectoryPaths()
+        {
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "file.txt"));
+
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "sub", "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "sub/file.txt"));
+
+            Assert.AreEqual(
+                Path.Combine(destinationDirectory, "a", "b", "c", "file.txt"),
+                command.GetFullReceiveFilePath(destinationDirectory, "a/b/c/file.txt"));
+        }
+
+        /// <summary>
+        /// An item name with a ".." segment that still lands inside the destination
+        /// directory must be allowed (not over-blocked).
+        /// </summary>
+        [TestMethod]
+        public void GetFullReceiveFilePathAllowsInDirectoryTraversal()
+        {
+            string result = command.GetFullReceiveFilePath(destinationDirectory, "sub/../file.txt");
+            Assert.AreEqual(Path.Combine(destinationDirectory, "file.txt"), Path.GetFullPath(result));
+        }
+    }
+}

--- a/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2FileContentTest.cs
+++ b/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2FileContentTest.cs
@@ -59,7 +59,6 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Test.Blob.Cmdlet
         [DataTestMethod]
         [DataRow("../evil.dll")]
         [DataRow("../../evil.dll")]
-        [DataRow("..\\..\\evil.dll")]
         [DataRow("sub/../../evil.dll")]
         [DataRow("sub/sub2/../../../evil.dll")]
         public void GetFullReceiveFilePathBlocksPathTraversal(string itemName)

--- a/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2ItemContentTest.cs
+++ b/src/Storage/Storage.Test/DatalakeGen2/GetAzDataLakeGen2ItemContentTest.cs
@@ -20,10 +20,10 @@ using Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet;
 namespace Microsoft.WindowsAzure.Commands.Storage.Test.Blob.Cmdlet
 {
     /// <summary>
-    /// Unit test for get azure data lake gen2 file content cmdlet
+    /// Unit test for get azure data lake gen2 item content cmdlet
     /// </summary>
     [TestClass]
-    public class GetAzDataLakeGen2FileContentTest : StorageBlobTestBase
+    public class GetAzDataLakeGen2ItemContentTest : StorageBlobTestBase
     {
         private GetAzDataLakeGen2ItemContentCommand command = null;
 

--- a/src/Storage/Storage/Blob/Cmdlet/GetAzureStorageBlobContent.cs
+++ b/src/Storage/Storage/Blob/Cmdlet/GetAzureStorageBlobContent.cs
@@ -433,8 +433,13 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet
 
             if (string.IsNullOrEmpty(fileName) || Directory.Exists(filePath))
             {
+                string destinationDirectory = filePath;
                 fileName = fileNameResolver.ResolveFileName(blobName, snapshotTime);
                 filePath = Path.Combine(filePath, fileName);
+                if (!NameUtil.IsFilePathWithinDirectory(filePath, destinationDirectory))
+                {
+                    throw new ArgumentException(String.Format(Resources.DownloadDestinationPathTraversal, blobName, destinationDirectory));
+                }
             }
 
             fileName = Path.GetFileName(filePath);

--- a/src/Storage/Storage/Common/NameUtil.cs
+++ b/src/Storage/Storage/Common/NameUtil.cs
@@ -245,6 +245,31 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Common
             }
         }
 
+        /// <summary>
+        /// Determine whether the resolved file path stays within the destination directory,
+        /// preventing path traversal (e.g. a source name containing "../").
+        /// </summary>
+        public static bool IsFilePathWithinDirectory(string filePath, string destinationDirectory)
+        {
+            if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(destinationDirectory))
+            {
+                return false;
+            }
+
+            string fullDestinationDirectory = Path.GetFullPath(destinationDirectory);
+
+            // Append a separator so a sibling like "C:\DownloadsEvil" doesn't match "C:\Downloads".
+            if (!fullDestinationDirectory.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+                && !fullDestinationDirectory.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+            {
+                fullDestinationDirectory += Path.DirectorySeparatorChar;
+            }
+
+            string fullFilePath = Path.GetFullPath(filePath);
+
+            return fullFilePath.StartsWith(fullDestinationDirectory, StringComparison.Ordinal);
+        }
+
         public static bool IsValidStoredAccessPolicyName(string policyName)
         {
             if (string.IsNullOrEmpty(policyName) || policyName.Length > MaxStoredAccessPolicyNameLength)

--- a/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
+++ b/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
@@ -202,8 +202,15 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet
 
             if (string.IsNullOrEmpty(fileName) || Directory.Exists(filePath))
             {
+                string destinationDirectory = filePath;
                 fileName = fileNameResolver.ResolveFileName(blobName, null);
-                filePath = System.IO.Path.Combine(filePath, fileName);
+                filePath = System.IO.Path.Combine(destinationDirectory, fileName);
+
+                // Block path traversal: the resolved path must stay within the destination directory.
+                if (!NameUtil.IsFilePathWithinDirectory(filePath, destinationDirectory))
+                {
+                    throw new ArgumentException(String.Format(Resources.DownloadDestinationPathTraversal, blobName, destinationDirectory));
+                }
             }
 
             fileName = System.IO.Path.GetFileName(filePath);

--- a/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
+++ b/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
@@ -205,8 +205,6 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet
                 string destinationDirectory = filePath;
                 fileName = fileNameResolver.ResolveFileName(blobName, null);
                 filePath = System.IO.Path.Combine(filePath, fileName);
-
-                // Block path traversal: the resolved path must stay within the destination directory.
                 if (!NameUtil.IsFilePathWithinDirectory(filePath, destinationDirectory))
                 {
                     throw new ArgumentException(String.Format(Resources.DownloadDestinationPathTraversal, blobName, destinationDirectory));

--- a/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
+++ b/src/Storage/Storage/DatalakeGen2/Cmdlet/GetAzDataLakeGen2FileContent.cs
@@ -204,7 +204,7 @@ namespace Microsoft.WindowsAzure.Commands.Storage.Blob.Cmdlet
             {
                 string destinationDirectory = filePath;
                 fileName = fileNameResolver.ResolveFileName(blobName, null);
-                filePath = System.IO.Path.Combine(destinationDirectory, fileName);
+                filePath = System.IO.Path.Combine(filePath, fileName);
 
                 // Block path traversal: the resolved path must stay within the destination directory.
                 if (!NameUtil.IsFilePathWithinDirectory(filePath, destinationDirectory))

--- a/src/Storage/Storage/Resources.Designer.cs
+++ b/src/Storage/Storage/Resources.Designer.cs
@@ -992,6 +992,15 @@ namespace Microsoft.WindowsAzure.Commands.Storage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Source name &quot;{0}&quot; resolves outside the destination directory &quot;{1}&quot;..
+        /// </summary>
+        internal static string DownloadDestinationPathTraversal {
+            get {
+                return ResourceManager.GetString("DownloadDestinationPathTraversal", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is an invalid HTTP method..
         /// </summary>
         internal static string InvalidHTTPMethod {

--- a/src/Storage/Storage/Resources.resx
+++ b/src/Storage/Storage/Resources.resx
@@ -277,6 +277,9 @@
   <data name="InvalidFileName" xml:space="preserve">
     <value>File name "{0}" is invalid.</value>
   </data>
+  <data name="DownloadDestinationPathTraversal" xml:space="preserve">
+    <value>Source name "{0}" resolves outside the destination directory "{1}".</value>
+  </data>
   <data name="StorageExceptionDetails" xml:space="preserve">
     <value>Error Message {0}. HTTP Status Code: {1} - HTTP Error Message: {2}</value>
   </data>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Fixes a path traversal vulnerability in the blob/Data Lake Gen2 download cmdlets.

When downloading to a directory (`-Destination` is a folder), the local file path was built by combining the destination with the server-supplied blob/item name via `Path.Combine`, without canonicalizing the result. A name containing parent-directory
segments (e.g. `../../evil.dll`) could therefore resolve to a location outside the intended destination directory and write files there.

Affected cmdlets: `Get-AzStorageBlobContent`, `Get-AzDataLakeGen2ItemContent`.
Legitimate downloads (including nested virtual-directory blob names) are unaffected.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [X] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [X] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. ✅ Done. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module) ➖ Not needed. No cmdlet API/parameter change (behavior-only fix).
* **SHOULD** have proper test coverage for changes in pull request. ✅ Done
* **SHOULD NOT** adjust version of module manually in pull request ✅ Not Changed
