### PR TITLE
[Resources] Point what-if noise notice to Deployment Stacks What-if with reduced noise

### DIFF
--- a/src/Resources/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/Resources/ResourceManager/Properties/Resources.Designer.cs
@@ -1260,7 +1260,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Note: The result may contain false positive predictions (noise).
-        ///NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA.
+        ///NOTICE! - Want to get What-if with reduced noise? Move to Deployment Stacks What-if https://aka.ms/stackswhatifGA.
         /// </summary>
         internal static string WhatIfNoiseNotice {
             get {

--- a/src/Resources/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/Resources/ResourceManager/Properties/Resources.Designer.cs
@@ -1260,7 +1260,6 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Note: The result may contain false positive predictions (noise).
-        ///You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
         ///NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA.
         /// </summary>
         internal static string WhatIfNoiseNotice {

--- a/src/Resources/ResourceManager/Properties/Resources.resx
+++ b/src/Resources/ResourceManager/Properties/Resources.resx
@@ -495,7 +495,7 @@
   </data>
   <data name="WhatIfNoiseNotice" xml:space="preserve">
     <value>Note: The result may contain false positive predictions (noise).
-NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA</value>
+NOTICE! - Want to get What-if with reduced noise? Move to Deployment Stacks What-if https://aka.ms/stackswhatifGA</value>
   </data>
   <data name="ConfirmDeploymentMessage" xml:space="preserve">
     <value>Are you sure you want to execute the deployment?</value>

--- a/src/Resources/ResourceManager/Properties/Resources.resx
+++ b/src/Resources/ResourceManager/Properties/Resources.resx
@@ -495,7 +495,6 @@
   </data>
   <data name="WhatIfNoiseNotice" xml:space="preserve">
     <value>Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
 NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA</value>
   </data>
   <data name="ConfirmDeploymentMessage" xml:space="preserve">

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 
 ## Upcoming Release
-* Added a notice to template deployment what-if output pointing users to Deployment Stacks What-If, which is now generally available and removes noise from results.
+* Added a notice to template deployment what-if output pointing users to Deployment Stacks What-if, which is now generally available and reduces noise in results.
     - Removed the preceding line asking users to open an issue at `https://aka.ms/WhatIfIssues`, so the notice offers a single next step.
 
 ## Version 10.1.0

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -20,6 +20,7 @@
 
 ## Upcoming Release
 * Added a notice to template deployment what-if output pointing users to Deployment Stacks What-If, which is now generally available and removes noise from results.
+    - Removed the preceding line asking users to open an issue at `https://aka.ms/WhatIfIssues`, so the notice offers a single next step.
 
 ## Version 10.1.0
 * Added deployment stack WhatIfResult cmdlets for resource group, subscription, and management group scopes.


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 44/44 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="44/44" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Blueprint</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.CosmosDB</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|73.54 %|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|73.54%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|73.54%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|73.54%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.KeyVault</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.MachineLearning</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.ManagedServiceIdentity</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Monitor</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Network</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Resources</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️UX Metadata Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Get-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Remove-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Get-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Remove-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Description

Follow-up to #30046, which added a line pointing template deployment what-if users to [Deployment Stacks What-if](https://aka.ms/stackswhatifGA) now that it is generally available.

This PR does two things:

1. Removes the older call to action, so the notice states the caveat and then gives a single next step that actually resolves it.
2. Corrects the new line to say **reduced noise** rather than *without noise*, and uses consistent `What-if` capitalization for both occurrences.

"Reduced noise" is the accurate claim: Stacks What-if filters noise against a baseline recorded when the stack was deployed, which substantially reduces false positives rather than eliminating them outright.

Affected output: `New-AzDeploymentWhatIf` / `New-AzResourceGroupDeploymentWhatIf` and the equivalent subscription, management group, and tenant cmdlets, plus the what-if preview rendered by the deployment create cmdlets.

### Before

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### After

```
Note: The result may contain false positive predictions (noise).
NOTICE! - Want to get What-if with reduced noise? Move to Deployment Stacks What-if https://aka.ms/stackswhatifGA
```

### Changes

- `src/Resources/ResourceManager/Properties/Resources.resx` — updated the `WhatIfNoiseNotice` value.
- `src/Resources/ResourceManager/Properties/Resources.Designer.cs` — kept the generated doc comment in sync with the `.resx`. Comment only; the accessor is unchanged.
- `src/Resources/Resources/ChangeLog.md` — extended the existing unreleased entry, since both changes ship in the same release, and aligned its capitalization and wording.

### Scope / risk

- `WhatIfNoiseNotice` is consumed only by `WhatIfOperationResultFormatter.FormatNoiseNotice()`, which formats `PSWhatIfOperationResult` for **template deployment** what-if.
- Deployment stacks what-if returns `PSDeploymentStackWhatIfResult` and is formatted separately, so it is not touched.
- After this change `https://aka.ms/WhatIfIssues` has no remaining code references under `src/`, so nothing is left orphaned.
- Tests in `src/Resources/Resources.Test/Formatters/WhatIfOperationResultFormatterTests.cs` assert with `Assert.Contains` / `Assert.EndsWith` against legend, change, stats, and diagnostic content. None include the noise notice, and the `Assert.EndsWith` case targets the trailing stats line while the notice is emitted at the top, so no test updates are required.
- The final string is byte-identical to the one used by the corresponding Azure CLI change (Azure/azure-cli#33952).
