### PR TITLE
[Resources] Point template deployment what-if noise notice to Deployment Stacks What-If

### DIFF
--- a/src/Resources/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/Resources/ResourceManager/Properties/Resources.Designer.cs
@@ -1260,7 +1260,8 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Note: The result may contain false positive predictions (noise).
-        ///You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues..
+        ///You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
+        ///NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA.
         /// </summary>
         internal static string WhatIfNoiseNotice {
             get {

--- a/src/Resources/ResourceManager/Properties/Resources.resx
+++ b/src/Resources/ResourceManager/Properties/Resources.resx
@@ -495,7 +495,8 @@
   </data>
   <data name="WhatIfNoiseNotice" xml:space="preserve">
     <value>Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.</value>
+You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
+NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA</value>
   </data>
   <data name="ConfirmDeploymentMessage" xml:space="preserve">
     <value>Are you sure you want to execute the deployment?</value>

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 
 ## Upcoming Release
+* Added a notice to template deployment what-if output pointing users to Deployment Stacks What-If, which is now generally available and removes noise from results.
 
 ## Version 10.1.0
 * Added deployment stack WhatIfResult cmdlets for resource group, subscription, and management group scopes.


### PR DESCRIPTION
### Description

What-if for Azure Deployment Stacks is now [generally available](https://aka.ms/stackswhatifGA) in all regions. Stacks What-if filters out noise by diffing against a baseline recorded when the stack was deployed, so it does not carry the false-positive caveat that template deployment what-if still has.

Today the very first thing a customer sees when they run template deployment what-if is a notice telling them the result may be wrong, and the only next step it offers is filing an issue. This PR replaces that call to action with the one that actually solves the problem for them: move to Stacks What-if.

Affected output: `New-AzDeploymentWhatIf` / `New-AzResourceGroupDeploymentWhatIf` and the equivalent subscription, management group, and tenant cmdlets, plus the what-if preview rendered by the deployment create cmdlets.

### Exact verbiage added

```
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### Exact verbiage removed

```
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
```

### Before

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
```

### After

```
Note: The result may contain false positive predictions (noise).
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

`https://` is included on the link (the short link itself is `aka.ms/stackswhatifGA`) so consoles render it as a hyperlink.

### Changes

- `src/Resources/ResourceManager/Properties/Resources.resx` — updated the `WhatIfNoiseNotice` value.
- `src/Resources/ResourceManager/Properties/Resources.Designer.cs` — kept the generated doc comment in sync with the `.resx`. Comment only; the accessor is unchanged.
- `src/Resources/Resources/ChangeLog.md` — added an `## Upcoming Release` entry.

### Scope / risk

- `WhatIfNoiseNotice` is consumed only by `WhatIfOperationResultFormatter.FormatNoiseNotice()`, which formats `PSWhatIfOperationResult` for **template deployment** what-if.
- Deployment stacks what-if returns `PSDeploymentStackWhatIfResult` from the cmdlets under `ResourceManager/Implementation/DeploymentStacksWhatIf` and is formatted separately, so it is deliberately **not** touched. Customers who already moved to stacks are not told to move to stacks.
- `https://aka.ms/WhatIfIssues` had no other references in `src/`, so nothing is left orphaned by its removal.
- Tests in `src/Resources/Resources.Test/Formatters/WhatIfOperationResultFormatterTests.cs` assert with `Assert.Contains` / `Assert.EndsWith` against legend, change, stats, and diagnostic content. None of them include the noise notice, and the `Assert.EndsWith` case targets the trailing stats line while the notice is emitted at the top, so no test updates are required.
