### PR TITLE
Fix Set-AzTrafficManagerProfile location bug caused by RecordType positional argument

### DIFF
--- a/src/TrafficManager/TrafficManager.Test/ScenarioTests/ProfileTests.ps1
+++ b/src/TrafficManager/TrafficManager.Test/ScenarioTests/ProfileTests.ps1
@@ -799,7 +799,7 @@ function Test-ProfileChangeRecordTypeShouldFail
 
 	$createdProfile.RecordType = "AAAA"
 
-	Assert-Throws { Set-AzTrafficManagerProfile -TrafficManagerProfile $createdProfile }
+	Assert-ThrowsContains { Set-AzTrafficManagerProfile -TrafficManagerProfile $createdProfile } "The RecordType of a Traffic Manager profile cannot be changed after creation."
 
 	Assert-True { Remove-AzTrafficManagerProfile -Name $profileName -ResourceGroupName $resourceGroup.ResourceGroupName -Force }
 	}

--- a/src/TrafficManager/TrafficManager.Test/UnitTests/TrafficManagerProfileTests.cs
+++ b/src/TrafficManager/TrafficManager.Test/UnitTests/TrafficManagerProfileTests.cs
@@ -1,0 +1,70 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+namespace Microsoft.Azure.Commands.TrafficManager.Test.UnitTests
+{
+    using Microsoft.Azure.Commands.TrafficManager.Models;
+    using Microsoft.Azure.Commands.TrafficManager.Utilities;
+    using Microsoft.WindowsAzure.Commands.ScenarioTest;
+    using ServiceManagement.Common.Models;
+    using WindowsAzure.Commands.Test.Utilities.Common;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class TrafficManagerProfileTests : RMTestBase
+    {
+        public TrafficManagerProfileTests(ITestOutputHelper output)
+        {
+            XunitTracingInterceptor.AddToContext(new XunitTracingInterceptor(output));
+        }
+
+        /// <summary>
+        /// Regression test for a bug where RecordType was passed as a positional constructor
+        /// argument to the generated SDK Profile type, causing it to be placed in the "location"
+        /// slot instead of RecordType's actual position. This resulted in ARM rejecting requests
+        /// with errors like: "The provided location 'A' is not permitted for subscription."
+        /// ToSDKProfile() must always send location = "global" and recordType = the configured value,
+        /// regardless of what RecordType is set to (A, AAAA, CNAME, etc.).
+        /// </summary>
+        [Theory]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        [InlineData("A")]
+        [InlineData("AAAA")]
+        [InlineData("CNAME")]
+        [InlineData(null)]
+        public void ToSDKProfile_SetsGlobalLocation_RegardlessOfRecordType(string recordType)
+        {
+            var profile = new TrafficManagerProfile
+            {
+                Id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/trafficManagerProfiles/profile1",
+                Name = "profile1",
+                RecordType = recordType,
+                ProfileStatus = "Enabled",
+                TrafficRoutingMethod = "Performance",
+                RelativeDnsName = "profile1-dns",
+                Ttl = 30,
+                MonitorProtocol = "HTTPS",
+                MonitorPort = 443,
+                MonitorPath = "/"
+            };
+
+            var sdkProfile = profile.ToSDKProfile();
+
+            Assert.Equal(TrafficManagerClient.ProfileResourceLocation, sdkProfile.Location);
+            Assert.Equal("global", sdkProfile.Location);
+            Assert.Equal(recordType, sdkProfile.RecordType);
+            Assert.Equal("Enabled", sdkProfile.ProfileStatus);
+        }
+    }
+}

--- a/src/TrafficManager/TrafficManager/ChangeLog.md
+++ b/src/TrafficManager/TrafficManager/ChangeLog.md
@@ -21,6 +21,9 @@
 * Upgraded TrafficManager SDK to API version 2024-04-01-preview [#29711]
     - With this release User can Create STP enabled Traffic Manager Profiles ie "RecordType" property is available to be added/modified on TrafficManagerProfile.
     - Updated corresponding test cases
+* Fixed a bug where `Set-AzTrafficManagerProfile` failed with `The provided location 'A'/'AAAA' is not permitted for subscription` whenever the profile's `RecordType` was set
+    - Caused by `RecordType` being passed as a positional constructor argument to the underlying SDK `Profile` model, which placed it into the `location` slot instead of `recordType`
+    - Added a unit test covering the `ToSDKProfile()` mapping and strengthened `Test-ProfileChangeRecordTypeShouldFail` to assert on the expected exception message
 
 ## Version 1.4.0
 * Added ChangeSafety Support

--- a/src/TrafficManager/TrafficManager/Models/TrafficManagerProfile.cs
+++ b/src/TrafficManager/TrafficManager/Models/TrafficManagerProfile.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.Commands.TrafficManager.Models
                 this.Name,
                 Constants.ProfileType,
                 tags,
-                this.RecordType,
-                TrafficManagerClient.ProfileResourceLocation)
+                location: TrafficManagerClient.ProfileResourceLocation,
+                recordType: this.RecordType)
             {
                 ProfileStatus = this.ProfileStatus,
                 TrafficRoutingMethod = this.TrafficRoutingMethod,


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ 18/18 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Succeeded" summary="18/18" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

PR #29711 added a `RecordType` property to `TrafficManagerProfile` and passed it as a new positional argument to `ToSDKProfile()`'s call into the generated SDK `Profile` constructor, without accounting for the constructor's actual parameter order.

As a result:
- `this.RecordType` landed in the constructor's `location` parameter slot instead of `location`.
- `TrafficManagerClient.ProfileResourceLocation` ("global") landed in the `profileStatus` slot instead.

**Impact:** Any `Set-AzTrafficManagerProfile` call on a profile with `RecordType` populated fails with:
```
The provided location 'A' is not permitted for subscription. List of permitted regions is '...'
```
This blocks no-op saves, TTL/status changes, and endpoint add/remove via `Add/Remove-AzTrafficManagerEndpointConfig` + `Set-AzTrafficManagerProfile`.

**Unaffected:** `New-AzTrafficManagerProfile`, `Get-AzTrafficManagerProfile`, and the combined `New-AzTrafficManagerEndpoint`/`Remove-AzTrafficManagerEndpoint` cmdlets (separate API path).

## Changes

- `TrafficManagerProfile.cs`: Use named arguments (`location:`, `recordType:`) in `ToSDKProfile()` so the mapping stays correct regardless of the SDK constructor's parameter order.
- Added `TrafficManagerProfileTests.cs`: unit test verifying `ToSDKProfile()` always sets `location = "global"` and correctly maps `RecordType` for `A`/`AAAA`/`CNAME`/`null`.
- Strengthened `Test-ProfileChangeRecordTypeShouldFail` to assert on the actual expected ARM exception message (`Assert-ThrowsContains`) instead of a bare `Assert-Throws`, so it can no longer silently pass due to an unrelated failure.
- Updated `ChangeLog.md`.

## Why the existing test didn't catch this

`Test-ProfileChangeRecordTypeShouldFail` runs against a recorded HTTP session in Playback mode. The recorded response happens to be the correct `400 BadRequest` ("RecordType...cannot be changed after creation"), so the mocked test passed regardless of what the (buggy) client actually sent. The bug is only visible against live Azure, since the client never validated the request payload before sending it. The new unit test inspects the mapped SDK object directly, so it will catch this class of bug without needing a live call or a re-recorded session.