### PR TITLE
[Compute] Add breaking-change attributes to deprecated Set-AzVMAEMExtension parameters

### DIFF
--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -21,6 +21,7 @@
 -->
 ## Upcoming Release
 * Deprecated installing the legacy Azure Enhanced Monitoring (AEM) extension for SAP on Virtual Machines (VMs); `Set-AzVMAEMExtension` now installs the new extension by default.
+* Marked the `-EnableWAD`, `-SkipStorage`, and `-InstallNewExtension` parameters of `Set-AzVMAEMExtension` as deprecated using breaking-change attributes. They will be removed in a future major release.
 
 ## Version 11.7.0
 * ComputeRP related cmdlets will now use 2026-03-01 version of the ComputeRP API.

--- a/src/Compute/Compute/Extension/AEM/SetAzureRmVMAEMExtension.cs
+++ b/src/Compute/Compute/Extension/AEM/SetAzureRmVMAEMExtension.cs
@@ -25,6 +25,7 @@ using Microsoft.Azure.Management.Compute.Models;
 using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
 using Microsoft.Azure.PowerShell.Cmdlets.Compute.Helpers.Storage;
 using Microsoft.Rest.Azure;
+using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Auth;
 using Microsoft.WindowsAzure.Storage.Shared.Protocol;
@@ -62,6 +63,7 @@ namespace Microsoft.Azure.Commands.Compute
         [ValidateNotNullOrEmpty]
         public string VMName { get; set; }
 
+        [CmdletParameterBreakingChangeWithVersion(nameof(EnableWAD), "17.0.0", "12.0.0", ChangeDescription = "This parameter is deprecated because it is only used by the legacy Azure Enhanced Monitoring (AEM) extension for SAP, which is being deprecated. It will be removed in a future release.")]
         [Parameter(
                 Mandatory = false,
                 ValueFromPipelineByPropertyName = false,
@@ -82,6 +84,7 @@ namespace Microsoft.Azure.Commands.Compute
                 HelpMessage = "Operating System Type of the virtual machines. Possible values: Windows | Linux")]
         public string OSType { get; set; }
 
+        [CmdletParameterBreakingChangeWithVersion(nameof(SkipStorage), "17.0.0", "12.0.0", ChangeDescription = "This parameter is deprecated because it is only used by the legacy Azure Enhanced Monitoring (AEM) extension for SAP, which is being deprecated. It will be removed in a future release.")]
         [Parameter(
                 Mandatory = false,
                 Position = 4,
@@ -101,6 +104,7 @@ namespace Microsoft.Azure.Commands.Compute
                 HelpMessage = "Sets the access of the VM identity to the individual resources, e.g. data disks instead of the complete resource group.")]
         public SwitchParameter SetAccessToIndividualResources { get; set; }
 
+        [CmdletParameterBreakingChangeWithVersion(nameof(InstallNewExtension), "17.0.0", "12.0.0", ChangeDescription = "This parameter is deprecated. The cmdlet installs the new VM Extension for SAP by default, so this switch is no longer required. It will be removed in a future release.")]
         [Parameter(
                 Mandatory = false,
                 Position = 6,


### PR DESCRIPTION
### Description
Follow-up to #29826 (`Deprecated the old AEM extension.`).

That PR announced the deprecation of the legacy Azure Enhanced Monitoring (AEM) extension only through parameter `HelpMessage` text. As noted in review feedback, help-text-only deprecation is **not traceable** by the Azure PowerShell breaking-change tooling (`tools/BreakingChanges/Get-BreakingChangeMetadata.ps1`) and produces **no runtime warning** to users. It therefore would not show up when assembling the breaking-change list for the next major release.

This PR adds `[CmdletParameterBreakingChangeWithVersion]` attributes to the three deprecated parameters of `Set-AzVMAEMExtension` so the deprecations are:
- tracked in the breaking-change metadata / migration guide, and
- surfaced to users at runtime as a standard deprecation warning.

### Parameters marked deprecated
- `-EnableWAD`
- `-SkipStorage`
- `-InstallNewExtension`

Deprecation target: Az `17.0.0` / Az.Compute `12.0.0` (next major). No behavior change; the parameters still function.

### Checklist
- [x] Updated `src/Compute/Compute/ChangeLog.md` under `## Upcoming Release`