### PR TITLE
[DynatraceObservability] Sync generated docs/help with examples and fix invalid pipeline in example

### DIFF
--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Get-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Get-AzDynatraceMonitoredSubscription.md
@@ -35,21 +35,105 @@ List the subscriptions currently being monitored by the Dynatrace monitor resour
 
 ## EXAMPLES
 
-### Example 1: List all monitored subscriptions for a Dynatrace monitor
+### Example 1: List monitored subscriptions for a monitor
 ```powershell
-$subs = Get-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup"
-$subs
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor
+$subs | Select-Object Id, Name, Type
 ```
 
-Returns all subscription monitoring entries (status, subscriptionId, log/metric rule flags) for the specified Dynatrace monitor resource.
-
-### Example 2: Retrieve monitoring status for a specific subscription
-```powershell
-$subId = (Get-AzContext).Subscription.Id
-Get-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -SubscriptionId $subId
+```output
+Id                                                                                                                    Name    Type
+--                                                                                                                    ----    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default Dynatrace.Observability/monitors/monitoredSubscriptions
 ```
 
-Filters the result to the provided subscription Id to quickly inspect its monitoring status and related rule settings.
+Displays monitored subscription entries attached to the specified monitor.
+(Sample output based on recording.)
+
+### Example 2: Use identity pipeline (monitor object)
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$monitorObj | Get-AzDynatraceMonitoredSubscription | Select-Object -First 1 -Property Id, Name
+```
+
+```output
+Id                                                                                                                    Name
+--                                                                                                                    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default
+```
+
+Pipes the monitor object (identity) to retrieve its monitored subscriptions.
+
+### Example 3: Retrieve a single monitored subscription (Get parameter set)
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$all = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor
+($all[0] | Get-AzDynatraceMonitoredSubscription) | Format-List Id, Name, Type, Properties
+```
+
+```output
+Id    : /subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default
+Name  : default
+Type  : Dynatrace.Observability/monitors/monitoredSubscriptions
+Properties : @{operation=AddBegin; monitoredSubscriptionList=} 
+```
+
+Selects the first monitored subscription and re-fetches it for detailed inspection (properties show operation AddBegin).
+
+### Example 4: Filter for current subscription
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $currentSub = (Get-AzContext).Subscription.Id
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor | Where-Object { $_.Id -like "/subscriptions/$currentSub/*" }
+$subs | Select-Object Id, Name
+```
+
+```output
+Id                                                                                                                    Name
+--                                                                                                                    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default
+```
+
+Filters results to the current subscription scope.
+
+### Example 5: Count monitored subscriptions
+```powershell
+$count = (Get-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor").Count
+Write-Host "Total monitored subscriptions: $count"
+```
+
+```output
+Total monitored subscriptions: 1
+```
+
+Outputs a simple count for reporting or validation.
+
+### Example 6: Graceful handling when none exist
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -ErrorAction SilentlyContinue
+if (-not $subs -or $subs.Count -eq 0) { Write-Warning "No monitored subscriptions found." } else { $subs | Select-Object -First 5 }
+```
+
+```output
+WARNING: No monitored subscriptions found.
+```
+
+Demonstrates defensive pattern when list may be empty.
+
+### Example 7: Format output for auditing
+```powershell
+Get-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" | 
+	Select-Object Id,@{n='SubscriptionGuid';e={ ($_).Id.Split('/')[2] }}, Name | Export-Csv -Path monitoredSubs.csv -NoTypeInformation
+```
+
+```output
+"Id","SubscriptionGuid","Name"
+"/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default","b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c","default"
+```
+
+Prepares a CSV of monitored subscriptions with extracted subscription GUIDs for audit or inventory.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Invoke-AzDynatraceManageMonitorAgentInstallation.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Invoke-AzDynatraceManageMonitorAgentInstallation.md
@@ -59,36 +59,78 @@ Performs Dynatrace agent install/uninstall action through the Azure Dynatrace re
 
 ## EXAMPLES
 
-### Example 1: Install Dynatrace agent on a VM using a request object
+### Example 1: Install agent on a VM using expanded parameters
 ```powershell
-$subId = (Get-AzContext).Subscription.Id
-$vmId  = "/subscriptions/$subId/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/appvm1"
-
-$request = New-Object Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest
-$request.Action = "Install"
-$vmEntry = New-Object Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList
-$vmEntry.Id = $vmId
-$request.ManageAgentInstallationList = @($vmEntry)
-
-Invoke-AzDynatraceManageMonitorAgentInstallation -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -Request $request -PassThru
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
 
-Creates a ManageAgentInstallationRequest to install the Dynatrace agent on the specified virtual machine and invokes the operation. PassThru returns true on success.
+Returns True when the install request is accepted.
 
-### Example 2: Uninstall Dynatrace agent using a JSON string
+### Example 2: Uninstall agent via expanded parameters
 ```powershell
-$subId = (Get-AzContext).Subscription.Id
-$json = @{ 
-	action = "Uninstall"; 
-	manageAgentInstallationList = @(
-		@{ id = "/subscriptions/$subId/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/appvm1" }
-	)
-} | ConvertTo-Json -Depth 5
-
-Invoke-AzDynatraceManageMonitorAgentInstallation -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -JsonString $json -PassThru
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Uninstall -ManageAgentInstallationList @($entry) -PassThru
 ```
 
-Provides the request payload as a JSON string to uninstall the Dynatrace agent from the target VM. Using -JsonString avoids manually constructing typed objects.
+Removes the Dynatrace agent from the specified resource.
+
+### Example 3: Use request object (Manage parameter set)
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
+$listEntry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $listEntry.Id = $vmId
+$request = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new()
+$request.Action = 'Install'
+$request.ManageAgentInstallationList = @($listEntry)
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Request $request -PassThru
+```
+
+Creates and submits a strongly-typed request object.
+
+### Example 4: Pipeline identity usage (monitor object)
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+$monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Action Install -ManageAgentInstallationList @($entry) -PassThru
+```
+
+Demonstrates identity parameter set by piping the monitor.
+
+### Example 5: JSON string input
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
+$json = '{"action":"Install","manageAgentInstallationList":[{"id":"' + $vmId + '"}]}'
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
+```
+
+Passes the request as raw JSON.
+
+### Example 6: JSON file path input
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
+$path = Join-Path $PWD 'agent-install.json'
+@{ action = 'Install'; manageAgentInstallationList = @(@{ id = $vmId }) } | ConvertTo-Json -Depth 4 | Set-Content -Path $path -Encoding UTF8
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path -PassThru
+```
+
+Reads parameters from a JSON file.
+
+### Example 7: Uninstall using request object and identity pipeline
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+$req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new(); $req.Action = 'Uninstall'; $req.ManageAgentInstallationList = @($entry)
+$monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Request $req -PassThru
+```
+
+Combines identity pipeline with the -Request parameter set.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Invoke-AzDynatraceManageMonitorAgentInstallation.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Invoke-AzDynatraceManageMonitorAgentInstallation.md
@@ -63,7 +63,7 @@ Performs Dynatrace agent install/uninstall action through the Azure Dynatrace re
 ```powershell
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -73,7 +73,7 @@ Returns True when the install request is accepted.
 ### Example 2: Uninstall agent via expanded parameters
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Uninstall -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -82,7 +82,7 @@ Removes the Dynatrace agent from the specified resource.
 
 ### Example 3: Use request object (Manage parameter set)
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
 $listEntry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $listEntry.Id = $vmId
 $request = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new()
 $request.Action = 'Install'
