### PR TITLE
Disable WAM broker on Linux and macOS; keep WAM on Windows only

### DIFF
--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,6 +19,9 @@
 -->
 
 ## Upcoming Release
+* Disabled login by WAM (Web Account Manager) broker on non-Windows platforms.
+    - The interactive login broker is only reliably available on Windows (WAM); it is not supported on Linux and its native runtime is not shipped for macOS. On Linux (including WSL) and macOS interactive login now uses the browser directly and never attempts the broker, avoiding the previous broker error.
+    - The `EnableLoginByWam` config now defaults to disabled on non-Windows platforms and is ignored on those platforms even if explicitly enabled.
 
 ## Version 5.5.1
 * Upgraded `Azure.Core` dependency from 1.50.0 to 1.56.0.

--- a/src/Accounts/Accounts/help/Clear-AzConfig.md
+++ b/src/Accounts/Accounts/help/Clear-AzConfig.md
@@ -224,7 +224,7 @@ Accept wildcard characters: False
 
 ### -EnableLoginByWam
 \[Preview\] When enabled, Web Account Manager (WAM) will be the default interactive login experience.
-It will fall back to using the browser if the platform does not support WAM.
+It is supported on Windows only; on Linux (including WSL) and macOS the browser is always used.
 Note that this feature is under preview. Microsoft Account (MSA) is currently not supported.
 Feel free to reach out to Azure PowerShell team if you have any feedbacks: https://aka.ms/azpsissue
 

--- a/src/Accounts/Accounts/help/Connect-AzAccount.md
+++ b/src/Accounts/Accounts/help/Connect-AzAccount.md
@@ -286,6 +286,7 @@ xxxxxxxx-xxxx-xxxx-xxxxxxxx Subscription1    yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyy Azu
 ### Example 10: Connect interactively using WAM
 
 This example demonstrates how to enable the config for WAM (Web Account Manager) and use it to connect to Azure.
