### PR TITLE
Preserve VerifyClientAuthMode in Application Gateway client auth configuration

### DIFF
--- a/src/Network/Network/Common/NetworkResourceManagerProfile.cs
+++ b/src/Network/Network/Common/NetworkResourceManagerProfile.cs
@@ -1558,15 +1558,15 @@ namespace Microsoft.Azure.Commands.Network
                         dest.CipherSuites = src.CipherSuites == null ? null : dest.CipherSuites;
                         dest.DisabledSslProtocols = src.DisabledSslProtocols == null ? null : dest.DisabledSslProtocols;
                     });
-                cfg.CreateMap<MNM.ApplicationGatewayClientAuthConfiguration,CNM.PSApplicationGatewayClientAuthConfiguration>()
-                  .ForMember(
-                   dest => dest.VerifyClientCertIssuerDN,
-                   opt => opt.MapFrom(src => src.VerifyClientCertIssuerDn)
-                   )
-                  .ForMember(
-                   dest => dest.VerifyClientAuthMode,
-                   opt => opt.MapFrom(src => src.VerifyClientAuthMode)
-                   );
+                cfg.CreateMap<MNM.ApplicationGatewayClientAuthConfiguration, CNM.PSApplicationGatewayClientAuthConfiguration>()
+                    .ForMember(
+                        dest => dest.VerifyClientCertIssuerDN,
+                        opt => opt.MapFrom(src => src.VerifyClientCertIssuerDn)
+                    )
+                    .ForMember(
+                        dest => dest.VerifyClientAuthMode,
+                        opt => opt.MapFrom(src => src.VerifyClientAuthMode)
+                    );
                 cfg.CreateMap<MNM.ApplicationGatewayPathRule, CNM.PSApplicationGatewayPathRule>();
                 cfg.CreateMap<MNM.ApplicationGatewayUrlPathMap, CNM.PSApplicationGatewayUrlPathMap>();
                 cfg.CreateMap<MNM.ApplicationGatewayProbeHealthResponseMatch, CNM.PSApplicationGatewayProbeHealthResponseMatch>()

--- a/src/Network/Network/Common/NetworkResourceManagerProfile.cs
+++ b/src/Network/Network/Common/NetworkResourceManagerProfile.cs
@@ -1449,15 +1449,15 @@ namespace Microsoft.Azure.Commands.Network
                         dest.CipherSuites = src.CipherSuites == null ? null : dest.CipherSuites;
                         dest.DisabledSslProtocols = src.DisabledSslProtocols == null ? null : dest.DisabledSslProtocols;
                     });
-               cfg.CreateMap<CNM.PSApplicationGatewayClientAuthConfiguration,MNM.ApplicationGatewayClientAuthConfiguration>()
-               .ForMember(
-                  dest => dest.VerifyClientCertIssuerDn,
-                  opt => opt.MapFrom(src => src.VerifyClientCertIssuerDN)
-                  )
-               .ForMember(
-                  dest => dest.VerifyClientAuthMode,
-                  opt => opt.MapFrom(src => src.VerifyClientAuthMode)
-                  );
+                cfg.CreateMap<CNM.PSApplicationGatewayClientAuthConfiguration, MNM.ApplicationGatewayClientAuthConfiguration>()
+                    .ForMember(
+                        dest => dest.VerifyClientCertIssuerDn,
+                        opt => opt.MapFrom(src => src.VerifyClientCertIssuerDN)
+                    )
+                    .ForMember(
+                        dest => dest.VerifyClientAuthMode,
+                        opt => opt.MapFrom(src => src.VerifyClientAuthMode)
+                    );
                 cfg.CreateMap<CNM.PSApplicationGatewayPathRule, MNM.ApplicationGatewayPathRule>();
                 cfg.CreateMap<CNM.PSApplicationGatewayUrlPathMap, MNM.ApplicationGatewayUrlPathMap>();
                 cfg.CreateMap<CNM.PSApplicationGatewayProbeHealthResponseMatch, MNM.ApplicationGatewayProbeHealthResponseMatch>()

--- a/src/Network/Network/Common/NetworkResourceManagerProfile.cs
+++ b/src/Network/Network/Common/NetworkResourceManagerProfile.cs
@@ -1449,11 +1449,15 @@ namespace Microsoft.Azure.Commands.Network
                         dest.CipherSuites = src.CipherSuites == null ? null : dest.CipherSuites;
                         dest.DisabledSslProtocols = src.DisabledSslProtocols == null ? null : dest.DisabledSslProtocols;
                     });