@@ -95,7 +95,7 @@ Creates and submits a strongly-typed request object.
 ### Example 4: Pipeline identity usage (monitor object)
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -104,7 +104,7 @@ Demonstrates identity parameter set by piping the monitor.
 
 ### Example 5: JSON string input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
 $json = '{"action":"Install","manageAgentInstallationList":[{"id":"' + $vmId + '"}]}'
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
 ```
@@ -113,7 +113,7 @@ Passes the request as raw JSON.
 
 ### Example 6: JSON file path input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
 $path = Join-Path $PWD 'agent-install.json'
 @{ action = 'Install'; manageAgentInstallationList = @(@{ id = $vmId }) } | ConvertTo-Json -Depth 4 | Set-Content -Path $path -Encoding UTF8
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path -PassThru
@@ -124,7 +124,7 @@ Reads parameters from a JSON file.
 ### Example 7: Uninstall using request object and identity pipeline
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new(); $req.Action = 'Uninstall'; $req.ManageAgentInstallationList = @($entry)
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Request $req -PassThru

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/New-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/New-AzDynatraceMonitoredSubscription.md
@@ -38,35 +38,93 @@ Add the subscriptions that should be monitored by the Dynatrace monitor resource
 
 ## EXAMPLES
 
-### Example 1: Add subscriptions to monitoring using an object list
+### Example 1: Begin adding subscription monitoring (AddBegin)
 ```powershell
-$subIds = @("11111111-1111-1111-1111-111111111111","22222222-2222-2222-2222-222222222222")
-$list = @()
-foreach ($id in $subIds) {
-	$entry = New-Object Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription
-	$entry.SubscriptionId = $id
-	$list += $entry
-}
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
 
-New-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -MonitoredSubscriptionList $list -Operation "Add"
+# Initiate monitoring relationship (AddBegin)
+$subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
+$subs[0].Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddBegin
 ```
 
-Constructs an array of MonitoredSubscription objects and adds them to the Dynatrace monitor. Use -Operation "Add" to append monitoring entries.
+Starts the monitored subscription onboarding workflow.
+Some services require a follow-up AddComplete operation.
 
-### Example 2: Add a subscription via JSON payload file
+### Example 2: Complete add workflow (AddComplete)
 ```powershell
-$json = @{ 
-	monitoredSubscriptionList = @(
-		@{ subscriptionId = "33333333-3333-3333-3333-333333333333" }
-	);
-	operation = "Add" 
-} | ConvertTo-Json -Depth 5
-$json | Out-File -FilePath .\addSubs.json -Encoding utf8
-
-New-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -JsonFilePath .\addSubs.json
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
+$subs[0].Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddComplete
 ```
 
-Supplies the monitored subscription list and operation through a JSON file, useful for automation scenarios or larger batch updates.
+Finalizes the monitoring relationship after an earlier AddBegin.
+
+### Example 3: Create via JSON string
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$json = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $subscriptionId + '"}],"operation":"AddBegin"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $json
+```
+
+Uses JSON payload rather than typed objects—helpful for automation or external template generation.
+
+### Example 4: Create via JSON file path
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$path = Join-Path $PWD 'monitored-subscription.json'
+@{ monitoredSubscriptionList = @(@{ id = "/subscriptions/$subscriptionId" }); operation = 'AddBegin' } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path
+```
+
+Reads creation parameters from a JSON file on disk.
+
+### Example 5: Pipeline identity usage with expanded parameters
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+($monitorObj | New-AzDynatraceMonitoredSubscription -MonitoredSubscriptionList @($subObj) -Operation AddBegin)
+```
+
+Demonstrates identity parameter set by piping the monitor object.
+
+### Example 6: Dry run with -WhatIf
+```powershell
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -MonitoredSubscriptionList @($subObj) -Operation AddBegin -WhatIf
+```
+
+Shows the operation details without persisting changes.
+
+### Example 7: JSON validation then completion
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $sid = (Get-AzContext).Subscription.Id
+$jsonBegin = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddBegin"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonBegin | Out-Null
+$jsonComplete = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddComplete"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonComplete
+```
+
+Executes the two-step add workflow entirely via JSON payloads.
+
+### Example 8: Verify monitored subscription list
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor | Select-Object -First 1 | Format-List Id,Name,Type
+```
+
+Retrieves and inspects monitored subscription after creation.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/New-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/New-AzDynatraceMonitoredSubscription.md
@@ -46,7 +46,7 @@ $subscriptionId = (Get-AzContext).Subscription.Id
 
 # Initiate monitoring relationship (AddBegin)
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddBegin
 ```
 
@@ -59,7 +59,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddComplete
 ```
 
@@ -70,7 +70,7 @@ Finalizes the monitoring relationship after an earlier AddBegin.
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
-$json = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $subscriptionId + '"}],"operation":"AddBegin"}'
+$json = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $subscriptionId + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $json
 ```
 
@@ -82,26 +82,29 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $path = Join-Path $PWD 'monitored-subscription.json'
-@{ monitoredSubscriptionList = @(@{ id = "/subscriptions/$subscriptionId" }); operation = 'AddBegin' } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+@{ properties = @{ operation = 'AddBegin'; monitoredSubscriptionList = @(@{ subscriptionId = "/subscriptions/$subscriptionId" }) } } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path
 ```
 
 Reads creation parameters from a JSON file on disk.
 
-### Example 5: Pipeline identity usage with expanded parameters
+### Example 5: Add multiple subscriptions in one request
 ```powershell
-$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor"
-$subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
-($monitorObj | New-AzDynatraceMonitoredSubscription -MonitoredSubscriptionList @($subObj) -Operation AddBegin)
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$sub1 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub1.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000001"
+$sub2 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub2.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000002"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList @($sub1, $sub2) -Operation AddBegin
 ```
 
-Demonstrates identity parameter set by piping the monitor object.
+Onboards several subscriptions to the monitor in a single AddBegin call.
 
 ### Example 6: Dry run with -WhatIf
 ```powershell
 $subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -MonitoredSubscriptionList @($subObj) -Operation AddBegin -WhatIf
 ```
 
