### PR TITLE
Fix Get-AzSubscription silently ignoring mismatched -TenantId under MSI auth

### DIFF
--- a/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
+++ b/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
@@ -1,0 +1,55 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common;
+using Microsoft.Azure.Commands.Common.Authentication;
+using Microsoft.Azure.Commands.Common.Authentication.Models;
+using System;
+using System.Management.Automation;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.Profile.Test.UnitTest
+{
+    public class GetAzureRMSubscriptionTest
+    {
+        [Fact]
+        public void ManagedServiceTenantMismatchThrows()
+        {
+            string defaultTenantId = Guid.NewGuid().ToString();
+            string requestedTenantId = Guid.NewGuid().ToString();
+            var command = new GetAzureRMSubscriptionCommand
+            {
+                TenantId = requestedTenantId,
+                DefaultProfile = new AzureRmProfile
+                {
+                    DefaultContext = new AzureContext(
+                        null,
+                        new AzureAccount { Type = AzureAccount.AccountType.ManagedService },
+                        null,
+                        new AzureTenant { Id = defaultTenantId })
+                }
+            };
+
+            var exception = Assert.Throws<PSInvalidOperationException>(() => command.ExecuteCmdlet());
+
+            Assert.Equal(
+                string.Format(
+                    "The current context is using Managed Service Identity (MSI) authentication which only supports the tenant of the Managed Identity ({0}). The requested TenantId '{1}' does not match and cannot be used. Remove the -TenantId parameter or use Connect-AzAccount with a different authentication method to target a different tenant.",
+                    defaultTenantId,
+                    requestedTenantId),
+                exception.Message);
+            Assert.Equal(ErrorKind.UserError, exception.Data[AzurePSErrorDataKeys.ErrorKindKey]);
+        }
+    }
+}

--- a/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
+++ b/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
@@ -15,6 +15,8 @@
 using Microsoft.Azure.Commands.Common;
 using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Models;
+using Microsoft.Azure.Commands.Profile;
+using Microsoft.Azure.Commands.Profile.Properties;
 using System;
 using System.Management.Automation;
 using Xunit;
@@ -45,7 +47,7 @@ namespace Microsoft.Azure.Commands.Profile.Test.UnitTest
 
             Assert.Equal(
                 string.Format(
-                    "The current context is using Managed Service Identity (MSI) authentication which only supports the tenant of the Managed Identity ({0}). The requested TenantId '{1}' does not match and cannot be used. Remove the -TenantId parameter or use Connect-AzAccount with a different authentication method to target a different tenant.",
+                    Resources.MSITenantMismatch,
                     defaultTenantId,
                     requestedTenantId),
                 exception.Message);

--- a/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
+++ b/src/Accounts/Accounts.Test/UnitTest/GetAzureRMSubscriptionTest.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Azure.Commands.Common;
 using Microsoft.Azure.Commands.Common.Authentication;
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using Microsoft.Azure.Commands.Common.Authentication.Models;
 using Microsoft.Azure.Commands.Profile;
 using Microsoft.Azure.Commands.Profile.Properties;

--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 
 ## Upcoming Release
