### PR TITLE
[Network] Add WAF rule ParanoiaLevel and rule set DisplayName to Az.Network output

### DIFF
--- a/src/Network/Network/ApplicationGateway/ApplicationGatewayPowerShellFormatting.cs
+++ b/src/Network/Network/ApplicationGateway/ApplicationGatewayPowerShellFormatting.cs
@@ -25,11 +25,18 @@ namespace Microsoft.Azure.Commands.Network
         public static string Format(PSApplicationGatewayFirewallRule rule, int depth = 0)
         {
             string prefix = new string(' ', depth * ApplicationGatewayPowerShellFormatting.TabSize);
+
+            // ParanoiaLevel is served only by api-version 2026-01-01 and later, and only for DRS and
+            // OWASP rule sets. When absent the line keeps its original shape.
+            string description = string.IsNullOrEmpty(rule.ParanoiaLevel)
+                ? rule.Description
+                : string.Format("[{0}] {1}", rule.ParanoiaLevel, rule.Description);
+
             return string.Format(
                 ApplicationGatewayPowerShellFormatting.RuleFormat, 
                 prefix, 
                 ApplicationGatewayPowerShellFormatting.NormalizeStringLength(Convert.ToString(rule.RuleId), ApplicationGatewayPowerShellFormatting.MaxRuleIdLength),
-                rule.Description);
+                description);
         }
 
         public static string Format(PSApplicationGatewayFirewallRuleGroup ruleGroup, int depth = 0)
@@ -82,7 +89,17 @@ namespace Microsoft.Azure.Commands.Network
             string prefix = new string(' ', depth * ApplicationGatewayPowerShellFormatting.TabSize);
             StringBuilder output = new StringBuilder();
 
-            output.AppendFormat("{0}{1} (Ver. {2}):\n", prefix, ruleSet.RuleSetType, ruleSet.RuleSetVersion);
+            // DisplayName is served only by api-version 2026-01-01 and later. When absent the header
+            // keeps its original shape.
+            if (string.IsNullOrEmpty(ruleSet.DisplayName))
+            {
+                output.AppendFormat("{0}{1} (Ver. {2}):\n", prefix, ruleSet.RuleSetType, ruleSet.RuleSetVersion);
+            }
+            else
+            {
+                output.AppendFormat("{0}{1} (Ver. {2}) {3}:\n", prefix, ruleSet.RuleSetType, ruleSet.RuleSetVersion, ruleSet.DisplayName);
+            }
+
             foreach (var ruleGroup in ruleSet.RuleGroups)
             {
                 output.AppendLine();

--- a/src/Network/Network/ChangeLog.md
+++ b/src/Network/Network/ChangeLog.md
@@ -22,6 +22,10 @@
 * Added minimum and maximum allocation size bounds to IPAM pool creation, update, and output.
     - Use `-MinAllocationSize` and `-MaxAllocationSize` with `New-AzNetworkManagerIpamPool` or `Set-AzNetworkManagerIpamPool`.
     - Specify an empty string with either `Set-AzNetworkManagerIpamPool` parameter to clear that bound.
+* Added WAF (Web Application Firewall) managed rule set display name and managed rule paranoia level to Application Gateway WAF cmdlet output.
+    - Added the `ParanoiaLevel` property to the rules returned by `Get-AzApplicationGatewayAvailableWafRuleSet` and `Get-AzApplicationGatewayWafDynamicManifest`.
+    - Added the `DisplayName` property to the rule sets returned by the same cmdlets.
+    - Both properties are read-only and are populated from API version 2026-01-01 and later.
 
 ## Version 8.2.0
 * Added `Get-AzExpressRouteLag`, `New-AzExpressRouteLag`, `Set-AzExpressRouteLag`, `Remove-AzExpressRouteLag`, `New-AzExpressRouteLagLOA`, `Get-AzExpressRouteLagLink`, and `Get-AzExpressRouteLagMember` for `ExpressRouteLag` resources (Microsoft.Network 2025-09-01 API).

--- a/src/Network/Network/Generated/Models/PSApplicationGatewayFirewallRule.cs
+++ b/src/Network/Network/Generated/Models/PSApplicationGatewayFirewallRule.cs
@@ -38,5 +38,6 @@ namespace Microsoft.Azure.Commands.Network.Models
         public string RuleIdString { get; set; }
         public string State { get; set; }
         public string Action { get; set; }
+        public string ParanoiaLevel { get; set; }
     }
 }