@@ -110,9 +113,9 @@ Shows the operation details without persisting changes.
 ### Example 7: JSON validation then completion
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $sid = (Get-AzContext).Subscription.Id
-$jsonBegin = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddBegin"}'
+$jsonBegin = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonBegin | Out-Null
-$jsonComplete = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddComplete"}'
+$jsonComplete = '{"properties":{"operation":"AddComplete","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonComplete
 ```
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Remove-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Remove-AzDynatraceMonitoredSubscription.md
@@ -30,21 +30,45 @@ Delete the subscriptions that are being monitored by the Dynatrace monitor resou
 
 ## EXAMPLES
 
-### Example 1: Remove monitoring for a single subscription
+### Example 1: Validate delete parameters (WhatIf)
 ```powershell
-$subId = (Get-AzContext).Subscription.Id
-Remove-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -SubscriptionId $subId -PassThru
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -WhatIf
 ```
 
-Deletes the monitored subscription entry for the specified subscription. PassThru returns true when the deletion succeeds.
+Performs a dry run; this matches the recorded validation step.
 
-### Example 2: Run removal asynchronously as a background job
+### Example 2: Delete monitored subscription (explicit parameters)
 ```powershell
-$subId = "11111111-1111-1111-1111-111111111111"
-Remove-AzDynatraceMonitoredSubscription -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -SubscriptionId $subId -AsJob
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false
 ```
 
-Starts the removal operation as a PowerShell job allowing you to continue other tasks while the deletion completes.
+Attempts deletion.
+If the backend is fully provisioned, this should succeed; otherwise you may see `ResourceDeletionFailed`.
+
+### Example 3: Idempotent second delete
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false -ErrorAction SilentlyContinue
+```
+
+Safe to run again; if already deleted, no change occurs.
+
+### Example 4: Handle transient backend errors
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+try {
+	Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false
+} catch {
+	Write-Warning "Deletion failed: $($_.Exception.Message). Retry after confirming the monitored subscription was fully created." 
+}
+```
+
+Provides a pattern for handling intermittent service errors gracefully.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Update-AzDynatraceMonitorPlan.md
@@ -59,29 +59,96 @@ Upgrades the billing Plan for Dynatrace monitor resource.
 
 ## EXAMPLES
 
-### Example 1: Upgrade the plan using expanded parameters
+### Example 1: Upgrade a monitor plan using expanded parameters
 ```powershell
-Update-AzDynatraceMonitorPlan -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -PlanDataPlanDetail "enterprise-plan" -PlanDataUsageType "PAYG" -PlanDataBillingCycle "MONTHLY" -PlanDataEffectiveDate (Get-Date) -PassThru
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+# Move from trial/preview plan to committed monthly plan
+$result = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
+	-PlanDataUsageType COMMITTED `
+	-PlanDataBillingCycle "1-Month" `
+	-PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" `
+	-PlanDataEffectiveDate (Get-Date) -PassThru
 ```
 
-Upgrades the Dynatrace monitor to the specified plan (enterprise-plan) with PAYG usage type and a monthly billing cycle. PassThru returns true on success.
-
-### Example 2: Upgrade the plan using a JSON file
-```powershell
-$json = @{ 
-	planData = @{ 
-		planDetail = "premium-plan"; 
-		usageType  = "COMMITTED"; 
-		billingCycle = "MONTHLY"; 
-		effectiveDate = (Get-Date).ToString("o") 
-	} 
-} | ConvertTo-Json -Depth 5
-$json | Out-File -FilePath .\upgradePlan.json -Encoding utf8
-
-Update-AzDynatraceMonitorPlan -MonitorName "myDynatraceMonitor" -ResourceGroupName "myResourceGroup" -JsonFilePath .\upgradePlan.json -PassThru
+```output
+True
 ```
 
-Provides the upgrade request body via JSON, useful for automation or storing predefined plan configurations.
+Updates the monitor's billing plan directly by specifying each field.
+Returns True on success.
+
+### Example 2: Use a request object (Upgrade parameter set)
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+# Construct upgrade request object
+$req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.UpgradePlanRequest]::new()
+$req.PlanData = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.PlanData]::new()
+$req.PlanData.UsageType = "COMMITTED"
+$req.PlanData.BillingCycle = "1-Month"
+$req.PlanData.PlanDetails = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
+$req.PlanData.EffectiveDate = Get-Date
+
+$ok = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
+```
+
+```output
+True
+```
+
+Shows how to supply all plan data via the -Request object instead of individual parameters.
+
+### Example 3: Pipeline identity usage
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor |
+	Update-AzDynatraceMonitorPlan -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru
+```
+
+Performs the upgrade by piping the monitor object (identity) and specifying expanded plan fields.
+
+### Example 4: JSON string input
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$json = '{"planData":{"usageType":"COMMITTED","billingCycle":"1-Month","planDetails":"dynatrace_azure_enterprise@TIDgmz7xq9ge3py","effectiveDate":"' + (Get-Date).ToString("o") + '"}}'
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
+```
+
+Passes plan properties as a JSON string.
+Useful for scripting scenarios where you materialize JSON externally.
+
+### Example 5: JSON file path input
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$jsonPath = Join-Path $PWD 'upgrade-plan.json'
+@{ planData = @{ usageType = 'COMMITTED'; billingCycle = '1-Month'; planDetails = 'dynatrace_azure_enterprise@TIDgmz7xq9ge3py'; effectiveDate = (Get-Date) } } | ConvertTo-Json -Depth 5 | Set-Content -Path $jsonPath -Encoding UTF8
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $jsonPath -PassThru
+```
+
+Reads the plan update payload from a JSON file on disk.
+
+### Example 6: Dry run with -WhatIf
+```powershell
+Update-AzDynatraceMonitorPlan -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -WhatIf
+```
+
+Shows what would change without performing the actual update.
+
+### Example 7: Verify plan after update
+```powershell
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru | Out-Null
+$updated = Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor
+$updated.planData | Format-List UsageType,BillingCycle,PlanDetails,EffectiveDate
+```
+
+Retrieves the monitor to validate the new plan details after a successful upgrade.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/docs/Update-AzDynatraceMonitorPlan.md
@@ -65,7 +65,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 
 # Move from trial/preview plan to committed monthly plan
-$result = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
 	-PlanDataUsageType COMMITTED `
 	-PlanDataBillingCycle "1-Month" `
 	-PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" `
@@ -89,10 +89,10 @@ $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.Upgrade
 $req.PlanData = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.PlanData]::new()
 $req.PlanData.UsageType = "COMMITTED"
 $req.PlanData.BillingCycle = "1-Month"
