### PR TITLE
[ChangeSafety] Add module mapping

### DIFF
--- a/tools/CreateMappings_rules.json
+++ b/tools/CreateMappings_rules.json
@@ -1001,6 +1001,10 @@
     "module": "EdgeAction"
   },
   {
+    "module": "ChangeSafety",
+    "alias": "ChangeSafety"
+  },
+  {
     "alias": "ArtifactSigning",
     "module": "ArtifactSigning"
   },


### PR DESCRIPTION
## Description

Adds the missing `ChangeSafety` module-to-alias entry in `tools/CreateMappings_rules.json`. This restores the documentation mapping that was omitted when Az.ChangeSafety was merged in #29651.

Validated by running `tools/CreateMappings.ps1` against `src/ChangeSafety`; all 12 cmdlets mapped to `ChangeSafety`.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell.
  - [ ] General release
  - [ ] Public preview
  - [ ] Private preview
  - [ ] Engineering build
  - [x] No need for a release

- [x] Check this box to confirm: **I have read the _Submitting Changes_ section of `CONTRIBUTING.md` and reviewed the required information.**