--- a/src/Network/Network/Generated/Models/PSApplicationGatewayFirewallRuleSet.cs
+++ b/src/Network/Network/Generated/Models/PSApplicationGatewayFirewallRuleSet.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Commands.Network.Models
         public string RuleSetType { get; set; }
         [Ps1Xml(Target = ViewControl.Table)]
         public string RuleSetVersion { get; set; }
+        public string DisplayName { get; set; }
         public List<PSApplicationGatewayFirewallRuleGroup> RuleGroups { get; set; }
 
         [JsonIgnore]

--- a/src/Network/Network/Models/PSApplicationGatewayFirewallManifestRuleSet.cs
+++ b/src/Network/Network/Models/PSApplicationGatewayFirewallManifestRuleSet.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.Commands.Network.Models
 
         public string RuleSetVersion { get; set; }
 
+        public string DisplayName { get; set; }
+
         public IList<string> Tiers { get; set; }
 
         public IList<PSApplicationGatewayFirewallRuleGroup> RuleGroups { get; set; }


### PR DESCRIPTION
<!-- act-bot:pr-validation:start --> ### 🤖 PR Validation — ❌ Action needed  | Tests | | :--: | | ❌ 144/148 |  <!-- act-bot:section title="PRComment" category="test" label="Tests" status="Failed" summary="144/148" --> <details> <summary>️✔️Az.Accounts</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.ApplicationInsights</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.Batch</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|79.10 %|79.17%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|79.10%|79.17%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|79.10%|79.17%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|79.10%|79.17%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>️✔️Az.CognitiveServices</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.Compute</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.ContainerRegistry</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.00 %|80.00%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.00%|80.00%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.00%|80.00%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.00%|80.00%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>⚠️Az.CosmosDB</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|72.49 %|85.63%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>⚠️Az.DataLakeStore</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|31.82 %|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|31.82%|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|31.82%|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|31.82%|Test coverage for the module cannot be lower than 50%.| >> >></details> ></details> </details> <details> <summary>️✔️Az.Dns</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.EventHub</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.47 %|87.76%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.47%|87.76%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.47%|87.76%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|75.47%|87.76%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>⚠️Az.KeyVault</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|25.56 %|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Description| >>|---|---|---|---| >>|⚠️|Test Coverage Less Than 50%|25.56%|Test coverage for the module cannot be lower than 50%.| >> >></details> ></details> </details> <details> <summary>️✔️Az.Maintenance</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.ManagedServiceIdentity</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.Monitor</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.NetAppFiles</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|66.98 %|78.87%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|66.98%|78.87%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>❌Az.Network</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Breaking Change Check</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Signature Check</summary> > >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Cmdlet|Description|Remediation| >>|---|---|---|---| >>|⚠️|Get-AzNetworkSecurityPerimeter|Get-AzNetworkSecurityPerimeter Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeter|Get-AzNetworkSecurityPerimeter changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAccessRule|Get-AzNetworkSecurityPerimeterAccessRule Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAccessRule|Get-AzNetworkSecurityPerimeterAccessRule changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociableResourceType|Get-AzNetworkSecurityPerimeterAssociableResourceType Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociableResourceType|Get-AzNetworkSecurityPerimeterAssociableResourceType changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociation|Get-AzNetworkSecurityPerimeterAssociation Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociation|Get-AzNetworkSecurityPerimeterAssociation changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLink|Get-AzNetworkSecurityPerimeterLink Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLink|Get-AzNetworkSecurityPerimeterLink changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLinkReference|Get-AzNetworkSecurityPerimeterLinkReference Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLinkReference|Get-AzNetworkSecurityPerimeterLinkReference changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLoggingConfiguration|Get-AzNetworkSecurityPerimeterLoggingConfiguration Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLoggingConfiguration|Get-AzNetworkSecurityPerimeterLoggingConfiguration changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterProfile|Get-AzNetworkSecurityPerimeterProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterProfile|Get-AzNetworkSecurityPerimeterProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterServiceTag|Get-AzNetworkSecurityPerimeterServiceTag Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterServiceTag|Get-AzNetworkSecurityPerimeterServiceTag changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Cmdlet|Description|Remediation| >>|---|---|---|---| >>|⚠️|Get-AzNetworkSecurityPerimeter|Get-AzNetworkSecurityPerimeter Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeter|Get-AzNetworkSecurityPerimeter changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAccessRule|Get-AzNetworkSecurityPerimeterAccessRule Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAccessRule|Get-AzNetworkSecurityPerimeterAccessRule changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociableResourceType|Get-AzNetworkSecurityPerimeterAssociableResourceType Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociableResourceType|Get-AzNetworkSecurityPerimeterAssociableResourceType changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociation|Get-AzNetworkSecurityPerimeterAssociation Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterAssociation|Get-AzNetworkSecurityPerimeterAssociation changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLink|Get-AzNetworkSecurityPerimeterLink Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLink|Get-AzNetworkSecurityPerimeterLink changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLinkReference|Get-AzNetworkSecurityPerimeterLinkReference Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLinkReference|Get-AzNetworkSecurityPerimeterLinkReference changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterLoggingConfiguration|Get-AzNetworkSecurityPerimeterLoggingConfiguration Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterLoggingConfiguration|Get-AzNetworkSecurityPerimeterLoggingConfiguration changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterProfile|Get-AzNetworkSecurityPerimeterProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterProfile|Get-AzNetworkSecurityPerimeterProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >>|⚠️|Get-AzNetworkSecurityPerimeterServiceTag|Get-AzNetworkSecurityPerimeterServiceTag Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue| >>|⚠️|Get-AzNetworkSecurityPerimeterServiceTag|Get-AzNetworkSecurityPerimeterServiceTag changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.| >> >></details> ></details> ><details> > <summary>️✔️Help File Existence Check</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️File Change Check</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️UX Metadata Check</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>❌Test</summary> > >><details> >> <summary>❌PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>❌PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>❌PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>❌Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.OperationalInsights</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.PrivateDns</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.RecoveryServices</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.Resources</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.Search</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|70.00 %|82.35%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|70.00%|82.35%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|70.00%|82.35%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|70.00%|82.35%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>️✔️Az.Security</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.ServiceBus</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>⚠️Az.SignalR</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>⚠️Test</summary> > >><details> >> <summary>⚠️PowerShell Core - Linux</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|76.47 %|90.62%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - MacOS</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|76.47%|90.62%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️PowerShell Core - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|76.47%|90.62%|Test coverage cannot be lower than the number of the last release.| >> >></details> >><details> >> <summary>⚠️Windows PowerShell - Windows</summary> >> >>|Type|Title|Current Coverage|Last Coverage|Description| >>|---|---|---|---|---| >>|⚠️|Test Coverage Less Than 80%|76.47%|90.62%|Test coverage cannot be lower than the number of the last release.| >> >></details> ></details> </details> <details> <summary>️✔️Az.Sql</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.Storage</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details> <details> <summary>️✔️Az.Websites</summary>  ><details> > <summary>️✔️Build</summary> > >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> ><details> > <summary>️✔️Test</summary> > >><details> >> <summary>️✔️PowerShell Core - Linux</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - MacOS</summary> >> >> >></details> >><details> >> <summary>️✔️PowerShell Core - Windows</summary> >> >> >></details> >><details> >> <summary>️✔️Windows PowerShell - Windows</summary> >> >> >></details> ></details> </details>  <!-- act-bot:section-end -->  <!-- act-bot:pr-validation:end -->  ## Description  Surfaces three read-only WAF properties that NRP returns from api-version `2026-01-01` for Application Gateway.  | Property | PS model | Cmdlet | |---|---|---| | `ParanoiaLevel` | `PSApplicationGatewayFirewallRule` | `Get-AzApplicationGatewayAvailableWafRuleSet`, `Get-AzApplicationGatewayWafDynamicManifest` | | `DisplayName` | `PSApplicationGatewayFirewallRuleSet` | `Get-AzApplicationGatewayAvailableWafRuleSet` | | `DisplayName` | `PSApplicationGatewayFirewallManifestRuleSet` | `Get-AzApplicationGatewayWafDynamicManifest` |  `ParanoiaLevel` is the OWASP CRS paranoia level of a managed rule (`PL1` to `PL4`). `DisplayName` is a friendly name for a managed rule set version, for example `Default Ruleset 2.1` or `Core Ruleset 3.2 (Older than DRS)`.  The REST API change is [azure-rest-api-specs-pr PR 29807](https://github.com/Azure/azure-rest-api-specs-pr/pull/29807).  ### SDK dependency status

