### PR TITLE
Normalize existing squad mentionees to org-qualified team form

### DIFF
--- a/tools/Github/ParseSquadMappingList.ps1
+++ b/tools/Github/ParseSquadMappingList.ps1
@@ -53,6 +53,37 @@ function NormalizeMentioneeValue {
     return $Mentionee
 }
 
+function NormalizeExistingSquadMentionees {
+    [CmdletBinding()]
+    param([string[]] $Lines)
+
+    $result = [System.Collections.Generic.List[string]]::new()
+    $inMentionees = $false
+    $mentioneesIndent = -1
+    foreach ($line in $Lines) {
+        if ($line -match '^\s*mentionees:\s*$') {
+            $inMentionees = $true
+            $mentioneesIndent = GetIndentLength -Line $line
+            $result.Add($line)
+            continue
+        }
+        if ($inMentionees) {
+            if ($line -match '^(\s*)-\s+(act-[a-z0-9-]+-squad)\s*$') {
+                $result.Add("$($Matches[1])- Azure/$($Matches[2])")
+                continue
+            }
+
+            if ($line.Trim().Length -ne 0 -and -not ($line -match '^\s*-\s+')) {
+                $inMentionees = $false
+            } elseif ($line -match '^\s*-\s+' -and (GetIndentLength -Line $line) -lt $mentioneesIndent) {
+                $inMentionees = $false
+            }
+        }
+        $result.Add($line)
+    }
+    return $result.ToArray()
+}
+
 function GetSquadMapping {
     [CmdletBinding()]
     param([string] $AccessToken)
@@ -265,6 +296,7 @@ if ($yamlContent.Contains("`r`n")) { $lineEnding = "`r`n" }
 $endsWithNewline = $yamlContent.EndsWith("`n")
 $yamlLines = [regex]::Split($yamlContent, "\r?\n", [System.Text.RegularExpressions.RegexOptions]::None)
 $updatedLines = AddSquadLabelsToYaml -Lines $yamlLines -LabelToSquad $labelToSquad
+$updatedLines = NormalizeExistingSquadMentionees -Lines $updatedLines
 $updatedContent = [string]::Join($lineEnding, $updatedLines)
 if (-not $endsWithNewline -and $updatedContent.EndsWith($lineEnding)) { $updatedContent = $updatedContent.Substring(0, $updatedContent.Length - $lineEnding.Length) }
 [System.IO.File]::WriteAllText($yamlConfigPath, $updatedContent)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The squad-mapping sync script (`tools/Github/ParseSquadMappingList.ps1`) only qualified the squad mentionees it added (`Azure/act-*-squad`), while leaving **pre-existing bare** `act-*-squad` mentionees in `mentionees:` lists untouched. 

In `mentionUsers.mentionees`, a team must be referenced as `org/team` (`Azure/act-*-squad`) to actually be notified. A bare `act-*-squad` is interpreted as a username, so the team is silently not pinged. Mixing both forms means some squads get routed and some don't.

Add `NormalizeExistingSquadMentionees`, run after `AddSquadLabelsToYaml`, which rewrites bare squad mentionees inside `mentionees:` blocks to `Azure/act-*-squad`.

- `addLabel` labels (`label: act-*-squad`) are unchanged (bare is correct for labels).
- `requestReview` reviewers (`reviewer: act-*-squad`) are unchanged (out of scope).

PowerShell syntax validated. Once merged, the next squad-mapping sync run regenerates `resourceManagement.yml` with all squad mentionees consistently org-qualified, resolving the Copilot comments on #29748.

## Validation
Ran the new function against the current sync output:

| | before | after |
|---|---|---|
| bare mentionees `- act-*-squad` | 171 | **0** |
| qualified mentionees `- Azure/act-*-squad` | 28 | **199** |
| `label: act-*-squad` (must stay bare) | 281 | 281 (unchanged) |
| `reviewer: act-*-squad` | 6 | 6 (unchanged) |

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [ ] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [x] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request