### PR TITLE
{CI} Improve issue auto-labeling coverage in resourceManagement.yml

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -5084,7 +5084,7 @@ configuration:
           action: Opened
       - or:
         - titleContains:
-            pattern: '[Aa]z\.?AlertsManagement'
+            pattern: '[Aa]z\.?AlertsManagement|[Aa]zAlertProcessingRule'
             isRegex: True
       then:
       - addLabel:
@@ -5190,7 +5190,7 @@ configuration:
           action: Opened
       - or:
         - titleContains:
-            pattern: '[Aa]z\.Resources|[Aa]z(ResourceGroup|ResourceGroupDeployment|ResourceLock|ManagedApplication)'
+            pattern: '[Aa]z\.Resources|[Aa]z(ResourceGroup|ResourceGroupDeployment|ResourceLock|ManagedApplication|ProviderFeature|ResourceProvider)'
             isRegex: True
       then:
       - addLabel:
@@ -6208,7 +6208,7 @@ configuration:
           action: Opened
       - or:
         - titleContains:
-            pattern: '[Aa]z(VpnGateway|VirtualNetworkGateway)'
+            pattern: '[Aa]z(VpnGateway|VirtualNetworkGateway|VpnConnection)'
             isRegex: True
       then:
       - addLabel:
@@ -6700,6 +6700,54 @@ configuration:
       - addLabel:
           label: Workloads
       description: '[Workloads] auto assign module label based on issue description.'
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - or:
+        - titleContains:
+            pattern: '[Aa]z(PolicyAssignment|PolicyDefinition|PolicySetDefinition|PolicyExemption)'
+            isRegex: True
+      then:
+      - addLabel:
+          label: Policy
+      description: '[Policy] auto assign module label based on issue description.'
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - or:
+        - titleContains:
+            pattern: '[Aa]z(ADApplication|ADServicePrincipal|ADGroup|ADUser|ADAppCredential|ADSpCredential)'
+            isRegex: True
+      then:
+      - addLabel:
+          label: Graph.Microsoft
+      description: '[Graph.Microsoft] auto assign module label based on issue description.'
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - or:
+        - titleContains:
+            pattern: '[Aa]zCostManagementQuery'
+            isRegex: True
+      then:
+      - addLabel:
+          label: Cost Management - Query
+      description: '[Cost Management - Query] auto assign module label based on issue description.'
+    - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - or:
+        - titleContains:
+            pattern: '[Aa]zCostManagementExport'
+            isRegex: True
+      then:
+      - addLabel:
+          label: Cost Management - UsageDetailsAndExport
+      description: '[Cost Management - UsageDetailsAndExport] auto assign module label based on issue description.'
     - if:
       - payloadType: Issues
       - labelAdded:


### PR DESCRIPTION
## Description

This PR improves the accuracy of GitHub issue auto-labeling in `.github/policies/resourceManagement.yml`. All matching stays title only, which is deliberate for this repo since issue bodies frequently contain a full `Get-Module Az.*` inventory dump with 100+ `Az.<Module>` tokens, so matching the body would apply dozens of false component labels.

Two kinds of change are included.

1. Extended three existing module rules to also match common cmdlet nouns that do not contain the module name in the issue title:
   - `ARM` now also matches `ProviderFeature` and `ResourceProvider`.
   - `Alerts Management` now also matches `AlertProcessingRule`.
   - `Network - VPN Gateway` now also matches `VpnConnection`.

2. Added four new title rules for component labels that already had squad routing but had no rule to apply them so issues about these areas were never auto-labeled:
   - `Policy` for the `PolicyAssignment`, `PolicyDefinition`, `PolicySetDefinition` and `PolicyExemption` cmdlets.
   - `Graph.Microsoft` for the Microsoft Entra cmdlets such as `ADApplication`, `ADServicePrincipal`, `ADGroup`, `ADUser`, `ADAppCredential` and `ADSpCredential`.
   - `Cost Management - Query` for `CostManagementQuery`.
   - `Cost Management - UsageDetailsAndExport` for `CostManagementExport`.

Every added mapping was verified against the current open issue backlog. Each previously unlabeled target issue now resolves to exactly one correct component label with no over-labeling.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [x] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
