### PR TITLE
[FrontDoor] Add WAF ParanoiaLevel, DisplayName and Status to Az.FrontDoor output

### DIFF
--- a/src/FrontDoor/FrontDoor.Autorest/README.md
+++ b/src/FrontDoor/FrontDoor.Autorest/README.md
@@ -28,14 +28,14 @@ For information on how to develop for `Az.FrontDoor`, see [how-to.md](how-to.md)
 
 ```yaml
 # pin the swagger version by using the commit id instead of branch name
-commit: 3a617d58ce1d84caade01a3a682ec5c06a9088d9
+commit: 5d1343f93a5bb718e76ee017aa175cf8a697cb73
 require:
 # readme.azure.noprofile.md is the common configuration file
   - $(this-folder)/../../readme.azure.noprofile.md
 # If the swagger has not been put in the repo, you may uncomment the following line and refer to it locally
 input-file:
 # You need to specify your swagger files here.
-  - $(repo)/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/stable/2025-11-01/openapi.json
+  - $(repo)/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/stable/2026-04-01/openapi.json
 
 try-require: 
   - $(repo)/specification/xxx/resource-manager/readme.powershell.md

--- a/src/FrontDoor/FrontDoor/ChangeLog.md
+++ b/src/FrontDoor/FrontDoor/ChangeLog.md
@@ -18,6 +18,11 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Upgraded API version to 2026-04-01.
+* Added WAF managed rule set display name and status, and managed rule paranoia level, to `Get-AzFrontDoorWafManagedRuleSetDefinition` output.
+    - Added the `DisplayName` and `Status` properties to the returned rule sets. `Status` is one of `Preview`, `GA`, `Supported`, or `Deprecated`.
+    - Added the `ParanoiaLevel` property to the returned rules. It is set for DRS rules only and is empty for Bot Manager, DDoS, and AI rules.
+    - All three properties are read-only and are populated from API version 2026-04-01 and later.
 
 ## Version 2.3.0
 * Added support for Front Door WAF managed rule exceptions.


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 14/14 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="14/14" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.FrontDoor</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzFrontDoor|Get-AzFrontDoor Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoor|Get-AzFrontDoor changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorFrontendEndpoint|Get-AzFrontDoorFrontendEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorFrontendEndpoint|Get-AzFrontDoorFrontendEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorRulesEngine|Get-AzFrontDoorRulesEngine Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorRulesEngine|Get-AzFrontDoorRulesEngine changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorWafManagedRuleSetDefinition|Get-AzFrontDoorWafManagedRuleSetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorWafManagedRuleSetDefinition|Get-AzFrontDoorWafManagedRuleSetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorWafPolicy|Get-AzFrontDoorWafPolicy Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorWafPolicy|Get-AzFrontDoorWafPolicy changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendObject|New-AzFrontDoorBackendObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendPoolObject|New-AzFrontDoorBackendPoolObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendPoolsSettingObject|New-AzFrontDoorBackendPoolsSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCacheConfigurationObject|New-AzFrontDoorCacheConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorForwardingConfigurationObject|New-AzFrontDoorForwardingConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorFrontendEndpointObject|New-AzFrontDoorFrontendEndpointObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorHeaderActionObject|New-AzFrontDoorHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorHealthProbeSettingObject|New-AzFrontDoorHealthProbeSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorLoadBalancingSettingObject|New-AzFrontDoorLoadBalancingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorPolicySettingsObject|New-AzFrontDoorPolicySettingsObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRedirectConfigurationObject|New-AzFrontDoorRedirectConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRoutingRuleObject|New-AzFrontDoorRoutingRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineActionObject|New-AzFrontDoorRulesEngineActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineMatchConditionObject|New-AzFrontDoorRulesEngineMatchConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineRuleObject|New-AzFrontDoorRulesEngineRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafCustomRuleGroupByVariableObject|New-AzFrontDoorWafCustomRuleGroupByVariableObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafCustomRuleObject|New-AzFrontDoorWafCustomRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafLogScrubbingRuleObject|New-AzFrontDoorWafLogScrubbingRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafLogScrubbingSettingObject|New-AzFrontDoorWafLogScrubbingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleExclusionObject|New-AzFrontDoorWafManagedRuleExclusionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleObject|New-AzFrontDoorWafManagedRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleOverrideObject|New-AzFrontDoorWafManagedRuleOverrideObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafMatchConditionObject|New-AzFrontDoorWafMatchConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafRuleGroupOverrideObject|New-AzFrontDoorWafRuleGroupOverrideObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzFrontDoor|Get-AzFrontDoor Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoor|Get-AzFrontDoor changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorFrontendEndpoint|Get-AzFrontDoorFrontendEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorFrontendEndpoint|Get-AzFrontDoorFrontendEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorRulesEngine|Get-AzFrontDoorRulesEngine Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorRulesEngine|Get-AzFrontDoorRulesEngine changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorWafManagedRuleSetDefinition|Get-AzFrontDoorWafManagedRuleSetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorWafManagedRuleSetDefinition|Get-AzFrontDoorWafManagedRuleSetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzFrontDoorWafPolicy|Get-AzFrontDoorWafPolicy Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzFrontDoorWafPolicy|Get-AzFrontDoorWafPolicy changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendObject|New-AzFrontDoorBackendObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendPoolObject|New-AzFrontDoorBackendPoolObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorBackendPoolsSettingObject|New-AzFrontDoorBackendPoolsSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorCacheConfigurationObject|New-AzFrontDoorCacheConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorForwardingConfigurationObject|New-AzFrontDoorForwardingConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorFrontendEndpointObject|New-AzFrontDoorFrontendEndpointObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorHeaderActionObject|New-AzFrontDoorHeaderActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorHealthProbeSettingObject|New-AzFrontDoorHealthProbeSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorLoadBalancingSettingObject|New-AzFrontDoorLoadBalancingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorPolicySettingsObject|New-AzFrontDoorPolicySettingsObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRedirectConfigurationObject|New-AzFrontDoorRedirectConfigurationObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRoutingRuleObject|New-AzFrontDoorRoutingRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineActionObject|New-AzFrontDoorRulesEngineActionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineMatchConditionObject|New-AzFrontDoorRulesEngineMatchConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorRulesEngineRuleObject|New-AzFrontDoorRulesEngineRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafCustomRuleGroupByVariableObject|New-AzFrontDoorWafCustomRuleGroupByVariableObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafCustomRuleObject|New-AzFrontDoorWafCustomRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafLogScrubbingRuleObject|New-AzFrontDoorWafLogScrubbingRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafLogScrubbingSettingObject|New-AzFrontDoorWafLogScrubbingSettingObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleExclusionObject|New-AzFrontDoorWafManagedRuleExclusionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleObject|New-AzFrontDoorWafManagedRuleObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafManagedRuleOverrideObject|New-AzFrontDoorWafManagedRuleOverrideObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafMatchConditionObject|New-AzFrontDoorWafMatchConditionObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzFrontDoorWafRuleGroupOverrideObject|New-AzFrontDoorWafRuleGroupOverrideObject changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|75.61 %|89.19%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|75.61%|89.19%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|75.61%|89.19%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|75.61%|89.19%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Bumps the `Az.FrontDoor` swagger pin to API version `2026-04-01` so `Get-AzFrontDoorWafManagedRuleSetDefinition` returns three new read-only WAF fields:

| Property | On | Values |
| --- | --- | --- |
| `DisplayName` | managed rule set | Free text, for example `Default Ruleset 2.2 (Latest, Recommended)` |
| `Status` | managed rule set | `Preview`, `GA`, `Supported`, `Deprecated` |
| `ParanoiaLevel` | managed rule | `PL1`, `PL2`, `PL3`, `PL4`. Set for DRS rules only, empty for Bot Manager, DDoS and AI rules |

Today these values are only visible in the portal. Users scripting WAF policy work have no way to tell which rule set version is current, which is deprecated, or which paranoia level a rule belongs to.

Az.FrontDoor is fully generated, so the change is the API version pin plus the changelog entry. No handwritten model or cmdlet code is involved.

### Blast radius

`2026-04-01` is additive over `2025-11-01`. Compared against the merged spec it adds:

- 2 definitions: `ManagedRuleSetStatus`, `ParanoiaLevel`
- 3 properties: `ManagedRuleSetDefinitionProperties.displayName`, `ManagedRuleSetDefinitionProperties.status`, `ManagedRuleDefinition.paranoiaLevel`

No paths, operations, or existing properties are added, removed or changed. All three new properties are `readOnly`, so there is no new input surface and no breaking change.

### Dependency, and why this is a draft

The spec is not merged yet. It is in [Azure/azure-rest-api-specs PR 42373](https://github.com/Azure/azure-rest-api-specs/pull/42373).

The `commit:` pin above points at that PR head (`5d1343f93a5bb718e76ee017aa175cf8a697cb73`), which resolves today but is not on `main`. Generated output is therefore not included in this PR: the pin has to be repointed at a `main` commit once the spec merges, and regenerating now would only have to be redone. Once the spec lands I will repoint the pin, regenerate, refresh the markdown help, and take this out of draft.

The matching Application Gateway change is [Azure/azure-powershell PR 30023](https://github.com/Azure/azure-powershell/pull/30023).

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. 
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request