-$req.PlanData.PlanDetails = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
+$req.PlanData.PlanDetail = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
 $req.PlanData.EffectiveDate = Get-Date
 
-$ok = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
 ```
 
 ```output
@@ -145,7 +145,7 @@ Shows what would change without performing the actual update.
 ```powershell
 Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru | Out-Null
 $updated = Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor
-$updated.planData | Format-List UsageType,BillingCycle,PlanDetails,EffectiveDate
+$updated.planData | Format-List UsageType,BillingCycle,PlanDetail,EffectiveDate
 ```
 
 Retrieves the monitor to validate the new plan details after a successful upgrade.

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Invoke-AzDynatraceManageMonitorAgentInstallation.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Invoke-AzDynatraceManageMonitorAgentInstallation.md
@@ -2,7 +2,7 @@
 ```powershell
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -12,7 +12,7 @@ Returns True when the install request is accepted.
 ### Example 2: Uninstall agent via expanded parameters
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Uninstall -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -21,7 +21,7 @@ Removes the Dynatrace agent from the specified resource.
 
 ### Example 3: Use request object (Manage parameter set)
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
 $listEntry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $listEntry.Id = $vmId
 $request = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new()
 $request.Action = 'Install'
@@ -34,7 +34,7 @@ Creates and submits a strongly-typed request object.
 ### Example 4: Pipeline identity usage (monitor object)
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -43,7 +43,7 @@ Demonstrates identity parameter set by piping the monitor.
 
 ### Example 5: JSON string input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
 $json = '{"action":"Install","manageAgentInstallationList":[{"id":"' + $vmId + '"}]}'
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
 ```
@@ -52,7 +52,7 @@ Passes the request as raw JSON.
 
 ### Example 6: JSON file path input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
 $path = Join-Path $PWD 'agent-install.json'
 @{ action = 'Install'; manageAgentInstallationList = @(@{ id = $vmId }) } | ConvertTo-Json -Depth 4 | Set-Content -Path $path -Encoding UTF8
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path -PassThru
@@ -63,7 +63,7 @@ Reads parameters from a JSON file.
 ### Example 7: Uninstall using request object and identity pipeline
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new(); $req.Action = 'Uninstall'; $req.ManageAgentInstallationList = @($entry)
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Request $req -PassThru

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/examples/New-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/examples/New-AzDynatraceMonitoredSubscription.md
@@ -6,7 +6,7 @@ $subscriptionId = (Get-AzContext).Subscription.Id
 
 # Initiate monitoring relationship (AddBegin)
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddBegin
 ```
 
@@ -18,7 +18,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddComplete
 ```
 
@@ -29,7 +29,7 @@ Finalizes the monitoring relationship after an earlier AddBegin.
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
-$json = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $subscriptionId + '"}],"operation":"AddBegin"}'
+$json = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $subscriptionId + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $json
 ```
 
@@ -41,26 +41,29 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $path = Join-Path $PWD 'monitored-subscription.json'
-@{ monitoredSubscriptionList = @(@{ id = "/subscriptions/$subscriptionId" }); operation = 'AddBegin' } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+@{ properties = @{ operation = 'AddBegin'; monitoredSubscriptionList = @(@{ subscriptionId = "/subscriptions/$subscriptionId" }) } } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path
 ```
 
 Reads creation parameters from a JSON file on disk.
 
-### Example 5: Pipeline identity usage with expanded parameters
+### Example 5: Add multiple subscriptions in one request
 ```powershell
-$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor"
-$subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
-($monitorObj | New-AzDynatraceMonitoredSubscription -MonitoredSubscriptionList @($subObj) -Operation AddBegin)
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$sub1 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub1.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000001"
+$sub2 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub2.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000002"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList @($sub1, $sub2) -Operation AddBegin
 ```
 
-Demonstrates identity parameter set by piping the monitor object.
+Onboards several subscriptions to the monitor in a single AddBegin call.
 
 ### Example 6: Dry run with -WhatIf
 ```powershell
 $subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -MonitoredSubscriptionList @($subObj) -Operation AddBegin -WhatIf
 ```
 
@@ -69,9 +72,9 @@ Shows the operation details without persisting changes.
 ### Example 7: JSON validation then completion
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $sid = (Get-AzContext).Subscription.Id
-$jsonBegin = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddBegin"}'
+$jsonBegin = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonBegin | Out-Null
-$jsonComplete = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddComplete"}'
+$jsonComplete = '{"properties":{"operation":"AddComplete","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonComplete
 ```
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Update-AzDynatraceMonitorPlan.md
@@ -44,7 +44,7 @@ Shows how to supply all plan data via the -Request object instead of individual 
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 
-Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor | \
+Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor |
 	Update-AzDynatraceMonitorPlan -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru
 ```
 

--- a/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability.Autorest/examples/Update-AzDynatraceMonitorPlan.md
@@ -4,7 +4,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 
 # Move from trial/preview plan to committed monthly plan
-$result = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
 	-PlanDataUsageType COMMITTED `
 	-PlanDataBillingCycle "1-Month" `
 	-PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" `
@@ -27,10 +27,10 @@ $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.Upgrade
 $req.PlanData = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.PlanData]::new()
 $req.PlanData.UsageType = "COMMITTED"
 $req.PlanData.BillingCycle = "1-Month"
-$req.PlanData.PlanDetails = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
+$req.PlanData.PlanDetail = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
 $req.PlanData.EffectiveDate = Get-Date
 
-$ok = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
 ```
 
 ```output
@@ -82,7 +82,7 @@ Shows what would change without performing the actual update.
 ```powershell
 Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru | Out-Null
 $updated = Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor
-$updated.planData | Format-List UsageType,BillingCycle,PlanDetails,EffectiveDate
+$updated.planData | Format-List UsageType,BillingCycle,PlanDetail,EffectiveDate
 ```
 
 Retrieves the monitor to validate the new plan details after a successful upgrade.