+The WAM broker is supported on Windows only. On Linux (including WSL) and macOS the `EnableLoginByWam` config is ignored and the browser is always used for interactive login.
 
 ```powershell
 Update-AzConfig -EnableLoginByWam $true

--- a/src/Accounts/Accounts/help/Get-AzConfig.md
+++ b/src/Accounts/Accounts/help/Get-AzConfig.md
@@ -235,7 +235,7 @@ Accept wildcard characters: False
 
 ### -EnableLoginByWam
 \[Preview\] When enabled, Web Account Manager (WAM) will be the default interactive login experience.
-It will fall back to using the browser if the platform does not support WAM.
+It is supported on Windows only; on Linux (including WSL) and macOS the browser is always used.
 Note that this feature is under preview. Microsoft Account (MSA) is currently not supported.
 Feel free to reach out to Azure PowerShell team if you have any feedbacks: https://aka.ms/azpsissue
 

--- a/src/Accounts/Accounts/help/Update-AzConfig.md
+++ b/src/Accounts/Accounts/help/Update-AzConfig.md
@@ -261,7 +261,7 @@ Accept wildcard characters: False
 
 ### -EnableLoginByWam
 \[Preview\] When enabled, Web Account Manager (WAM) will be the default interactive login experience.
-It will fall back to using the browser if the platform does not support WAM.
+It is supported on Windows only; on Linux (including WSL) and macOS the browser is always used.
 Note that this feature is under preview. Microsoft Account (MSA) is currently not supported.
 Feel free to reach out to Azure PowerShell team if you have any feedbacks: https://aka.ms/azpsissue
 

--- a/src/Accounts/Authentication/Config/Definitions/EnableLoginByWamConfig.cs
+++ b/src/Accounts/Authentication/Config/Definitions/EnableLoginByWamConfig.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using Microsoft.Azure.Commands.Common.Authentication.Properties;
 using Microsoft.Azure.Commands.ResourceManager.Common;
@@ -27,7 +28,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Config.Definitions
     /// </summary>
     internal class EnableLoginByWamConfig : TypedConfig<bool>
     {
-        public override object DefaultValue => true;
+        // WAM depends on the OS broker, which is only reliably supported on Windows.
+        // Default to enabled on Windows and disabled elsewhere (Linux/WSL, macOS) so that
+        // non-Windows platforms don't fall into the unsupported broker path by default.
+        public override object DefaultValue => SharedUtilities.IsWindowsPlatform();
 
         public override string Key => ConfigKeys.EnableLoginByWam;
 

--- a/src/Accounts/Authentication/Properties/Resources.Designer.cs
+++ b/src/Accounts/Authentication/Properties/Resources.Designer.cs
@@ -425,7 +425,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to When enabled, Web Account Manager (WAM) will be the default interactive login experience. It will fall back to using the browser if the platform does not support WAM. For more details please refer to https://go.microsoft.com/fwlink/?linkid=2272007.
+        ///   Looks up a localized string similar to When enabled, Web Account Manager (WAM) will be the default interactive login experience. It is supported on Windows only; on Linux (including WSL) and macOS the browser is always used. For more details please refer to https://go.microsoft.com/fwlink/?linkid=2272007.
         /// </summary>
         public static string HelpMessageOfEnableWamLogin {
             get {

--- a/src/Accounts/Authentication/Properties/Resources.resx
+++ b/src/Accounts/Authentication/Properties/Resources.resx
@@ -381,7 +381,7 @@
     <comment>0 = key of the config</comment>
   </data>
   <data name="HelpMessageOfEnableWamLogin" xml:space="preserve">
-    <value>When enabled, Web Account Manager (WAM) will be the default interactive login experience. It will fall back to using the browser if the platform does not support WAM. For more details please refer to https://go.microsoft.com/fwlink/?linkid=2272007</value>
+    <value>When enabled, Web Account Manager (WAM) will be the default interactive login experience. It is supported on Windows only; on Linux (including WSL) and macOS the browser is always used. For more details please refer to https://go.microsoft.com/fwlink/?linkid=2272007</value>
   </data>
   <data name="RecommendationMessageForLocation" xml:space="preserve">
     <value>Selecting “{0}” may reduce your costs. The region you’ve selected may cost more for the same services. You can disable this message in the future with the command “Update-AzConfig -DisplayRegionIdentified $false”. Learn more at https://go.microsoft.com/fwlink/?linkid=2225665</value>

--- a/src/Accounts/Authentication/Utilities/AzConfigReader.cs
+++ b/src/Accounts/Authentication/Utilities/AzConfigReader.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Utilities
                     {
                         authority = authority + "/";
                     }
-                    return Instance.GetConfigValue<bool>(ConfigKeys.EnableLoginByWam) && authority.StartsWith(AzureAuthorityHosts.AzurePublicCloud.OriginalString, System.StringComparison.OrdinalIgnoreCase);
+                    // The OS broker is only reliably available on Windows (WAM). It is not supported on Linux, and
+                    // on macOS the required native runtime is not shipped with the module, so gate on Windows only.
+                    // Non-Windows (Linux/WSL, macOS) never selects the broker path and always falls back to the
+                    // browser, even if the user explicitly turns the config on.
+                    return SharedUtilities.IsWindowsPlatform() && Instance.GetConfigValue<bool>(ConfigKeys.EnableLoginByWam) && authority.StartsWith(AzureAuthorityHosts.AzurePublicCloud.OriginalString, System.StringComparison.OrdinalIgnoreCase);
                 }
                 catch
                 {


### PR DESCRIPTION
## Description

WAM (Web Account Manager) relies on the operating system broker, which is only reliably available on Windows. On non-Windows platforms this previously caused interactive login to fail with a broker/`msalruntime` error, because:
- The broker is not supported on Linux, and
- The native broker runtime (`msalruntime.dylib`) is not shipped with the module for macOS.

This change gates the broker to Windows only:
- `EnableLoginByWam` now defaults to enabled on Windows and disabled on non-Windows (Linux/WSL, macOS).
- `AzConfigReader.IsWamEnabled` requires `IsWindowsPlatform()`, so on Linux and macOS the broker path is never selected and interactive login uses the browser directly — even if the user explicitly enables the config.

Windows WAM behavior is unchanged.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell.
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately — done (`src/Accounts/Accounts/ChangeLog.md`).
* No cmdlet API change, so no markdown help regeneration required.
