### PR TITLE
Fix Redis Enterprise database InputObject updates

### DIFF
--- a/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/custom/Update-AzRedisEnterpriseCacheDatabase.ps1
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/custom/Update-AzRedisEnterpriseCacheDatabase.ps1
@@ -58,6 +58,90 @@ MODULE <IModule[]>: Optional set of redis modules to enable in this database - m
 .Link
 https://learn.microsoft.com/powershell/module/az.redisenterprisecache/update-azredisenterprisecachedatabase
 #>
+function Resolve-AzRedisEnterpriseCacheDatabaseIdentity {
+    [Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.DoNotExportAttribute()]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Object]
+        ${InputObject}
+    )
+
+    $identityValues = @{}
+    foreach ($propertyName in @('SubscriptionId', 'ResourceGroupName', 'ClusterName', 'DatabaseName', 'Id')) {
+        $propertyValue = $null
+        if ($InputObject -is [System.Collections.IDictionary]) {
+            foreach ($key in $InputObject.Keys) {
+                if ([System.String]::Equals([System.String]$key, $propertyName, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $propertyValue = $InputObject[$key]
+                    break
+                }
+            }
+        } else {
+            $property = $InputObject.PSObject.Properties[$propertyName]
+            if ($null -ne $property) {
+                $propertyValue = $property.Value
+            }
+        }
+
+        if (-not [System.String]::IsNullOrWhiteSpace([System.String]$propertyValue)) {
+            $identityValues[$propertyName] = [System.String]$propertyValue
+        }
+    }
+
+    $requiredFields = @('SubscriptionId', 'ResourceGroupName', 'ClusterName')
+    $hasMissingField = $false
+    foreach ($fieldName in $requiredFields) {
+        if (-not $identityValues.ContainsKey($fieldName)) {
+            $hasMissingField = $true
+            break
+        }
+    }
+
+    if (($hasMissingField -or -not $identityValues.ContainsKey('DatabaseName')) -and $identityValues.ContainsKey('Id')) {
+        $resourceIdPattern = '^/subscriptions/(?<SubscriptionId>[^/]+)/resourceGroups/(?<ResourceGroupName>[^/]+)/providers/Microsoft[.]Cache/redisEnterprise/(?<ClusterName>[^/]+)(?:/databases/(?<DatabaseName>[^/]+))?$'
+        $resourceIdMatch = [System.Text.RegularExpressions.Regex]::Match(
+            $identityValues['Id'],
+            $resourceIdPattern,
+            [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+        if (-not $resourceIdMatch.Success) {
+            throw [System.Management.Automation.PSArgumentException]::new(
+                "InputObject.Id must be a Redis Enterprise cluster or database resource ID in the form '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/redisEnterprise/{clusterName}[/databases/default]'.")
+        }
+
+        foreach ($fieldName in $requiredFields) {
+            if (-not $identityValues.ContainsKey($fieldName)) {
+                $identityValues[$fieldName] = $resourceIdMatch.Groups[$fieldName].Value
+            }
+        }
+        if (-not $identityValues.ContainsKey('DatabaseName') -and $resourceIdMatch.Groups['DatabaseName'].Success) {
+            $identityValues['DatabaseName'] = $resourceIdMatch.Groups['DatabaseName'].Value
+        }
+    }
+
+    foreach ($fieldName in $requiredFields) {
+        if (-not $identityValues.ContainsKey($fieldName)) {
+            throw [System.Management.Automation.PSArgumentException]::new(
+                "InputObject must specify $fieldName directly or through a valid Redis Enterprise resource Id.")
+        }
+    }
+
+    if (-not $identityValues.ContainsKey('DatabaseName')) {
+        $identityValues['DatabaseName'] = 'default'
+    } elseif (-not [System.String]::Equals($identityValues['DatabaseName'], 'default', [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw [System.Management.Automation.PSArgumentException]::new(
+            "InputObject must identify the Redis Enterprise database named 'default'.")
+    }
+
+    return @{
+        SubscriptionId = $identityValues['SubscriptionId']
+        ResourceGroupName = $identityValues['ResourceGroupName']
+        ClusterName = $identityValues['ClusterName']
+        DatabaseName = 'default'
+    }
+}
+
 function Update-AzRedisEnterpriseCacheDatabase {
     [Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.Runtime.PreviewMessage("**********************************************************************************************`n
     * This cmdlet will undergo a breaking change in Az v16.0.0, to be released in May 2026. *`n
@@ -244,8 +328,11 @@ function Update-AzRedisEnterpriseCacheDatabase {
         }
 
         if ($PSCmdlet.ParameterSetName -eq 'UpdateViaIdentityExpanded') {
-            $getParameters['InputObject'] = $InputObject
-            $putParameters['InputObject'] = $InputObject
+            $identityParameters = Resolve-AzRedisEnterpriseCacheDatabaseIdentity -InputObject $InputObject
+            foreach ($parameterName in @('SubscriptionId', 'ResourceGroupName', 'ClusterName', 'DatabaseName')) {
+                $getParameters[$parameterName] = $identityParameters[$parameterName]
+                $putParameters[$parameterName] = $identityParameters[$parameterName]
+            }
         } else {
             $getParameters['ClusterName'] = $ClusterName
             $getParameters['ResourceGroupName'] = $ResourceGroupName

--- a/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/custom/Update-AzRedisEnterpriseCacheDatabase.ps1
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/custom/Update-AzRedisEnterpriseCacheDatabase.ps1
@@ -212,7 +212,91 @@ function Update-AzRedisEnterpriseCacheDatabase {
     )
 
     process {
-        $null = $PSBoundParameters.Add("DatabaseName", "default")
-        Az.RedisEnterpriseCache.internal\Update-AzRedisEnterpriseCacheDatabase @PSBoundParameters
+        $getParameters = @{}
+        $putParameters = @{}
+        $runtimeParameterNames = @(
+            'DefaultProfile',
+            'Break',
+            'HttpPipelineAppend',
+            'HttpPipelinePrepend',
+            'Proxy',
+            'ProxyCredential',
+            'ProxyUseDefaultCredentials'
+        )
+
+        foreach ($parameterName in $runtimeParameterNames) {
+            if ($PSBoundParameters.ContainsKey($parameterName)) {
+                $getParameters[$parameterName] = $PSBoundParameters[$parameterName]
+                $putParameters[$parameterName] = $PSBoundParameters[$parameterName]
+            }
+        }
+
+        foreach ($parameterName in @('AsJob', 'NoWait')) {
+            if ($PSBoundParameters.ContainsKey($parameterName)) {
+                $putParameters[$parameterName] = $PSBoundParameters[$parameterName]
+            }
+        }
+
+        foreach ($parameterName in @('WhatIf', 'Confirm')) {
+            if ($PSBoundParameters.ContainsKey($parameterName)) {
+                $putParameters[$parameterName] = $PSBoundParameters[$parameterName]
+            }
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'UpdateViaIdentityExpanded') {
+            $getParameters['InputObject'] = $InputObject
+            $putParameters['InputObject'] = $InputObject
+        } else {
+            $getParameters['ClusterName'] = $ClusterName
+            $getParameters['ResourceGroupName'] = $ResourceGroupName
+            $getParameters['DatabaseName'] = 'default'
+            $putParameters['ClusterName'] = $ClusterName
+            $putParameters['ResourceGroupName'] = $ResourceGroupName
+            $putParameters['DatabaseName'] = 'default'
+            if ($PSBoundParameters.ContainsKey('SubscriptionId')) {
+                $getParameters['SubscriptionId'] = $SubscriptionId
+                $putParameters['SubscriptionId'] = $SubscriptionId
+            }
+        }
+
+        $currentDatabase = Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase @getParameters
+
+        $propertyMappings = @{
+            AccessKeysAuthentication = 'AccessKeysAuthentication'
+            ClientProtocol = 'ClientProtocol'
+            EvictionPolicy = 'EvictionPolicy'
+            AofPersistenceEnabled = 'PersistenceAofEnabled'
+            AofPersistenceFrequency = 'PersistenceAofFrequency'
+            RdbPersistenceEnabled = 'PersistenceRdbEnabled'
+            RdbPersistenceFrequency = 'PersistenceRdbFrequency'
+            ClusteringPolicy = 'ClusteringPolicy'
+            DeferUpgrade = 'DeferUpgrade'
+            GroupNickname = 'GeoReplicationGroupNickname'
+            LinkedDatabase = 'GeoReplicationLinkedDatabase'
+            Module = 'Module'
+            Port = 'Port'
+        }
+
+        foreach ($parameterName in $propertyMappings.Keys) {
+            $propertyName = $propertyMappings[$parameterName]
+            if ($null -ne $currentDatabase.$propertyName) {
+                $putParameters[$parameterName] = $currentDatabase.$propertyName
+            }
+        }
+
+        foreach ($parameterName in @(
+            'AccessKeysAuthentication',
+            'ClientProtocol',
+            'EvictionPolicy',
+            'AofPersistenceEnabled',
+            'AofPersistenceFrequency',
+            'RdbPersistenceEnabled',
+            'RdbPersistenceFrequency')) {
+            if ($PSBoundParameters.ContainsKey($parameterName)) {
+                $putParameters[$parameterName] = $PSBoundParameters[$parameterName]
+            }
+        }
+
+        Az.RedisEnterpriseCache.internal\New-AzRedisEnterpriseCacheDatabase @putParameters
     }
 }

--- a/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/test/Update-AzRedisEnterpriseCacheDatabase.Tests.ps1
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/test/Update-AzRedisEnterpriseCacheDatabase.Tests.ps1
@@ -6,20 +6,164 @@ if (-Not (Test-Path -Path $loadEnvPath)) {
 $TestRecordingFile = Join-Path $PSScriptRoot 'Update-AzRedisEnterpriseCacheDatabase.Recording.json'
 
 Describe 'Update-AzRedisEnterpriseCacheDatabase' {
-    It 'Uses read-modify-write via PUT for database updates' {
-        $customCmdletPath = Join-Path $PSScriptRoot '..\custom\Update-AzRedisEnterpriseCacheDatabase.ps1'
-        $customCmdlet = Get-Content -Path $customCmdletPath -Raw
-
-        $customCmdlet | Should -Match 'Get-AzRedisEnterpriseCacheDatabase'
-        $customCmdlet | Should -Match 'New-AzRedisEnterpriseCacheDatabase'
-        $customCmdlet | Should -Not -Match 'internal\\Update-AzRedisEnterpriseCacheDatabase'
+    BeforeAll {
+        $customModule = Get-Module -All 'Az.RedisEnterpriseCache.custom'
+        $script:updateCommand = & $customModule {
+            Get-Command 'Update-AzRedisEnterpriseCacheDatabase'
+        }
     }
 
-    It 'UpdateExpanded' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    BeforeEach {
+        Mock 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' -ModuleName 'Az.RedisEnterpriseCache.custom' {
+            [pscustomobject]@{
+                ClientProtocol = 'Encrypted'
+                EvictionPolicy = 'VolatileLRU'
+            }
+        }
+        Mock 'Az.RedisEnterpriseCache.internal\New-AzRedisEnterpriseCacheDatabase' -ModuleName 'Az.RedisEnterpriseCache.custom' { }
     }
 
-    It 'UpdateViaIdentityExpanded' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    It 'preserves the named route including an explicit SubscriptionId' {
+        & $script:updateCommand `
+            -ClusterName 'named-cache' `
+            -ResourceGroupName 'named-rg' `
+            -SubscriptionId 'named-sub' `
+            -ClientProtocol 'Plaintext'
+
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'named-cache' -and
+                $ResourceGroupName -eq 'named-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'named-sub'
+            }
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\New-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'named-cache' -and
+                $ResourceGroupName -eq 'named-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'named-sub' -and
+                $ClientProtocol -eq 'Plaintext' -and
+                $EvictionPolicy -eq 'VolatileLRU'
+            }
+    }
+
+    It 'routes an Id-only database identity through named GET and PUT parameters' {
+        $identity = New-Object Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.Models.RedisEnterpriseCacheIdentity
+        $identity.Id = '/subscriptions/id-sub/resourceGroups/id-rg/providers/Microsoft.Cache/redisEnterprise/id-cache/databases/default'
+
+        & $script:updateCommand -InputObject $identity -EvictionPolicy 'NoEviction'
+
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'id-cache' -and
+                $ResourceGroupName -eq 'id-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'id-sub' -and
+                $null -eq $RedisEnterpriseInputObject
+            }
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\New-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'id-cache' -and
+                $ResourceGroupName -eq 'id-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'id-sub' -and
+                $EvictionPolicy -eq 'NoEviction' -and
+                $null -eq $InputObject -and
+                $null -eq $RedisEnterpriseInputObject
+            }
+        $identity.Id | Should -Be '/subscriptions/id-sub/resourceGroups/id-rg/providers/Microsoft.Cache/redisEnterprise/id-cache/databases/default'
+        $identity.DatabaseName | Should -BeNullOrEmpty
+    }
+
+    It 'defaults an Id-only cluster identity to the default database' {
+        $identity = New-Object Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.Models.RedisEnterpriseCacheIdentity
+        $identity.Id = '/subscriptions/cluster-sub/resourceGroups/cluster-rg/providers/Microsoft.Cache/redisEnterprise/cluster-cache'
+
+        & $script:updateCommand -InputObject $identity
+
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'cluster-cache' -and
+                $ResourceGroupName -eq 'cluster-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'cluster-sub'
+            }
+    }
+
+    It 'routes field-based identities without mutation' {
+        $identity = New-Object Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.Models.RedisEnterpriseCacheIdentity
+        $identity.SubscriptionId = 'field-sub'
+        $identity.ResourceGroupName = 'field-rg'
+        $identity.ClusterName = 'field-cache'
+        $identity.DatabaseName = 'default'
+
+        & $script:updateCommand -InputObject $identity
+
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 1 `
+            -Exactly `
+            -Scope It `
+            -ParameterFilter {
+                $ClusterName -eq 'field-cache' -and
+                $ResourceGroupName -eq 'field-rg' -and
+                $Name -eq 'default' -and
+                $SubscriptionId -eq 'field-sub' -and
+                $null -eq $RedisEnterpriseInputObject
+            }
+        $identity.SubscriptionId | Should -Be 'field-sub'
+        $identity.ResourceGroupName | Should -Be 'field-rg'
+        $identity.ClusterName | Should -Be 'field-cache'
+        $identity.DatabaseName | Should -Be 'default'
+    }
+
+    It 'rejects malformed or wrong-resource IDs before calling GET or PUT' {
+        foreach ($invalidId in @(
+            '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Cache/redis/cache',
+            '/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Cache/redisEnterprise/cache/databases/default/databases/default')) {
+            $identity = New-Object Microsoft.Azure.PowerShell.Cmdlets.RedisEnterpriseCache.Models.RedisEnterpriseCacheIdentity
+            $identity.Id = $invalidId
+
+            $caughtException = $null
+            try {
+                & $script:updateCommand -InputObject $identity
+            } catch {
+                $caughtException = $_.Exception
+            }
+
+            $caughtException | Should -BeOfType ([System.Management.Automation.PSArgumentException])
+        }
+
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\Get-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 0 `
+            -Exactly `
+            -Scope It
+        Assert-MockCalled 'Az.RedisEnterpriseCache.internal\New-AzRedisEnterpriseCacheDatabase' `
+            -ModuleName 'Az.RedisEnterpriseCache.custom' `
+            -Times 0 `
+            -Exactly `
+            -Scope It
     }
 }

--- a/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/test/Update-AzRedisEnterpriseCacheDatabase.Tests.ps1
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache.Autorest/test/Update-AzRedisEnterpriseCacheDatabase.Tests.ps1
@@ -4,14 +4,17 @@ if (-Not (Test-Path -Path $loadEnvPath)) {
 }
 . ($loadEnvPath)
 $TestRecordingFile = Join-Path $PSScriptRoot 'Update-AzRedisEnterpriseCacheDatabase.Recording.json'
-$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
-}
-. ($mockingPath | Select-Object -First 1).FullName
 
 Describe 'Update-AzRedisEnterpriseCacheDatabase' {
+    It 'Uses read-modify-write via PUT for database updates' {
+        $customCmdletPath = Join-Path $PSScriptRoot '..\custom\Update-AzRedisEnterpriseCacheDatabase.ps1'
+        $customCmdlet = Get-Content -Path $customCmdletPath -Raw
+
+        $customCmdlet | Should -Match 'Get-AzRedisEnterpriseCacheDatabase'
+        $customCmdlet | Should -Match 'New-AzRedisEnterpriseCacheDatabase'
+        $customCmdlet | Should -Not -Match 'internal\\Update-AzRedisEnterpriseCacheDatabase'
+    }
+
     It 'UpdateExpanded' -skip {
         { throw [System.NotImplementedException] } | Should -Not -Throw
     }

--- a/src/RedisEnterpriseCache/RedisEnterpriseCache/ChangeLog.md
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache/ChangeLog.md
@@ -18,6 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Fixed `Update-AzRedisEnterpriseCacheDatabase` to update databases using a read-modify-write request.
+    - Fixed issue [#30045]
 
 ## Version 2.0.0
 * [Upgraded code generator](https://go.microsoft.com/fwlink/?linkid=2340249)
@@ -58,4 +60,3 @@
 
 ## Version 0.1.0
 * First preview release for module Az.RedisEnterpriseCache
-

--- a/src/RedisEnterpriseCache/RedisEnterpriseCache/ChangeLog.md
+++ b/src/RedisEnterpriseCache/RedisEnterpriseCache/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 ## Upcoming Release
 * Fixed `Update-AzRedisEnterpriseCacheDatabase` to update databases using a read-modify-write request.
+    - Fixed `InputObject` updates that could append the default database path twice.
     - Fixed issue [#30045]
 
 ## Version 2.0.0


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 18/18 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="18/18" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.RedisEnterpriseCache</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzRedisEnterpriseCache|Get-AzRedisEnterpriseCache Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCache|Get-AzRedisEnterpriseCache changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheAccessPolicyAssignment|Get-AzRedisEnterpriseCacheAccessPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheAccessPolicyAssignment|Get-AzRedisEnterpriseCacheAccessPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheDatabase|Get-AzRedisEnterpriseCacheDatabase Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheDatabase|Get-AzRedisEnterpriseCacheDatabase changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheOperationStatus|Get-AzRedisEnterpriseCacheOperationStatus Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheOperationStatus|Get-AzRedisEnterpriseCacheOperationStatus changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzRedisEnterpriseCache|Get-AzRedisEnterpriseCache Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCache|Get-AzRedisEnterpriseCache changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheAccessPolicyAssignment|Get-AzRedisEnterpriseCacheAccessPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheAccessPolicyAssignment|Get-AzRedisEnterpriseCacheAccessPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheDatabase|Get-AzRedisEnterpriseCacheDatabase Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheDatabase|Get-AzRedisEnterpriseCacheDatabase changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzRedisEnterpriseCacheOperationStatus|Get-AzRedisEnterpriseCacheOperationStatus Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzRedisEnterpriseCacheOperationStatus|Get-AzRedisEnterpriseCacheOperationStatus changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️UX Metadata Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Backports the Redis Enterprise database read-modify-write fix from #30047 to `release-2026-09-01` and fixes the `-InputObject` update path.

The original identity route passed `InputObject` to the internal GET cmdlet, which does not expose that parameter, and identity-based PUT routing could append `/databases/default` twice. This change resolves the Redis Enterprise resource identity into named subscription, resource group, cluster, and database parameters before the GET and PUT calls.

## Validation

- Built the targeted RedisEnterpriseCache solution: 0 warnings, 0 errors.
- Ran `Update-AzRedisEnterpriseCacheDatabase` tests through the generated `test-module.ps1` with Pester 4.10.1: 5 passed, 0 failed.
- Verified the identity resolver is marked `DoNotExport` and is not exposed by the built module.
- Verified Windows PowerShell 5.1 parsing and `git diff --check`.

No live recording was fabricated; the regression coverage uses the real custom wrapper with module-scoped mocks for the internal GET and PUT cmdlets.

Fixes #30045