--- a/src/DynatraceObservability/DynatraceObservability/ChangeLog.md
+++ b/src/DynatraceObservability/DynatraceObservability/ChangeLog.md
@@ -18,6 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Regenerated cmdlet reference documentation and help to include the complete usage examples for 'Get-AzDynatraceMonitoredSubscription', 'New-AzDynatraceMonitoredSubscription', 'Remove-AzDynatraceMonitoredSubscription', 'Invoke-AzDynatraceManageMonitorAgentInstallation', and 'Update-AzDynatraceMonitorPlan'.
+    - Corrected an invalid bash-style pipeline continuation ('| \') in the 'Update-AzDynatraceMonitorPlan' example so it parses as valid PowerShell.
 
 ## Version 0.4.0
 * Added complete help examples for Dynatrace Observability cmdlets

--- a/src/DynatraceObservability/DynatraceObservability/ChangeLog.md
+++ b/src/DynatraceObservability/DynatraceObservability/ChangeLog.md
@@ -20,6 +20,7 @@
 ## Upcoming Release
 * Regenerated cmdlet reference documentation and help to include the complete usage examples for 'Get-AzDynatraceMonitoredSubscription', 'New-AzDynatraceMonitoredSubscription', 'Remove-AzDynatraceMonitoredSubscription', 'Invoke-AzDynatraceManageMonitorAgentInstallation', and 'Update-AzDynatraceMonitorPlan'.
     - Corrected an invalid bash-style pipeline continuation ('| \') in the 'Update-AzDynatraceMonitorPlan' example so it parses as valid PowerShell.
+    - Fixed example content flagged in review: monitored-subscription examples now set the 'SubscriptionId' property and send a 'properties'-wrapped request body, plan examples use the singular 'PlanDetail' property, agent-installation examples use correct '$((Get-AzContext).Subscription.Id)' subexpression interpolation, and a non-runnable pipeline example was replaced with a runnable multi-subscription example.
 
 ## Version 0.4.0
 * Added complete help examples for Dynatrace Observability cmdlets

--- a/src/DynatraceObservability/DynatraceObservability/help/Get-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Get-AzDynatraceMonitoredSubscription.md
@@ -37,20 +37,105 @@ List the subscriptions currently being monitored by the Dynatrace monitor resour
 
 ## EXAMPLES
 
-### Example 1: List all monitored subscriptions for a Dynatrace monitor
+### Example 1: List monitored subscriptions for a monitor
 ```powershell
-Get-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1"
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor
+$subs | Select-Object Id, Name, Type
 ```
 
-Lists every subscription currently monitored by the specified Dynatrace monitor resource, returning subscription IDs and monitoring status details.
-
-### Example 2: Filter the monitored subscriptions to the current context subscription
-```powershell
-$currentSub = (Get-AzContext).Subscription.Id
-Get-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -SubscriptionId $currentSub
+```output
+Id                                                                                                                    Name    Type
+--                                                                                                                    ----    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default Dynatrace.Observability/monitors/monitoredSubscriptions
 ```
 
-Returns only the monitored subscription matching the active Azure context, useful when a monitor tracks multiple subscriptions.
+Displays monitored subscription entries attached to the specified monitor.
+(Sample output based on recording.)
+
+### Example 2: Use identity pipeline (monitor object)
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$monitorObj | Get-AzDynatraceMonitoredSubscription | Select-Object -First 1 -Property Id, Name
+```
+
+```output
+Id                                                                                                                    Name
+--                                                                                                                    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default
+```
+
+Pipes the monitor object (identity) to retrieve its monitored subscriptions.
+
+### Example 3: Retrieve a single monitored subscription (Get parameter set)
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$all = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor
+($all[0] | Get-AzDynatraceMonitoredSubscription) | Format-List Id, Name, Type, Properties
+```
+
+```output
+Id    : /subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default
+Name  : default
+Type  : Dynatrace.Observability/monitors/monitoredSubscriptions
+Properties : @{operation=AddBegin; monitoredSubscriptionList=}
+```
+
+Selects the first monitored subscription and re-fetches it for detailed inspection (properties show operation AddBegin).
+
+### Example 4: Filter for current subscription
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $currentSub = (Get-AzContext).Subscription.Id
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor | Where-Object { $_.Id -like "/subscriptions/$currentSub/*" }
+$subs | Select-Object Id, Name
+```
+
+```output
+Id                                                                                                                    Name
+--                                                                                                                    ----
+/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default  default
+```
+
+Filters results to the current subscription scope.
+
+### Example 5: Count monitored subscriptions
+```powershell
+$count = (Get-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor").Count
+Write-Host "Total monitored subscriptions: $count"
+```
+
+```output
+Total monitored subscriptions: 1
+```
+
+Outputs a simple count for reporting or validation.
+
+### Example 6: Graceful handling when none exist
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$subs = Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -ErrorAction SilentlyContinue
+if (-not $subs -or $subs.Count -eq 0) { Write-Warning "No monitored subscriptions found." } else { $subs | Select-Object -First 5 }
+```
+
+```output
+WARNING: No monitored subscriptions found.
+```
+
+Demonstrates defensive pattern when list may be empty.
+
+### Example 7: Format output for auditing
+```powershell
+Get-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" | 
+	Select-Object Id,@{n='SubscriptionGuid';e={ ($_).Id.Split('/')[2] }}, Name | Export-Csv -Path monitoredSubs.csv -NoTypeInformation
+```
+
+```output
+"Id","SubscriptionGuid","Name"
+"/subscriptions/b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c/resourceGroups/dyobrg45en7g/providers/Dynatrace.Observability/monitors/dyob83ctr7/monitoredSubscriptions/default","b16e4b4e-2ed8-4f32-bac1-0e3eb56bef5c","default"
+```
+
+Prepares a CSV of monitored subscriptions with extracted subscription GUIDs for audit or inventory.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability/help/Invoke-AzDynatraceManageMonitorAgentInstallation.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Invoke-AzDynatraceManageMonitorAgentInstallation.md
@@ -60,28 +60,78 @@ Performs Dynatrace agent install/uninstall action through the Azure Dynatrace re
 
 ## EXAMPLES
 
-### Example 1: Install the Dynatrace agent on a virtual machine
+### Example 1: Install agent on a VM using expanded parameters
 ```powershell
-$targets = @(
-	@{ resourceId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/rg-dynatrace/providers/Microsoft.Compute/virtualMachines/vm1" }
-)
-Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -Action Install -ManageAgentInstallationList $targets -PassThru
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
 
-Initiates agent installation on the specified VM through the Dynatrace monitor, returning True on success.
+Returns True when the install request is accepted.
 
-### Example 2: Uninstall the Dynatrace agent using a JSON request
+### Example 2: Uninstall agent via expanded parameters
 ```powershell
-$json = @{ 
-	action = "Uninstall"; 
-	manageAgentInstallationList = @(
-		@{ resourceId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/rg-dynatrace/providers/Microsoft.Compute/virtualMachines/vm1" }
-	) 
-} | ConvertTo-Json -Depth 4
-Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -JsonString $json -PassThru
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Uninstall -ManageAgentInstallationList @($entry) -PassThru
 ```
 
-Performs an uninstall using a JSON payload, simplifying scenarios where target resource lists are generated programmatically.
+Removes the Dynatrace agent from the specified resource.
+
+### Example 3: Use request object (Manage parameter set)
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
+$listEntry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $listEntry.Id = $vmId
+$request = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new()
+$request.Action = 'Install'
+$request.ManageAgentInstallationList = @($listEntry)
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Request $request -PassThru
+```
+
+Creates and submits a strongly-typed request object.
+
+### Example 4: Pipeline identity usage (monitor object)
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+$monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Action Install -ManageAgentInstallationList @($entry) -PassThru
+```
+
+Demonstrates identity parameter set by piping the monitor.
+
+### Example 5: JSON string input
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
+$json = '{"action":"Install","manageAgentInstallationList":[{"id":"' + $vmId + '"}]}'
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
+```
+
+Passes the request as raw JSON.
+
+### Example 6: JSON file path input
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
+$path = Join-Path $PWD 'agent-install.json'
+@{ action = 'Install'; manageAgentInstallationList = @(@{ id = $vmId }) } | ConvertTo-Json -Depth 4 | Set-Content -Path $path -Encoding UTF8
+Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path -PassThru
+```
+
+Reads parameters from a JSON file.
+
+### Example 7: Uninstall using request object and identity pipeline
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
+$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
+$entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
+$req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new(); $req.Action = 'Uninstall'; $req.ManageAgentInstallationList = @($entry)
+$monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Request $req -PassThru
+```
+
+Combines identity pipeline with the -Request parameter set.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability/help/Invoke-AzDynatraceManageMonitorAgentInstallation.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Invoke-AzDynatraceManageMonitorAgentInstallation.md
@@ -64,7 +64,7 @@ Performs Dynatrace agent install/uninstall action through the Azure Dynatrace re
 ```powershell
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -74,7 +74,7 @@ Returns True when the install request is accepted.
 ### Example 2: Uninstall agent via expanded parameters
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm01"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -Action Uninstall -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -83,7 +83,7 @@ Removes the Dynatrace agent from the specified resource.
 
 ### Example 3: Use request object (Manage parameter set)
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm02"
 $listEntry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $listEntry.Id = $vmId
 $request = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new()
 $request.Action = 'Install'
@@ -96,7 +96,7 @@ Creates and submits a strongly-typed request object.
 ### Example 4: Pipeline identity usage (monitor object)
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm03"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Action Install -ManageAgentInstallationList @($entry) -PassThru
 ```
@@ -105,7 +105,7 @@ Demonstrates identity parameter set by piping the monitor.
 
 ### Example 5: JSON string input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm04"
 $json = '{"action":"Install","manageAgentInstallationList":[{"id":"' + $vmId + '"}]}'
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
 ```
@@ -114,7 +114,7 @@ Passes the request as raw JSON.
 
 ### Example 6: JSON file path input
 ```powershell
-$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/$rg/providers/Microsoft.Compute/virtualMachines/myVm05"
 $path = Join-Path $PWD 'agent-install.json'
 @{ action = 'Install'; manageAgentInstallationList = @(@{ id = $vmId }) } | ConvertTo-Json -Depth 4 | Set-Content -Path $path -Encoding UTF8
 Invoke-AzDynatraceManageMonitorAgentInstallation -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path -PassThru
@@ -125,7 +125,7 @@ Reads parameters from a JSON file.
 ### Example 7: Uninstall using request object and identity pipeline
 ```powershell
 $monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor" | Select-Object -First 1
-$vmId = "/subscriptions/$(Get-AzContext).Subscription.Id/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
+$vmId = "/subscriptions/$((Get-AzContext).Subscription.Id)/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVm09"
 $entry = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentList]::new(); $entry.Id = $vmId
 $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.ManageAgentInstallationRequest]::new(); $req.Action = 'Uninstall'; $req.ManageAgentInstallationList = @($entry)
 $monitorObj | Invoke-AzDynatraceManageMonitorAgentInstallation -Request $req -PassThru

--- a/src/DynatraceObservability/DynatraceObservability/help/New-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/New-AzDynatraceMonitoredSubscription.md
@@ -39,26 +39,93 @@ Add the subscriptions that should be monitored by the Dynatrace monitor resource
 
 ## EXAMPLES
 
-### Example 1: Add the current subscription to monitoring using an object list
+### Example 1: Begin adding subscription monitoring (AddBegin)
 ```powershell
-$sub = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
-$sub.SubscriptionId = "/subscriptions/$(Get-AzContext).Subscription.Id"
-$list = @($sub)
-New-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -MonitoredSubscriptionList $list -Operation AddBegin
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+
+# Initiate monitoring relationship (AddBegin)
+$subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
+$subs[0].Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddBegin
 ```
 
-Adds the active Azure subscription to the Dynatrace monitor using the expanded parameter set. The Operation value AddBegin initiates monitoring for the supplied subscription list.
+Starts the monitored subscription onboarding workflow.
+Some services require a follow-up AddComplete operation.
 
-### Example 2: Add a subscription using a JSON payload
+### Example 2: Complete add workflow (AddComplete)
 ```powershell
-$json = @{ 
-	monitoredSubscriptionList = @(@{ subscriptionId = "/subscriptions/$(Get-AzContext).Subscription.Id" })
-	operation = 'AddBegin'
-} | ConvertTo-Json -Depth 4
-New-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -JsonString $json
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
+$subs[0].Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddComplete
 ```
 
-Adds the current subscription by supplying a JSON definition (instead of building objects), enabling automation scenarios where the monitored subscription list is generated dynamically.
+Finalizes the monitoring relationship after an earlier AddBegin.
+
+### Example 3: Create via JSON string
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$json = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $subscriptionId + '"}],"operation":"AddBegin"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $json
+```
+
+Uses JSON payload rather than typed objects-helpful for automation or external template generation.
+
+### Example 4: Create via JSON file path
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$path = Join-Path $PWD 'monitored-subscription.json'
+@{ monitoredSubscriptionList = @(@{ id = "/subscriptions/$subscriptionId" }); operation = 'AddBegin' } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path
+```
+
+Reads creation parameters from a JSON file on disk.
+
+### Example 5: Pipeline identity usage with expanded parameters
+```powershell
+$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor"
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+($monitorObj | New-AzDynatraceMonitoredSubscription -MonitoredSubscriptionList @($subObj) -Operation AddBegin)
+```
+
+Demonstrates identity parameter set by piping the monitor object.
+
+### Example 6: Dry run with -WhatIf
+```powershell
+$subscriptionId = (Get-AzContext).Subscription.Id
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -MonitoredSubscriptionList @($subObj) -Operation AddBegin -WhatIf
+```
+
+Shows the operation details without persisting changes.
+
+### Example 7: JSON validation then completion
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $sid = (Get-AzContext).Subscription.Id
+$jsonBegin = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddBegin"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonBegin | Out-Null
+$jsonComplete = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddComplete"}'
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonComplete
+```
+
+Executes the two-step add workflow entirely via JSON payloads.
+
+### Example 8: Verify monitored subscription list
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+Get-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor | Select-Object -First 1 | Format-List Id,Name,Type
+```
+
+Retrieves and inspects monitored subscription after creation.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability/help/New-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/New-AzDynatraceMonitoredSubscription.md
@@ -47,7 +47,7 @@ $subscriptionId = (Get-AzContext).Subscription.Id
 
 # Initiate monitoring relationship (AddBegin)
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddBegin
 ```
 
@@ -60,7 +60,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $subs = @([Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new())
-$subs[0].Id = "/subscriptions/$subscriptionId"
+$subs[0].SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList $subs -Operation AddComplete
 ```
 
@@ -71,7 +71,7 @@ Finalizes the monitoring relationship after an earlier AddBegin.
 $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
-$json = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $subscriptionId + '"}],"operation":"AddBegin"}'
+$json = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $subscriptionId + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $json
 ```
 
@@ -83,26 +83,29 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 $subscriptionId = (Get-AzContext).Subscription.Id
 $path = Join-Path $PWD 'monitored-subscription.json'
-@{ monitoredSubscriptionList = @(@{ id = "/subscriptions/$subscriptionId" }); operation = 'AddBegin' } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
+@{ properties = @{ operation = 'AddBegin'; monitoredSubscriptionList = @(@{ subscriptionId = "/subscriptions/$subscriptionId" }) } } | ConvertTo-Json -Depth 5 | Set-Content -Path $path -Encoding UTF8
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $path
 ```
 
 Reads creation parameters from a JSON file on disk.
 
-### Example 5: Pipeline identity usage with expanded parameters
+### Example 5: Add multiple subscriptions in one request
 ```powershell
-$monitorObj = Get-AzDynatraceMonitor -ResourceGroupName "myResourceGroup" -Name "myDynatraceMonitor"
-$subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
-($monitorObj | New-AzDynatraceMonitoredSubscription -MonitoredSubscriptionList @($subObj) -Operation AddBegin)
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$sub1 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub1.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000001"
+$sub2 = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new()
+$sub2.SubscriptionId = "/subscriptions/00000000-0000-0000-0000-000000000002"
+New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -MonitoredSubscriptionList @($sub1, $sub2) -Operation AddBegin
 ```
 
-Demonstrates identity parameter set by piping the monitor object.
+Onboards several subscriptions to the monitor in a single AddBegin call.
 
 ### Example 6: Dry run with -WhatIf
 ```powershell
 $subscriptionId = (Get-AzContext).Subscription.Id
-$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.Id = "/subscriptions/$subscriptionId"
+$subObj = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.MonitoredSubscription]::new(); $subObj.SubscriptionId = "/subscriptions/$subscriptionId"
 New-AzDynatraceMonitoredSubscription -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -MonitoredSubscriptionList @($subObj) -Operation AddBegin -WhatIf
 ```
 
@@ -111,9 +114,9 @@ Shows the operation details without persisting changes.
 ### Example 7: JSON validation then completion
 ```powershell
 $rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"; $sid = (Get-AzContext).Subscription.Id
-$jsonBegin = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddBegin"}'
+$jsonBegin = '{"properties":{"operation":"AddBegin","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonBegin | Out-Null
-$jsonComplete = '{"monitoredSubscriptionList":[{"id":"/subscriptions/' + $sid + '"}],"operation":"AddComplete"}'
+$jsonComplete = '{"properties":{"operation":"AddComplete","monitoredSubscriptionList":[{"subscriptionId":"/subscriptions/' + $sid + '"}]}}'
 New-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -JsonString $jsonComplete
 ```
 

--- a/src/DynatraceObservability/DynatraceObservability/help/Remove-AzDynatraceMonitoredSubscription.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Remove-AzDynatraceMonitoredSubscription.md
@@ -31,19 +31,45 @@ Delete the subscriptions that are being monitored by the Dynatrace monitor resou
 
 ## EXAMPLES
 
-### Example 1: Remove monitored subscription associations from a Dynatrace monitor
+### Example 1: Validate delete parameters (WhatIf)
 ```powershell
-Remove-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -Confirm:$false
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -WhatIf
 ```
 
-Deletes monitored subscription entries for the specified monitor. The -Confirm:$false switch suppresses the confirmation prompt for non-interactive execution.
+Performs a dry run; this matches the recorded validation step.
 
-### Example 2: Remove and return success status
+### Example 2: Delete monitored subscription (explicit parameters)
 ```powershell
-Remove-AzDynatraceMonitoredSubscription -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -PassThru
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false
 ```
 
-Performs the removal and returns a Boolean True on success, allowing script logic to branch based on the outcome.
+Attempts deletion.
+If the backend is fully provisioned, this should succeed; otherwise you may see `ResourceDeletionFailed`.
+
+### Example 3: Idempotent second delete
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false -ErrorAction SilentlyContinue
+```
+
+Safe to run again; if already deleted, no change occurs.
+
+### Example 4: Handle transient backend errors
+```powershell
+$rg = "myResourceGroup"; $monitor = "myDynatraceMonitor"
+try {
+	Remove-AzDynatraceMonitoredSubscription -ResourceGroupName $rg -MonitorName $monitor -Confirm:$false
+} catch {
+	Write-Warning "Deletion failed: $($_.Exception.Message). Retry after confirming the monitored subscription was fully created." 
+}
+```
+
+Provides a pattern for handling intermittent service errors gracefully.
 
 ## PARAMETERS
 

--- a/src/DynatraceObservability/DynatraceObservability/help/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Update-AzDynatraceMonitorPlan.md
@@ -67,7 +67,7 @@ $rg = "myResourceGroup"
 $monitor = "myDynatraceMonitor"
 
 # Move from trial/preview plan to committed monthly plan
-$result = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
 	-PlanDataUsageType COMMITTED `
 	-PlanDataBillingCycle "1-Month" `
 	-PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" `
@@ -91,10 +91,10 @@ $req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.Upgrade
 $req.PlanData = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.PlanData]::new()
 $req.PlanData.UsageType = "COMMITTED"
 $req.PlanData.BillingCycle = "1-Month"
