### PR TITLE
Cache service principal access tokens across operations

### DIFF
--- a/src/Accounts/Accounts/Account/DisconnectAzureRmAccount.cs
+++ b/src/Accounts/Accounts/Account/DisconnectAzureRmAccount.cs
@@ -16,7 +16,6 @@ using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using Microsoft.Azure.Commands.Common.Authentication.Models;
 using Microsoft.Azure.Commands.Profile.Models;
-// TODO: Remove IfDef
 #if NETSTANDARD
 using Microsoft.Azure.Commands.Profile.Models.Core;
 #endif
@@ -127,6 +126,12 @@ namespace Microsoft.Azure.Commands.Profile
                     if (GetContextModificationScope() == ContextModificationScope.CurrentUser)
                     {
                         AzureSession.Instance.AuthenticationFactory.RemoveUser(azureAccount, environment: null);
+                    }
+                    else if ((string.Equals(azureAccount.Type, AzureAccount.AccountType.ServicePrincipal, StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(azureAccount.Type, "ClientAssertion", StringComparison.OrdinalIgnoreCase))
+                        && AzureSession.Instance.TryGetComponent(PowerShellTokenCacheProvider.PowerShellTokenCacheProviderKey, out PowerShellTokenCacheProvider tokenCacheProvider))
+                    {
+                        tokenCacheProvider.ClearAppTokenCache();
                     }
 
                     if (AzureRmProfileProvider.Instance.Profile != null)

--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 
 ## Upcoming Release
-* Reused cached service principal access tokens across Azure PowerShell operations.
+* Reused cached service principal (app-only) access tokens within the same PowerShell session.
     - Fixed issue [#29857]
 * Upgraded `Azure.Core` dependency from 1.56.0 to 1.57.0.
 * Upgraded `System.ClientModel` dependency from 1.12.0 to 1.13.0.

--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,6 +19,8 @@
 -->
 
 ## Upcoming Release
+* Reused cached service principal access tokens across Azure PowerShell operations.
+    - Fixed issue [#29857]
 * Upgraded `Azure.Core` dependency from 1.56.0 to 1.57.0.
 * Upgraded `System.ClientModel` dependency from 1.12.0 to 1.13.0.
 

--- a/src/Accounts/Authentication.Test/AuthenticatorsTest/ServicePrincipalAuthenticatorTests.cs
+++ b/src/Accounts/Authentication.Test/AuthenticatorsTest/ServicePrincipalAuthenticatorTests.cs
@@ -23,6 +23,7 @@ using Microsoft.WindowsAzure.Commands.ScenarioTest;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using Moq;
 using System;
+using System.Collections.Generic;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -104,6 +105,56 @@ namespace Common.Authenticators.Test
             mockAzureCredentialFactory.Verify(f => f.CreateClientSecretCredential(TestTenantId, accountId, securePassword, It.IsAny<ClientSecretCredentialOptions>()), Times.Once());
             Assert.Equal(fakeToken, token.AccessToken);
             Assert.Equal(TestTenantId, token.TenantId);
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public async Task ServicePrincipalAuthenticationUsesSharedAppTokenCache()
+        {
+            var securePassword = new SecureString();
+            "pa88w0rd!".ToCharArray().ForEach(c => securePassword.AppendChar(c));
+            var cacheProvider = new InMemoryTokenCacheProvider();
+            var cacheOptions = new List<TokenCachePersistenceOptions>();
+            var mockAzureCredentialFactory = new Mock<AzureCredentialFactory>();
+            mockAzureCredentialFactory.Setup(f => f.CreateClientSecretCredential(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SecureString>(), It.IsAny<ClientSecretCredentialOptions>()))
+                .Callback<string, string, SecureString, ClientSecretCredentialOptions>((_, _, _, options) => cacheOptions.Add(options.TokenCachePersistenceOptions))
+                .Returns(() => new TokenCredentialMock());
+
+            AzureSession.Instance.RegisterComponent(nameof(AzureCredentialFactory), () => mockAzureCredentialFactory.Object, true);
+
+            var parameter = new ServicePrincipalParameters(
+                cacheProvider,
+                AzureEnvironment.PublicEnvironments["AzureCloud"],
+                null,
+                TestTenantId,
+                TestResourceId,
+                "testuser",
+                null,
+                null,
+                null,
+                securePassword,
+                null);
+            var authenticator = new ServicePrincipalAuthenticator();
+
+            await authenticator.Authenticate(parameter);
+            await authenticator.Authenticate(parameter);
+
+            Assert.Equal(2, cacheOptions.Count);
+            Assert.Same(cacheProvider.GetAppTokenCachePersistenceOptions(), cacheOptions[0]);
+            Assert.Same(cacheOptions[0], cacheOptions[1]);
+            Assert.NotSame(cacheProvider.GetTokenCachePersistenceOptions(), cacheOptions[0]);
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void AppTokenCacheCanBeCleared()
+        {
+            var cacheOptions = new InMemoryTokenCacheOptions(new byte[] { 1, 2, 3 });
+
+            cacheOptions.Clear();
+
+            Assert.Empty(cacheOptions.CachedToken.ToArray());
         }
 
         [Fact]

--- a/src/Accounts/Authentication/Authentication/TokenCache/InMemoryTokenCacheOptions.cs
+++ b/src/Accounts/Authentication/Authentication/TokenCache/InMemoryTokenCacheOptions.cs
@@ -63,6 +63,19 @@ namespace Microsoft.Azure.Commands.Common.Authentication
             return Task.CompletedTask;
         }
 
+        public void Clear()
+        {
+            readerWriterLockSlim.EnterWriteLock();
+            try
+            {
+                CachedToken = ReadOnlyMemory<byte>.Empty;
+            }
+            finally
+            {
+                readerWriterLockSlim.ExitWriteLock();
+            }
+        }
+
         public void Serialize(Stream stream)
         {
             readerWriterLockSlim.EnterReadLock();

--- a/src/Accounts/Authentication/Authentication/TokenCache/InMemoryTokenCacheProvider.cs
+++ b/src/Accounts/Authentication/Authentication/TokenCache/InMemoryTokenCacheProvider.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         public override void ClearCache()
         {
             InMemoryTokenCacheOptions = new InMemoryTokenCacheOptions();
+            ClearAppTokenCache();
         }
 
         protected override void RegisterCache(IPublicClientApplication client)

--- a/src/Accounts/Authentication/Authentication/TokenCache/PowerShellTokenCacheProvider.cs
+++ b/src/Accounts/Authentication/Authentication/TokenCache/PowerShellTokenCacheProvider.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         private const string organizationTenant = "organizations";
 
         protected byte[] _tokenCacheDataToFlush;
+        private readonly InMemoryTokenCacheOptions _appTokenCacheOptions = new InMemoryTokenCacheOptions();
 
         public abstract byte[] ReadTokenData();
 
@@ -62,6 +63,16 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         public virtual void ClearCache(string authority)
         {
             ClearCache();
+        }
+
+        public virtual TokenCachePersistenceOptions GetAppTokenCachePersistenceOptions()
+        {
+            return _appTokenCacheOptions;
+        }
+
+        public virtual void ClearAppTokenCache()
+        {
+            _appTokenCacheOptions.Clear();
         }
 
         public bool TryRemoveAccount(string accountId)

--- a/src/Accounts/Authentication/Authentication/TokenCache/SharedTokenCacheProvider.cs
+++ b/src/Accounts/Authentication/Authentication/TokenCache/SharedTokenCacheProvider.cs
@@ -85,7 +85,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication
                     }
                     catch (Exception)
                     {
-                        //TODO:
                     }
                     finally
                     {
@@ -105,11 +104,13 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         public override void ClearCache()
         {
             ClearCacheInternal(null);
+            ClearAppTokenCache();
         }
 
         public override void ClearCache(string authority)
         {
             ClearCacheInternal(authority);
+            ClearAppTokenCache();
         }
 
         private void ClearCacheInternal(string authority)

--- a/src/Accounts/Authentication/Factories/AuthenticationFactory.cs
+++ b/src/Accounts/Authentication/Factories/AuthenticationFactory.cs
@@ -538,7 +538,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Factories
                             // make best effort to remove credentials
                         }
 
-                        RemoveFromTokenCache(account);
+                        RemoveFromTokenCache(account, clearAppTokenCache: true);
+                        break;
+                    case "ClientAssertion":
+                        RemoveFromTokenCache(account, clearAppTokenCache: true);
                         break;
                     case AzureAccount.AccountType.User:
                         RemoveFromTokenCache(account);
@@ -583,12 +586,17 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Factories
             return account.GetProperty(tokenKey);
         }
 
-        private void RemoveFromTokenCache(IAzureAccount account)
+        private void RemoveFromTokenCache(IAzureAccount account, bool clearAppTokenCache = false)
         {
             PowerShellTokenCacheProvider tokenCacheProvider;
             if (!AzureSession.Instance.TryGetComponent(PowerShellTokenCacheProvider.PowerShellTokenCacheProviderKey, out tokenCacheProvider))
             {
                 throw new NullReferenceException(Resources.AuthenticationClientFactoryNotRegistered);
+            }
+
+            if (clearAppTokenCache)
+            {
+                tokenCacheProvider.ClearAppTokenCache();
             }
 
             var publicClient = tokenCacheProvider.CreatePublicClient();

--- a/src/Accounts/Authenticators/ClientAssertionAuthenticator.cs
+++ b/src/Accounts/Authenticators/ClientAssertionAuthenticator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.PowerShell.Authenticators
             var options = new ClientAssertionCredentialOptions()
             {
                 AuthorityHost = new Uri(authority),
-                TokenCachePersistenceOptions = spParameters.TokenCacheProvider.GetTokenCachePersistenceOptions()
+                TokenCachePersistenceOptions = spParameters.TokenCacheProvider.GetAppTokenCachePersistenceOptions()
             };
 
             options.DisableInstanceDiscovery = spParameters.DisableInstanceDiscovery ?? options.DisableInstanceDiscovery;

--- a/src/Accounts/Authenticators/ServicePrincipalAuthenticator.cs
+++ b/src/Accounts/Authenticators/ServicePrincipalAuthenticator.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Azure.PowerShell.Authenticators
     {
         private const string AuthenticationFailedMessage = "No certificate thumbprint or secret provided for the given service principal '{0}'.";
 
-        // MSAL doesn't cache the secret of Service Principal, but it caches access tokens
         public override Task<IAccessToken> Authenticate(AuthenticationParameters parameters, CancellationToken cancellationToken)
         {
             var spParameters = parameters as ServicePrincipalParameters;
@@ -43,14 +42,12 @@ namespace Microsoft.Azure.PowerShell.Authenticators
             var authority = spParameters.Environment.ActiveDirectoryAuthority;
 
             var requestContext = new TokenRequestContext(scopes, isCaeEnabled: true);
-            // var tokenCachePersistenceOptions = spParameters.TokenCacheProvider.GetTokenCachePersistenceOptions();
+            var tokenCachePersistenceOptions = spParameters.TokenCacheProvider.GetAppTokenCachePersistenceOptions();
             AzureSession.Instance.TryGetComponent(nameof(AzureCredentialFactory), out AzureCredentialFactory azureCredentialFactory);
 
             var options = new ClientCertificateCredentialOptions()
             {
-                // commented due to https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3218
-                // todo: investigate splitting user token cache and app token cache
-                // TokenCachePersistenceOptions = tokenCachePersistenceOptions, // allows MSAL to cache access tokens
+                TokenCachePersistenceOptions = tokenCachePersistenceOptions,
                 AuthorityHost = new Uri(authority),
                 SendCertificateChain = spParameters.SendCertificateChain ?? default(bool)
             };
@@ -70,7 +67,7 @@ namespace Microsoft.Azure.PowerShell.Authenticators
                 //Service principal with secret
                 var csOptions = new ClientSecretCredentialOptions()
                 {
-                    // TokenCachePersistenceOptions = tokenCachePersistenceOptions, // allows MSAL to cache access tokens
+                    TokenCachePersistenceOptions = tokenCachePersistenceOptions,
                     AuthorityHost = new Uri(authority)
                 };
                 csOptions.DisableInstanceDiscovery = spParameters.DisableInstanceDiscovery ?? csOptions.DisableInstanceDiscovery;


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Service principal authentication currently creates a new Azure.Identity credential for each Azure PowerShell operation. Because service principal cache persistence was disabled, every credential starts with an empty MSAL cache and requests a new access token.

This change introduces a separate process-local cache for app-only tokens and shares it across recreated service principal and client assertion credentials. The existing user-token cache remains isolated, avoiding the user/app cache collision that caused service principal caching to be disabled previously. App tokens are cleared when app-only accounts disconnect and when contexts are cleared.

Regression coverage verifies that repeated service principal authentication receives the same app-only cache while remaining separate from the user cache.

Fixes #29857

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request