-* Fixed `Get-AzSubscription` to throw a clear error instead of silently returning nothing when `-TenantId` does not match the current context under Managed Service Identity (MSI) authentication.
+* Fixed `Get-AzSubscription` to throw a clear error instead of silently returning nothing when `-TenantId` does not match the current context under Managed Service Identity (MSI) authentication. [#25710]
 
 ## Version 5.5.2
 * Upgraded `Azure.Core` dependency from 1.56.0 to 1.57.0.

--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 
 ## Upcoming Release
+* Fixed `Get-AzSubscription` to throw a clear error instead of silently returning nothing when `-TenantId` does not match the current context under Managed Service Identity (MSI) authentication.
 
 ## Version 5.5.2
 * Upgraded `Azure.Core` dependency from 1.56.0 to 1.57.0.

--- a/src/Accounts/Accounts/Properties/Resources.Designer.cs
+++ b/src/Accounts/Accounts/Properties/Resources.Designer.cs
@@ -761,6 +761,15 @@ namespace Microsoft.Azure.Commands.Profile.Properties {
                 return ResourceManager.GetString("MSITenantDomainNotFound", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The current context is using Managed Service Identity (MSI) authentication which only supports the tenant of the Managed Identity ({0}). The requested TenantId &apos;{1}&apos; does not match and cannot be used. Remove the -TenantId parameter or use Connect-AzAccount with a different authentication method to target a different tenant..
+        /// </summary>
+        internal static string MSITenantMismatch {
+            get {
+                return ResourceManager.GetString("MSITenantMismatch", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to (no account provided).

--- a/src/Accounts/Accounts/Properties/Resources.resx
+++ b/src/Accounts/Accounts/Properties/Resources.resx
@@ -432,6 +432,9 @@
   <data name="MSITenantDomainNotFound" xml:space="preserve">
     <value>Please ensure that the managed service identity found on this machine has proper permissions to the provided tenant domain.</value>
   </data>
+  <data name="MSITenantMismatch" xml:space="preserve">
+    <value>The current context is using Managed Service Identity (MSI) authentication which only supports the tenant of the Managed Identity ({0}). The requested TenantId '{1}' does not match and cannot be used. Remove the -TenantId parameter or use Connect-AzAccount with a different authentication method to target a different tenant.</value>
+  </data>
   <data name="ServicePrincipalTenantDomainNotFound" xml:space="preserve">
     <value>Please ensure that the provided service principal '{0}' is found in the provided tenant domain.</value>
   </data>

--- a/src/Accounts/Accounts/Properties/Resources.resx
+++ b/src/Accounts/Accounts/Properties/Resources.resx
@@ -433,7 +433,7 @@
     <value>Please ensure that the managed service identity found on this machine has proper permissions to the provided tenant domain.</value>
   </data>
   <data name="MSITenantMismatch" xml:space="preserve">
-    <value>The current context is using Managed Service Identity (MSI) authentication which only supports the tenant of the Managed Identity ({0}). The requested TenantId '{1}' does not match and cannot be used. Remove the -TenantId parameter or use Connect-AzAccount with a different authentication method to target a different tenant.</value>
+    <value>The current context is using Managed Identity authentication, which is scoped to tenant '{0}'. The requested -TenantId '{1}' does not match the current tenant and cannot be used. Remove the -TenantId parameter, or use Connect-AzAccount with a different authentication method to target a different tenant.</value>
   </data>
   <data name="ServicePrincipalTenantDomainNotFound" xml:space="preserve">
     <value>Please ensure that the provided service principal '{0}' is found in the provided tenant domain.</value>

--- a/src/Accounts/Accounts/Subscription/GetAzureRMSubscription.cs
+++ b/src/Accounts/Accounts/Subscription/GetAzureRMSubscription.cs
@@ -122,6 +122,10 @@ namespace Microsoft.Azure.Commands.Profile
                             var subscriptions = _client.ListSubscriptions(TenantId);
                             WriteSubscriptions(subscriptions);
                         }
+                        else
+                        {
+                            ThrowMSITenantMismatchError(DefaultContext.Tenant.Id, TenantId);
+                        }
                     }
                     else
                     {
@@ -140,6 +144,13 @@ namespace Microsoft.Azure.Commands.Profile
         private void ThrowSubscriptionNotFoundError(string tenant, string subscription)
         {
             PSArgumentException exception = new PSArgumentException(string.Format(Resources.SubscriptionNotFoundError, subscription, tenant));
+            exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError;
+            throw exception;
+        }
+
+        private void ThrowMSITenantMismatchError(string defaultTenant, string requestedTenant)
+        {
+            PSInvalidOperationException exception = new PSInvalidOperationException(string.Format(Resources.MSITenantMismatch, defaultTenant, requestedTenant));
             exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError;
             throw exception;
         }


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 126/126 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="126/126" -->
<details>
<summary>⚠️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Signature Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️UX Metadata Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Accounts|Microsoft.Subscription|subscriptions|Get-AzSubscription|The path /subscriptions/{subscriptionId} doesn't contains the right resource tpye: Microsoft.Subscription|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Accounts|Microsoft.Subscription|subscriptions|Get-AzSubscription|The path /subscriptions/{subscriptionId} doesn't contains the right resource tpye: Microsoft.Subscription|
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Aks</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.ApplicationInsights</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.05 %|64.86%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.05%|64.86%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.05%|64.86%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.05%|64.86%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Cdn</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzCdnCustomDomain|Get-AzCdnCustomDomain Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnCustomDomain|Get-AzCdnCustomDomain changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeAction|Get-AzCdnEdgeAction Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeAction|Get-AzCdnEdgeAction changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeActionExecutionFilter|Get-AzCdnEdgeActionExecutionFilter Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeActionExecutionFilter|Get-AzCdnEdgeActionExecutionFilter changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeActionVersion|Get-AzCdnEdgeActionVersion Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeActionVersion|Get-AzCdnEdgeActionVersion changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeNode|Get-AzCdnEdgeNode Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeNode|Get-AzCdnEdgeNode changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEndpoint|Get-AzCdnEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEndpoint|Get-AzCdnEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnManagedRuleSet|Get-AzCdnManagedRuleSet Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnManagedRuleSet|Get-AzCdnManagedRuleSet changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnOrigin|Get-AzCdnOrigin Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnOrigin|Get-AzCdnOrigin changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnOriginGroup|Get-AzCdnOriginGroup Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnOriginGroup|Get-AzCdnOriginGroup changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnProfile|Get-AzCdnProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnProfile|Get-AzCdnProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnCustomDomain|Get-AzFrontDoorCdnCustomDomain Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnCustomDomain|Get-AzFrontDoorCdnCustomDomain changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnEndpoint|Get-AzFrontDoorCdnEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnEndpoint|Get-AzFrontDoorCdnEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnOrigin|Get-AzFrontDoorCdnOrigin Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnOrigin|Get-AzFrontDoorCdnOrigin changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnOriginGroup|Get-AzFrontDoorCdnOriginGroup Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnOriginGroup|Get-AzFrontDoorCdnOriginGroup changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnProfile|Get-AzFrontDoorCdnProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnProfile|Get-AzFrontDoorCdnProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRoute|Get-AzFrontDoorCdnRoute Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRoute|Get-AzFrontDoorCdnRoute changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRule|Get-AzFrontDoorCdnRule Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRule|Get-AzFrontDoorCdnRule changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRuleSet|Get-AzFrontDoorCdnRuleSet Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRuleSet|Get-AzFrontDoorCdnRuleSet changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnSecret|Get-AzFrontDoorCdnSecret Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnSecret|Get-AzFrontDoorCdnSecret changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnSecurityPolicy|Get-AzFrontDoorCdnSecurityPolicy Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnSecurityPolicy|Get-AzFrontDoorCdnSecurityPolicy changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCacheExpirationActionObject|New-AzCdnDeliveryRuleCacheExpirationActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCacheKeyQueryStringActionObject|New-AzCdnDeliveryRuleCacheKeyQueryStringActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCookiesConditionObject|New-AzCdnDeliveryRuleCookiesConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleHttpVersionConditionObject|New-AzCdnDeliveryRuleHttpVersionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleIsDeviceConditionObject|New-AzCdnDeliveryRuleIsDeviceConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleObject|New-AzCdnDeliveryRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRulePostArgsConditionObject|New-AzCdnDeliveryRulePostArgsConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleQueryStringConditionObject|New-AzCdnDeliveryRuleQueryStringConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRemoteAddressConditionObject|New-AzCdnDeliveryRuleRemoteAddressConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestBodyConditionObject|New-AzCdnDeliveryRuleRequestBodyConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestHeaderActionObject|New-AzCdnDeliveryRuleRequestHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestHeaderConditionObject|New-AzCdnDeliveryRuleRequestHeaderConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestMethodConditionObject|New-AzCdnDeliveryRuleRequestMethodConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestSchemeConditionObject|New-AzCdnDeliveryRuleRequestSchemeConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestUriConditionObject|New-AzCdnDeliveryRuleRequestUriConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleResponseHeaderActionObject|New-AzCdnDeliveryRuleResponseHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlFileExtensionConditionObject|New-AzCdnDeliveryRuleUrlFileExtensionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlFileNameConditionObject|New-AzCdnDeliveryRuleUrlFileNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlPathConditionObject|New-AzCdnDeliveryRuleUrlPathConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnHealthProbeParametersObject|New-AzCdnHealthProbeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnLoadParametersObject|New-AzCdnLoadParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnManagedHttpsParametersObject|New-AzCdnManagedHttpsParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnMigrationEndpointMappingObject|New-AzCdnMigrationEndpointMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnOriginGroupOverrideActionObject|New-AzCdnOriginGroupOverrideActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnPurgeParametersObject|New-AzCdnPurgeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnResourceReferenceObject|New-AzCdnResourceReferenceObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnResponseBasedOriginErrorDetectionParametersObject|New-AzCdnResponseBasedOriginErrorDetectionParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlRedirectActionObject|New-AzCdnUrlRedirectActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlRewriteActionObject|New-AzCdnUrlRewriteActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlSigningActionObject|New-AzCdnUrlSigningActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUserManagedHttpsParametersObject|New-AzCdnUserManagedHttpsParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnCustomDomainTlsSettingParametersObject|New-AzFrontDoorCdnCustomDomainTlsSettingParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnMigrationParametersObject|New-AzFrontDoorCdnMigrationParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnMigrationWebApplicationFirewallMappingObject|New-AzFrontDoorCdnMigrationWebApplicationFirewallMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnOriginGroupHealthProbeSettingObject|New-AzFrontDoorCdnOriginGroupHealthProbeSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnOriginGroupLoadBalancingSettingObject|New-AzFrontDoorCdnOriginGroupLoadBalancingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileChangeSkuWafMappingObject|New-AzFrontDoorCdnProfileChangeSkuWafMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileLogScrubbingObject|New-AzFrontDoorCdnProfileLogScrubbingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileScrubbingRulesObject|New-AzFrontDoorCdnProfileScrubbingRulesObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileUpgradeParametersObject|New-AzFrontDoorCdnProfileUpgradeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnPurgeParametersObject|New-AzFrontDoorCdnPurgeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnResourceReferenceObject|New-AzFrontDoorCdnResourceReferenceObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleClientPortConditionObject|New-AzFrontDoorCdnRuleClientPortConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleCookiesConditionObject|New-AzFrontDoorCdnRuleCookiesConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleHostNameConditionObject|New-AzFrontDoorCdnRuleHostNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleHttpVersionConditionObject|New-AzFrontDoorCdnRuleHttpVersionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleIsDeviceConditionObject|New-AzFrontDoorCdnRuleIsDeviceConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRulePostArgsConditionObject|New-AzFrontDoorCdnRulePostArgsConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleQueryStringConditionObject|New-AzFrontDoorCdnRuleQueryStringConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRemoteAddressConditionObject|New-AzFrontDoorCdnRuleRemoteAddressConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestBodyConditionObject|New-AzFrontDoorCdnRuleRequestBodyConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestHeaderActionObject|New-AzFrontDoorCdnRuleRequestHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestHeaderConditionObject|New-AzFrontDoorCdnRuleRequestHeaderConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestMethodConditionObject|New-AzFrontDoorCdnRuleRequestMethodConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestSchemeConditionObject|New-AzFrontDoorCdnRuleRequestSchemeConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestUriConditionObject|New-AzFrontDoorCdnRuleRequestUriConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleResponseHeaderActionObject|New-AzFrontDoorCdnRuleResponseHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRouteConfigurationOverrideActionObject|New-AzFrontDoorCdnRuleRouteConfigurationOverrideActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleServerPortConditionObject|New-AzFrontDoorCdnRuleServerPortConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleSocketAddrConditionObject|New-AzFrontDoorCdnRuleSocketAddrConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleSslProtocolConditionObject|New-AzFrontDoorCdnRuleSslProtocolConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlFileExtensionConditionObject|New-AzFrontDoorCdnRuleUrlFileExtensionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlFileNameConditionObject|New-AzFrontDoorCdnRuleUrlFileNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlPathConditionObject|New-AzFrontDoorCdnRuleUrlPathConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlRedirectActionObject|New-AzFrontDoorCdnRuleUrlRedirectActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlRewriteActionObject|New-AzFrontDoorCdnRuleUrlRewriteActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlSigningActionObject|New-AzFrontDoorCdnRuleUrlSigningActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretCustomerCertificateParametersObject|New-AzFrontDoorCdnSecretCustomerCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretFirstPartyManagedCertificateParametersObject|New-AzFrontDoorCdnSecretFirstPartyManagedCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretManagedCertificateParametersObject|New-AzFrontDoorCdnSecretManagedCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretUrlSigningKeyParametersObject|New-AzFrontDoorCdnSecretUrlSigningKeyParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallAssociationObject|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallAssociationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallParametersObject|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzCdnCustomDomain|Get-AzCdnCustomDomain Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnCustomDomain|Get-AzCdnCustomDomain changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeAction|Get-AzCdnEdgeAction Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeAction|Get-AzCdnEdgeAction changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeActionExecutionFilter|Get-AzCdnEdgeActionExecutionFilter Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeActionExecutionFilter|Get-AzCdnEdgeActionExecutionFilter changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeActionVersion|Get-AzCdnEdgeActionVersion Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeActionVersion|Get-AzCdnEdgeActionVersion changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEdgeNode|Get-AzCdnEdgeNode Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEdgeNode|Get-AzCdnEdgeNode changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnEndpoint|Get-AzCdnEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnEndpoint|Get-AzCdnEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnManagedRuleSet|Get-AzCdnManagedRuleSet Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnManagedRuleSet|Get-AzCdnManagedRuleSet changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnOrigin|Get-AzCdnOrigin Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnOrigin|Get-AzCdnOrigin changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnOriginGroup|Get-AzCdnOriginGroup Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnOriginGroup|Get-AzCdnOriginGroup changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzCdnProfile|Get-AzCdnProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzCdnProfile|Get-AzCdnProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnCustomDomain|Get-AzFrontDoorCdnCustomDomain Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnCustomDomain|Get-AzFrontDoorCdnCustomDomain changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnEndpoint|Get-AzFrontDoorCdnEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnEndpoint|Get-AzFrontDoorCdnEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnOrigin|Get-AzFrontDoorCdnOrigin Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnOrigin|Get-AzFrontDoorCdnOrigin changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnOriginGroup|Get-AzFrontDoorCdnOriginGroup Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnOriginGroup|Get-AzFrontDoorCdnOriginGroup changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnProfile|Get-AzFrontDoorCdnProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnProfile|Get-AzFrontDoorCdnProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRoute|Get-AzFrontDoorCdnRoute Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRoute|Get-AzFrontDoorCdnRoute changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRule|Get-AzFrontDoorCdnRule Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRule|Get-AzFrontDoorCdnRule changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnRuleSet|Get-AzFrontDoorCdnRuleSet Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnRuleSet|Get-AzFrontDoorCdnRuleSet changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnSecret|Get-AzFrontDoorCdnSecret Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnSecret|Get-AzFrontDoorCdnSecret changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorCdnSecurityPolicy|Get-AzFrontDoorCdnSecurityPolicy Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorCdnSecurityPolicy|Get-AzFrontDoorCdnSecurityPolicy changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCacheExpirationActionObject|New-AzCdnDeliveryRuleCacheExpirationActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCacheKeyQueryStringActionObject|New-AzCdnDeliveryRuleCacheKeyQueryStringActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleCookiesConditionObject|New-AzCdnDeliveryRuleCookiesConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleHttpVersionConditionObject|New-AzCdnDeliveryRuleHttpVersionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleIsDeviceConditionObject|New-AzCdnDeliveryRuleIsDeviceConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleObject|New-AzCdnDeliveryRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRulePostArgsConditionObject|New-AzCdnDeliveryRulePostArgsConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleQueryStringConditionObject|New-AzCdnDeliveryRuleQueryStringConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRemoteAddressConditionObject|New-AzCdnDeliveryRuleRemoteAddressConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestBodyConditionObject|New-AzCdnDeliveryRuleRequestBodyConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestHeaderActionObject|New-AzCdnDeliveryRuleRequestHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestHeaderConditionObject|New-AzCdnDeliveryRuleRequestHeaderConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestMethodConditionObject|New-AzCdnDeliveryRuleRequestMethodConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestSchemeConditionObject|New-AzCdnDeliveryRuleRequestSchemeConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleRequestUriConditionObject|New-AzCdnDeliveryRuleRequestUriConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleResponseHeaderActionObject|New-AzCdnDeliveryRuleResponseHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlFileExtensionConditionObject|New-AzCdnDeliveryRuleUrlFileExtensionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlFileNameConditionObject|New-AzCdnDeliveryRuleUrlFileNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnDeliveryRuleUrlPathConditionObject|New-AzCdnDeliveryRuleUrlPathConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnHealthProbeParametersObject|New-AzCdnHealthProbeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnLoadParametersObject|New-AzCdnLoadParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnManagedHttpsParametersObject|New-AzCdnManagedHttpsParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnMigrationEndpointMappingObject|New-AzCdnMigrationEndpointMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnOriginGroupOverrideActionObject|New-AzCdnOriginGroupOverrideActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnPurgeParametersObject|New-AzCdnPurgeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnResourceReferenceObject|New-AzCdnResourceReferenceObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnResponseBasedOriginErrorDetectionParametersObject|New-AzCdnResponseBasedOriginErrorDetectionParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlRedirectActionObject|New-AzCdnUrlRedirectActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlRewriteActionObject|New-AzCdnUrlRewriteActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUrlSigningActionObject|New-AzCdnUrlSigningActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzCdnUserManagedHttpsParametersObject|New-AzCdnUserManagedHttpsParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnCustomDomainTlsSettingParametersObject|New-AzFrontDoorCdnCustomDomainTlsSettingParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnMigrationParametersObject|New-AzFrontDoorCdnMigrationParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnMigrationWebApplicationFirewallMappingObject|New-AzFrontDoorCdnMigrationWebApplicationFirewallMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnOriginGroupHealthProbeSettingObject|New-AzFrontDoorCdnOriginGroupHealthProbeSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnOriginGroupLoadBalancingSettingObject|New-AzFrontDoorCdnOriginGroupLoadBalancingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileChangeSkuWafMappingObject|New-AzFrontDoorCdnProfileChangeSkuWafMappingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileLogScrubbingObject|New-AzFrontDoorCdnProfileLogScrubbingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileScrubbingRulesObject|New-AzFrontDoorCdnProfileScrubbingRulesObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnProfileUpgradeParametersObject|New-AzFrontDoorCdnProfileUpgradeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnPurgeParametersObject|New-AzFrontDoorCdnPurgeParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnResourceReferenceObject|New-AzFrontDoorCdnResourceReferenceObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleClientPortConditionObject|New-AzFrontDoorCdnRuleClientPortConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleCookiesConditionObject|New-AzFrontDoorCdnRuleCookiesConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleHostNameConditionObject|New-AzFrontDoorCdnRuleHostNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleHttpVersionConditionObject|New-AzFrontDoorCdnRuleHttpVersionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleIsDeviceConditionObject|New-AzFrontDoorCdnRuleIsDeviceConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRulePostArgsConditionObject|New-AzFrontDoorCdnRulePostArgsConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleQueryStringConditionObject|New-AzFrontDoorCdnRuleQueryStringConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRemoteAddressConditionObject|New-AzFrontDoorCdnRuleRemoteAddressConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestBodyConditionObject|New-AzFrontDoorCdnRuleRequestBodyConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestHeaderActionObject|New-AzFrontDoorCdnRuleRequestHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestHeaderConditionObject|New-AzFrontDoorCdnRuleRequestHeaderConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestMethodConditionObject|New-AzFrontDoorCdnRuleRequestMethodConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestSchemeConditionObject|New-AzFrontDoorCdnRuleRequestSchemeConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRequestUriConditionObject|New-AzFrontDoorCdnRuleRequestUriConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleResponseHeaderActionObject|New-AzFrontDoorCdnRuleResponseHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleRouteConfigurationOverrideActionObject|New-AzFrontDoorCdnRuleRouteConfigurationOverrideActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleServerPortConditionObject|New-AzFrontDoorCdnRuleServerPortConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleSocketAddrConditionObject|New-AzFrontDoorCdnRuleSocketAddrConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleSslProtocolConditionObject|New-AzFrontDoorCdnRuleSslProtocolConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlFileExtensionConditionObject|New-AzFrontDoorCdnRuleUrlFileExtensionConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlFileNameConditionObject|New-AzFrontDoorCdnRuleUrlFileNameConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlPathConditionObject|New-AzFrontDoorCdnRuleUrlPathConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlRedirectActionObject|New-AzFrontDoorCdnRuleUrlRedirectActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlRewriteActionObject|New-AzFrontDoorCdnRuleUrlRewriteActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnRuleUrlSigningActionObject|New-AzFrontDoorCdnRuleUrlSigningActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretCustomerCertificateParametersObject|New-AzFrontDoorCdnSecretCustomerCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretFirstPartyManagedCertificateParametersObject|New-AzFrontDoorCdnSecretFirstPartyManagedCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretManagedCertificateParametersObject|New-AzFrontDoorCdnSecretManagedCertificateParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecretUrlSigningKeyParametersObject|New-AzFrontDoorCdnSecretUrlSigningKeyParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallAssociationObject|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallAssociationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallParametersObject|New-AzFrontDoorCdnSecurityPolicyWebApplicationFirewallParametersObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️UX Metadata Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.14 %|55.41%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.14%|55.41%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.14%|55.41%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|54.14%|55.41%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Compute</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Functions</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.KeyVault</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|25.56 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.KubernetesConfiguration</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.ManagedServiceIdentity</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Monitor</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.NetAppFiles</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Signature Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Help Example Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️UX Metadata Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|66.98 %|78.87%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Network</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.OperationalInsights</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.PrivateDns</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Purview</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|8.20 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|8.20%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|8.20%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|8.20%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Resources</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Sql</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Storage</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|43.96 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|43.96%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|43.96%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|43.96%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Websites</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|44.95 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|44.95%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|44.95%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|44.95%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Fixes #25710.

Under Managed Service Identity (MSI) authentication, `Get-AzSubscription` only supports the tenant of the Default Context. When a caller passed `-TenantId` that did not match `DefaultContext.Tenant.Id`, the cmdlet silently did nothing — no output, no warning, no error — leaving the caller with no indication their request was ignored.

This change throws a clear `PSInvalidOperationException` (`ErrorKind.UserError`) in that mismatch case, with an actionable message pointing to removing `-TenantId` or using `Connect-AzAccount` to target a different tenant. Behavior for the matching-tenant case and for non-MSI auth is unchanged.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Updated `src/Accounts/Accounts/ChangeLog.md` under `## Upcoming Release`.
* **SHOULD** regenerate markdown help files if there is cmdlet API change.
    * No parameter/API change, so no markdown help regeneration needed.
* **SHOULD** have proper test coverage for changes in pull request.
    * Added `GetAzureRMSubscriptionTest.cs` covering the MSI tenant-mismatch exception (type, message, `ErrorKind`).
* **SHOULD NOT** adjust version of module manually in pull request
    * Not changed.

Note: this is my first PR to this repo — I understand the Microsoft CLA needs to be signed before merge.