-                cfg.CreateMap<CNM.PSApplicationGatewayClientAuthConfiguration, MNM.ApplicationGatewayClientAuthConfiguration>()
-                    .ForMember(
-                        dest => dest.VerifyClientCertIssuerDn,
-                        opt => opt.MapFrom(src => src.VerifyClientCertIssuerDN)
-                    );
+               cfg.CreateMap<CNM.PSApplicationGatewayClientAuthConfiguration,MNM.ApplicationGatewayClientAuthConfiguration>()
+               .ForMember(
+                  dest => dest.VerifyClientCertIssuerDn,
+                  opt => opt.MapFrom(src => src.VerifyClientCertIssuerDN)
+                  )
+               .ForMember(
+                  dest => dest.VerifyClientAuthMode,
+                  opt => opt.MapFrom(src => src.VerifyClientAuthMode)
+                  );
                 cfg.CreateMap<CNM.PSApplicationGatewayPathRule, MNM.ApplicationGatewayPathRule>();
                 cfg.CreateMap<CNM.PSApplicationGatewayUrlPathMap, MNM.ApplicationGatewayUrlPathMap>();
                 cfg.CreateMap<CNM.PSApplicationGatewayProbeHealthResponseMatch, MNM.ApplicationGatewayProbeHealthResponseMatch>()
@@ -1554,11 +1558,15 @@ namespace Microsoft.Azure.Commands.Network
                         dest.CipherSuites = src.CipherSuites == null ? null : dest.CipherSuites;
                         dest.DisabledSslProtocols = src.DisabledSslProtocols == null ? null : dest.DisabledSslProtocols;
                     });
-                cfg.CreateMap<MNM.ApplicationGatewayClientAuthConfiguration, CNM.PSApplicationGatewayClientAuthConfiguration>()
-                    .ForMember(
-                        dest => dest.VerifyClientCertIssuerDN,
-                        opt => opt.MapFrom(src => src.VerifyClientCertIssuerDn)
-                    );
+                cfg.CreateMap<MNM.ApplicationGatewayClientAuthConfiguration,CNM.PSApplicationGatewayClientAuthConfiguration>()
+                  .ForMember(
+                   dest => dest.VerifyClientCertIssuerDN,
+                   opt => opt.MapFrom(src => src.VerifyClientCertIssuerDn)
+                   )
+                  .ForMember(
+                   dest => dest.VerifyClientAuthMode,
+                   opt => opt.MapFrom(src => src.VerifyClientAuthMode)
+                   );
                 cfg.CreateMap<MNM.ApplicationGatewayPathRule, CNM.PSApplicationGatewayPathRule>();
                 cfg.CreateMap<MNM.ApplicationGatewayUrlPathMap, CNM.PSApplicationGatewayUrlPathMap>();
                 cfg.CreateMap<MNM.ApplicationGatewayProbeHealthResponseMatch, CNM.PSApplicationGatewayProbeHealthResponseMatch>()

--- a/src/Network/Network/Models/PSApplicationGatewayClientAuthConfiguration.cs
+++ b/src/Network/Network/Models/PSApplicationGatewayClientAuthConfiguration.cs
@@ -19,5 +19,6 @@ namespace Microsoft.Azure.Commands.Network.Models
     {
         public bool? VerifyClientCertIssuerDN { get; set; }
         public string VerifyClientRevocation { get; set; }
+        public string VerifyClientAuthMode { get; set; }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes the missing `VerifyClientAuthMode` property in the PowerShell model for Application Gateway client authentication configuration.

### Changes made

- Added the missing `VerifyClientAuthMode` property to `PSApplicationGatewayClientAuthConfiguration`.
- Updated AutoMapper mappings between:
  - `PSApplicationGatewayClientAuthConfiguration` → `ApplicationGatewayClientAuthConfiguration`
  - `ApplicationGatewayClientAuthConfiguration` → `PSApplicationGatewayClientAuthConfiguration`
- Ensured that `VerifyClientAuthMode` is preserved during conversions between PowerShell and SDK models.

### Impact

Previously, `VerifyClientAuthMode` was not available in the PowerShell model, causing the value to be lost during PowerShell object conversions. As a result, Application Gateway configurations using `Passthrough` mode could unintentionally be updated to the default `Strict` mode during read-modify-write operations.

This change preserves the original `VerifyClientAuthMode` value and prevents unintended configuration changes.

Fixes #29540.

---

## Mandatory Checklist

- [x] General release
- [ ] Public preview
- [ ] Private preview
- [ ] Engineering build
- [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* [ ] Updated `ChangeLog.md` appropriately (if required).
* [ ] Regenerated markdown help files (not required since there is no cmdlet API change).
* [ ] Added/updated test coverage for the change.
* [x] Did not manually adjust the module version.