-$req.PlanData.PlanDetails = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
+$req.PlanData.PlanDetail = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
 $req.PlanData.EffectiveDate = Get-Date
 
-$ok = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
 ```
 
 ```output
@@ -147,7 +147,7 @@ Shows what would change without performing the actual update.
 ```powershell
 Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru | Out-Null
 $updated = Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor
-$updated.planData | Format-List UsageType,BillingCycle,PlanDetails,EffectiveDate
+$updated.planData | Format-List UsageType,BillingCycle,PlanDetail,EffectiveDate
 ```
 
 Retrieves the monitor to validate the new plan details after a successful upgrade.

--- a/src/DynatraceObservability/DynatraceObservability/help/Update-AzDynatraceMonitorPlan.md
+++ b/src/DynatraceObservability/DynatraceObservability/help/Update-AzDynatraceMonitorPlan.md
@@ -61,29 +61,96 @@ Upgrades the billing Plan for Dynatrace monitor resource.
 
 ## EXAMPLES
 
-### Example 1: Upgrade the monitor to a PAYG monthly plan
+### Example 1: Upgrade a monitor plan using expanded parameters
 ```powershell
-Update-AzDynatraceMonitorPlan -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" `
-	-PlanDataPlanDetail "dynatrace-enterprise" -PlanDataUsageType "PAYG" -PlanDataBillingCycle "MONTHLY" `
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+# Move from trial/preview plan to committed monthly plan
+$result = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor `
+	-PlanDataUsageType COMMITTED `
+	-PlanDataBillingCycle "1-Month" `
+	-PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" `
 	-PlanDataEffectiveDate (Get-Date) -PassThru
 ```
 
-Upgrades the billing plan for the Dynatrace monitor to the specified enterprise plan with a monthly Pay-As-You-Go cycle, returning True on success.
-
-### Example 2: Upgrade using a JSON payload
-```powershell
-$json = @{ 
-	planData = @{ 
-		planDetail = "dynatrace-enterprise"; 
-		usageType = "PAYG"; 
-		billingCycle = "MONTHLY"; 
-		effectiveDate = (Get-Date).ToString("o") 
-	} 
-} | ConvertTo-Json -Depth 4
-Update-AzDynatraceMonitorPlan -ResourceGroupName "rg-dynatrace" -MonitorName "dynatrace-monitor1" -JsonString $json -PassThru
+```output
+True
 ```
 
