### PR TITLE
Increase PowerShell test job timeout to four hours

### DIFF
--- a/.azure-pipelines/powershell-core.yml
+++ b/.azure-pipelines/powershell-core.yml
@@ -15,7 +15,7 @@ variables:
   IsGenerateBased: $[startsWith(variables['system.pullRequest.targetBranch'], 'generation')]
   BuildTimeoutInMinutes: 120
   AnalysisTimeoutInMinutes: 120
-  TestTimeoutInMinutes: 180
+  TestTimeoutInMinutes: 240
   BuildAzPredictor: false
   EnableTestCoverage: true
   TestCoverageLocation: $(Build.SourcesDirectory)/artifacts

--- a/.azure-pipelines/windows-powershell.yml
+++ b/.azure-pipelines/windows-powershell.yml
@@ -127,7 +127,7 @@ jobs:
 - job: Test
   displayName: Test
   dependsOn: Build
-  timeoutInMinutes: 180
+  timeoutInMinutes: 240
   pool: ${{ variables.AgentPoolName }}
   steps:
   - template: util/download-build-steps.yml


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ Pass |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Succeeded" summary="Pass" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Increase the PowerShell Core and Windows PowerShell test job timeouts from 180 to 240 minutes.

In PR #30018, the PowerShell Core macOS test was cancelled after approximately three hours, while the Linux and Windows test jobs took approximately 2 hours 20 minutes and 2 hours 28 minutes respectively. The current three-hour limit leaves insufficient headroom for normal runtime variation.

## Changes

- Increase TestTimeoutInMinutes in .azure-pipelines/powershell-core.yml from 180 to 240.
- Increase the Test job timeout in .azure-pipelines/windows-powershell.yml from 180 to 240.

## Validation

- Ran git diff --check.
- Confirmed both modified values control the test jobs reported on PR #30018.