The `2026-01-01` Network SDK regeneration is merged into the target release branch. It supplies `paranoiaLevel` and `displayName`, so the former AutoMapper failure is resolved.

This PR now includes production-backed `2026-01-01` session records and scenario assertions for both properties.

No changes are needed in `NetworkResourceManagerProfile.cs`.  There is one consequence worth calling out. `PSApplicationGatewayFirewallManifestRuleSet` has no explicit `CreateMap`, so AutoMapper 6.2.2 builds that map dynamically and validates it inline. Until the SDK is regenerated, the new `DisplayName` has no source property, inline validation fails, and two existing scenario tests break:  - `ApplicationGatewayTests.TestWafDynamicManifest` - `ApplicationGatewayTests.TestApplicationGatewayFirewallPolicyComputedDisabledRules`  Both report the same error:  ``` Error mapping types:   ApplicationGatewayWafDynamicManifestResult -> PSApplicationGatewayWafDynamicManifests Property: AvailableRuleSets ```  The regenerated SDK is now present in the target branch, and the affected mapping path passes playback coverage.  No markdown help regeneration was needed. No parameters or output types changed.  Note: `DefaultRuleSetPropertyFormat.displayName` from the same REST API change is not covered here. No Az.Network cmdlet calls the `ApplicationGatewayWafDynamicManifestsDefault` operations, so it would need a new cmdlet and a design review first.  ## Testing  Production, api-version `2026-01-01`: 5 of 5 scenarios passing. Full evidence: [wiki page (PR)](https://dev.azure.com/msazure/AzureWiki/_git/AzureWiki.wiki/pullrequest/16830120)  | # | Scenario | Result | |---|---|---| | 1 | `DisplayName` on `Get-AzApplicationGatewayAvailableWafRuleSet` | Pass | | 2 | `ParanoiaLevel` on rules from the same cmdlet | Pass | | 3 | `ParanoiaLevel` spread across all rule sets (PL1 469, PL2 196, PL3 38, PL4 18, blank 256) | Pass | | 4 | `DisplayName` on `Get-AzApplicationGatewayWafDynamicManifest` | Pass | | 5 | `ParanoiaLevel` through the manifest cmdlet | Pass |  The committed scenario records use production API version `2026-01-01` responses. The two focused playback tests pass locally.  ## Mandatory Checklist  - Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)   - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)   - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)   - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)   - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)   - [ ] No need for a release  - [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**  * **SHOULD** update `ChangeLog.md` file(s) appropriately     * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.         * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense.     * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only. * **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module) * **SHOULD** have proper test coverage for changes in pull request. * **SHOULD NOT** adjust version of module manually in pull request 