-Performs the same upgrade using a JSON request body, which is convenient for automation scenarios or when the plan details are generated dynamically.
+Updates the monitor's billing plan directly by specifying each field.
+Returns True on success.
+
+### Example 2: Use a request object (Upgrade parameter set)
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+# Construct upgrade request object
+$req = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.UpgradePlanRequest]::new()
+$req.PlanData = [Microsoft.Azure.PowerShell.Cmdlets.DynatraceObservability.Models.PlanData]::new()
+$req.PlanData.UsageType = "COMMITTED"
+$req.PlanData.BillingCycle = "1-Month"
+$req.PlanData.PlanDetails = "dynatrace_azure_enterprise@TIDgmz7xq9ge3py"
+$req.PlanData.EffectiveDate = Get-Date
+
+$ok = Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -Request $req -PassThru
+```
+
+```output
+True
+```
+
+Shows how to supply all plan data via the -Request object instead of individual parameters.
+
+### Example 3: Pipeline identity usage
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+
+Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor |
+	Update-AzDynatraceMonitorPlan -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru
+```
+
+Performs the upgrade by piping the monitor object (identity) and specifying expanded plan fields.
+
+### Example 4: JSON string input
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$json = '{"planData":{"usageType":"COMMITTED","billingCycle":"1-Month","planDetails":"dynatrace_azure_enterprise@TIDgmz7xq9ge3py","effectiveDate":"' + (Get-Date).ToString("o") + '"}}'
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -JsonString $json -PassThru
+```
+
+Passes plan properties as a JSON string.
+Useful for scripting scenarios where you materialize JSON externally.
+
+### Example 5: JSON file path input
+```powershell
+$rg = "myResourceGroup"
+$monitor = "myDynatraceMonitor"
+$jsonPath = Join-Path $PWD 'upgrade-plan.json'
+@{ planData = @{ usageType = 'COMMITTED'; billingCycle = '1-Month'; planDetails = 'dynatrace_azure_enterprise@TIDgmz7xq9ge3py'; effectiveDate = (Get-Date) } } | ConvertTo-Json -Depth 5 | Set-Content -Path $jsonPath -Encoding UTF8
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -JsonFilePath $jsonPath -PassThru
+```
+
+Reads the plan update payload from a JSON file on disk.
+
+### Example 6: Dry run with -WhatIf
+```powershell
+Update-AzDynatraceMonitorPlan -ResourceGroupName "myResourceGroup" -MonitorName "myDynatraceMonitor" -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -WhatIf
+```
+
+Shows what would change without performing the actual update.
+
+### Example 7: Verify plan after update
+```powershell
+Update-AzDynatraceMonitorPlan -ResourceGroupName $rg -MonitorName $monitor -PlanDataUsageType COMMITTED -PlanDataBillingCycle "1-Month" -PlanDataPlanDetail "dynatrace_azure_enterprise@TIDgmz7xq9ge3py" -PassThru | Out-Null
+$updated = Get-AzDynatraceMonitor -ResourceGroupName $rg -Name $monitor
+$updated.planData | Format-List UsageType,BillingCycle,PlanDetails,EffectiveDate
+```
+
+Retrieves the monitor to validate the new plan details after a successful upgrade.
 
 ## PARAMETERS
 


### PR DESCRIPTION
## Description

This is a **documentation-only** change for the **Az.DynatraceObservability** module. It regenerates the cmdlet reference documentation (`docs/`) and markdown help (`help/`) so they reflect the complete usage examples that were previously added under `examples/` (module version 0.4.0) but never regenerated into the committed help. It also fixes one invalid example.

There is **no API-version change, no code/behavior change, and no module-version bump** — the underlying spec (`2024-04-24`) and all cmdlet parameter sets are unchanged.

### Changes

- Regenerated `docs/` and `help/` to include the full usage examples for:
  - `Get-AzDynatraceMonitoredSubscription`
  - `New-AzDynatraceMonitoredSubscription`
  - `Remove-AzDynatraceMonitoredSubscription`
  - `Invoke-AzDynatraceManageMonitorAgentInstallation`
  - `Update-AzDynatraceMonitorPlan`
- Fixed an invalid **bash-style** pipeline continuation (`| \`) in the `Update-AzDynatraceMonitorPlan` example (Example 3 — pipeline identity usage). In PowerShell a trailing `|` is already valid line-continuation; the trailing `\` caused a parse error. The identical fix is applied consistently across the `examples/`, `docs/`, and `help/` copies.

### Testing

This change is documentation-only, so no test recordings were added or modified. All five updated example files were verified to parse as valid PowerShell using `[System.Management.Automation.Language.Parser]::ParseInput` — **0 syntax errors across all 33 code blocks**.

## Mandatory Checklist

- Target release of Azure PowerShell:
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
- [x] I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of `CONTRIBUTING.md`.
- [x] Updated `ChangeLog.md` under `## Upcoming Release`.
- [x] Regenerated markdown help files for the cmdlet documentation changes.
- [ ] Added test coverage for the changes in this PR. _(N/A — documentation-only change; no code or behavior change.)_
- [x] Did not manually adjust the module version.
