### PR TITLE
[Release-2026-09-01] Trim changelog after #30073

### DIFF
--- a/src/Accounts/Accounts/ChangeLog.md
+++ b/src/Accounts/Accounts/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 
 ## Upcoming Release
-* Fixed `Get-AzSubscription` to throw a clear error instead of silently returning nothing when `-TenantId` does not match the current context under Managed Service Identity (MSI) authentication. [#25710]
+* Fixed `Get-AzSubscription` to throw a clear error instead of returning nothing when `-TenantId` does not match the current Managed Service Identity (MSI) context. [#25710]
 
 ## Version 5.5.2
 * Upgraded `Azure.Core` dependency from 1.56.0 to 1.57.0.

--- a/src/Compute/Compute/ChangeLog.md
+++ b/src/Compute/Compute/ChangeLog.md
@@ -21,13 +21,13 @@
 -->
 ## Upcoming Release
 * Added `-WireServerUseLocalFileRules` and `-ImdsUseLocalFileRules` to `Set-AzVMProxyAgentSetting` and `Set-AzVmssProxyAgentSetting` to configure local file rules for Virtual Machine (VM) and Virtual Machine Scale Set (VMSS) host endpoints. [#30055]
-* Updated ComputeRP cmdlets to API version 2026-04-01, DiskRP cmdlets to 2026-03-02, and GalleryRP cmdlets to 2025-12-03.
-* Added `-ProcessorMode` to VM and VMSS create and update flows in `New-AzVMConfig`, `New-AzVM`, `Update-AzVM`, `New-AzVmssConfig`, `New-AzVmss`, and `Update-AzVmss`. [#30012]
+* Updated ComputeRP, DiskRP, and GalleryRP cmdlets to API versions 2026-04-01, 2026-03-02, and 2025-12-03, respectively.
+* Added `-ProcessorMode` to VM and VMSS create and update cmdlets: `New-AzVMConfig`, `New-AzVM`, `Update-AzVM`, `New-AzVmssConfig`, `New-AzVmss`, and `Update-AzVmss`. [#30012]
 * Added `-ForceDeallocate` to `Stop-AzVM` to force deallocate a VM during stop; it cannot be used with `-Hibernate`, `-StayProvisioned`, or `-SkipShutdown`.
-* Added `-ReservationType` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` to support creating `Open` capacity reservation groups, and surfaced `ReservationType` on the capacity reservation group output.
-* Added `-DisableCapacityReservationAssignment` to `New-AzVM`, `New-AzVMConfig`, and `Update-AzVM` to opt a VM (Virtual Machine) out of any capacity reservation.
-* Added `CapacityReservationType` to the VM (Virtual Machine) instance view returned by `Get-AzVM -Status`.
-* Added `-DisableCapacityReservationAssignment` parameter to `New-AzVmss`, `New-AzVmssConfig`, and `Update-AzVmss` to opt VMSS instances out of capacity reservation assignment.
+* Added `-ReservationType` to `New-AzCapacityReservationGroup` and `Update-AzCapacityReservationGroup` for `Open` capacity reservation groups, and exposed `ReservationType` in output.
+* Added `-DisableCapacityReservationAssignment` to `New-AzVM`, `New-AzVMConfig`, and `Update-AzVM` to opt a VM out of capacity reservation.
+* Added `CapacityReservationType` to `Get-AzVM -Status` instance views.
+* Added `-DisableCapacityReservationAssignment` to `New-AzVmss`, `New-AzVmssConfig`, and `Update-AzVmss` to opt VMSS instances out of capacity reservation.
 * Added `CapacityReservation` property to `Get-AzVmssVM` output and `CapacityReservationType` property to its `-InstanceView` output.
 
 ## Version 11.8.0

--- a/src/CosmosDB/CosmosDB/ChangeLog.md
+++ b/src/CosmosDB/CosmosDB/ChangeLog.md
@@ -19,7 +19,7 @@
 -->
 
 ## Upcoming Release
-* Regenerated the Cosmos DB management SDK against the stable 2026-03-15 API version.
+* Regenerated the Cosmos DB management SDK with stable API version 2026-03-15.
 
 ## Version 1.21.1
 * Upgraded `Azure.Security.KeyVault.Keys` to `4.10.0` to align with other modules.

--- a/src/IotHub/IotHub/ChangeLog.md
+++ b/src/IotHub/IotHub/ChangeLog.md
@@ -18,7 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Fixed `New-AzIotHubKey` to generate cryptographically secure shared access keys when rotating primary or secondary keys.
+* Fixed `New-AzIotHubKey` to generate secure shared access keys during primary or secondary key rotation.
 
 ## Version 2.9.1
 * Updated `Microsoft.Extensions.DependencyInjection.Abstractions` dependency from `8.0.2` to `10.0.3`.

--- a/src/KeyVault/KeyVault/ChangeLog.md
+++ b/src/KeyVault/KeyVault/ChangeLog.md
@@ -19,8 +19,8 @@
 -->
 ## Upcoming Release
 * Upgraded the Key Vault control plane API version to '2026-02-01'.
-    - Earlier API versions retire on 27 February 2027; this upgrade keeps `Az.KeyVault` working past that date.
-    - No action or cmdlet behavior change is required. `New-AzKeyVault` has created vaults with RBAC (Role-Based Access Control) enabled by default since Az.KeyVault 6.0.0 and still sends this setting explicitly, so the new service-side default does not affect vaults created through this module. Use `DisableRbacAuthorization` to create a vault that uses access policies.
+    - Earlier API versions retire on 27 February 2027; this upgrade keeps `Az.KeyVault` working afterward.
+    - No action or cmdlet behavior change is required. `New-AzKeyVault` has created vaults with RBAC (Role-Based Access Control) enabled by default since Az.KeyVault 6.0.0 and sends this setting explicitly, so the new service default does not affect it. Use `DisableRbacAuthorization` for access policies.
 
 ## Version 6.6.0
 * Populated 'KeySize' in 'Get-AzKeyVaultKey' output for additional key types when available; previously only RSA keys had a size populated.

--- a/src/NetAppFiles/NetAppFiles/ChangeLog.md
+++ b/src/NetAppFiles/NetAppFiles/ChangeLog.md
@@ -18,8 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Added deprecation notices to all Azure NetApp Files subvolume cmdlets
-* Added breaking change notices for the removal of the `EnableSubvolume` parameter and `EnableSubvolumes` volume output property
+* Added deprecation notices to Azure NetApp Files subvolume cmdlets
+* Added breaking change notices for removing `EnableSubvolume` and the `EnableSubvolumes` volume output property
 * Fixed the output type of `Get-AzNetAppFilesVolumeQuotaRule` from `PSNetAppFilesVolume` to `PSNetAppFilesVolumeQuotaRule`
 
 ## Version 1.4.0

--- a/src/Network/Network/ChangeLog.md
+++ b/src/Network/Network/ChangeLog.md
@@ -22,29 +22,29 @@
 * Added `Get-AzExpressRouteLag`, `New-AzExpressRouteLag`, `Set-AzExpressRouteLag`, `Remove-AzExpressRouteLag`, `New-AzExpressRouteLagLOA`, `Get-AzExpressRouteLagLink`, and `Get-AzExpressRouteLagMember` for `ExpressRouteLag` resources (Microsoft.Network 2025-09-01 API).
     - The cmdlets support CRUD operations, letter of authorization generation, and link and member retrieval.
     - Added `New-AzExpressRouteLagIdentity`, `Get-AzExpressRouteLagIdentity`, `Set-AzExpressRouteLagIdentity`, and `Remove-AzExpressRouteLagIdentity` for the user-assigned managed identity on an `ExpressRouteLag`.
-* Added `Get-AzAddressPrefixSet`, `New-AzAddressPrefixSet`, `Set-AzAddressPrefixSet`, and `Remove-AzAddressPrefixSet` to manage IPv4 and IPv6 prefixes in Classless Inter-Domain Routing (CIDR) notation for application security groups.
-* Added `Move-AzVirtualNetworkIpConfiguration` to move one or more secondary private IP configurations between network interfaces within a virtual network, and `New-AzMoveIpConfigurationItem` to create source and target pairs. The long-running operation supports `-AsJob`.
-* Added `-AddressPrefixV6` to specify or update the IPv6 prefix with `New-AzVirtualHub` and `Update-AzVirtualHub`, and `-EnableOnlyIpv6Peering` to enable IPv6-only peering with `New-AzVirtualHubVnetConnection`.
+* Added `Get-AzAddressPrefixSet`, `New-AzAddressPrefixSet`, `Set-AzAddressPrefixSet`, and `Remove-AzAddressPrefixSet` to manage IPv4 and IPv6 CIDR (Classless Inter-Domain Routing) prefixes for application security groups.
+* Added `Move-AzVirtualNetworkIpConfiguration` to move secondary private IP configurations between network interfaces in a virtual network, and `New-AzMoveIpConfigurationItem` to create source and target pairs. Supports `-AsJob`.
+* Added `-AddressPrefixV6` to `New-AzVirtualHub` and `Update-AzVirtualHub`, and `-EnableOnlyIpv6Peering` to `New-AzVirtualHubVnetConnection`.
 * Added support for managing Kube Selector Groups on a firewall policy.
     - `Get-AzFirewallPolicyKubeSelectorGroup`, `New-AzFirewallPolicyKubeSelectorGroup`, `Set-AzFirewallPolicyKubeSelectorGroup`, `Remove-AzFirewallPolicyKubeSelectorGroup`.
     - Added `New-AzFirewallPolicyKubeLabelSelector` and `New-AzFirewallPolicyLabelSelectorExpression` for pod and namespace label selectors.
-* Exposed service-managed, read-only AFC (Azure Firewall for Containers) properties: `AfcManaged` on `Get-AzFirewallPolicy` to indicate AFC management, and the `AfcConfiguration.ServiceEndpoint` control-plane endpoint on `Get-AzFirewall`. The latter cannot be set or updated through `New-AzFirewall` or `Set-AzFirewall`.
+* Exposed read-only AFC (Azure Firewall for Containers) properties: `AfcManaged` on `Get-AzFirewallPolicy` and the `AfcConfiguration.ServiceEndpoint` control-plane endpoint on `Get-AzFirewall`. The endpoint cannot be set through `New-AzFirewall` or `Set-AzFirewall`.
 * Upgraded Network SDK to API version `2025-09-01`; added `DisableDefaultServerHeaderInResponse` to `Get-AzApplicationGateway` output and `-DisableDefaultServerHeaderInResponse` to `New-AzApplicationGateway`.
-* Added the read-only `UpgradedToV2` property to `Get-AzPublicIpAddress` and `Get-AzPublicIpPrefix` output to indicate whether the SKU was upgraded from Standard to StandardV2.
+* Added read-only `UpgradedToV2` output to `Get-AzPublicIpAddress` and `Get-AzPublicIpPrefix` for Standard-to-StandardV2 SKU upgrades.
 * Added `Get-AzInterconnectGroup` to retrieve one or more InterconnectGroups, and `New-AzInterconnectGroup`, `Set-AzInterconnectGroup`, and `Remove-AzInterconnectGroup` to create, update, and delete them.
     - Added `Get-AzInterconnectGroupSubgroup` to retrieve one or all subgroups and `Get-AzInterconnectGroupNodeAvailability` to retrieve node availability.
 * Added `-DdosCustomPolicyId` and `-RemoveDdosCustomPolicy` to `Set-AzPublicIpAddress` to add or remove DDoS custom policy (DCP) associations on supported Public IP address attachments, without requiring a specific DDoS protection mode.
 * Added `New-AzFirstPartyServiceTag`, `Get-AzFirstPartyServiceTag`, `Set-AzFirstPartyServiceTag`, and `Remove-AzFirstPartyServiceTag` to create, retrieve, update, and remove First Party Service Tags, and association support to `New-AzPublicIpTag`.
-* Added `Get-AzVirtualNetworkGatewayEffectiveRoute` to retrieve effective routes for a Virtual Network Gateway.
+* Added `Get-AzVirtualNetworkGatewayEffectiveRoute` for Virtual Network Gateway effective routes.
 * Added `-Mode` and `-Scope` to `New-AzLoadBalancer`. Use `-Mode Advanced` with `-Scope Public` or `-Scope Private` to create an advanced (Banksy-based) Standard SKU load balancer; the mode cannot be changed afterward.
 * Added the `-EnableConnectionTracking` switch to `New-AzLoadBalancerFrontendIpConfig`, `Add-AzLoadBalancerFrontendIpConfig`, and `Set-AzLoadBalancerFrontendIpConfig`.
     - Enables UDP (User Datagram Protocol) flow tracking for the frontend IP configuration so packets in the same flow consistently reach the same backend instance, taking precedence over rule-level settings. Requires a load balancer created with `-Mode Advanced` and `-Scope`.
 * Added multi-cloud ExpressRoute circuit support with the `MultiCloud` value for `-SkuTier`, and `-PartnerAccountId` and `-ActivationKey` on `New-AzExpressRouteCircuit`.
     - Exposed `PartnerAccountId`, `ActivationKey`, and `ResiliencyLevel` on `PSExpressRouteCircuit`.
 * Added `RoutingConfiguration`, `VirtualHubVnetConnection`, and `VirtualHubVnetConnectionId` parameters to `Add-AzRouteServerPeer` and `Update-AzRouteServerPeer`.
-    - Supports inbound and outbound route maps and a hub virtual network connection, specified by object or resource ID, for Route Server BGP peer connections.
+    - Supports inbound and outbound route maps and a hub virtual network connection by object or resource ID.
 * Added `RoutingConfiguration` parameter to `New-AzVirtualNetworkGatewayConnection` and `Set-AzVirtualNetworkGatewayConnection`.
-    - Supports inbound and outbound route maps for Virtual Network Gateway connections.
+    - Supports inbound and outbound route maps.
 
 ## Version 8.1.0
 * Added new cmdlets for ConnectionPolicy management under VirtualHub

--- a/src/RecoveryServices/RecoveryServices/ChangeLog.md
+++ b/src/RecoveryServices/RecoveryServices/ChangeLog.md
@@ -19,10 +19,10 @@
 -->
 
 ## Upcoming Release
-* Added Cross Region Restore for Azure File Share backup items through `Get-AzRecoveryServicesBackupItem -UseSecondaryRegion`, `Get-AzRecoveryServicesBackupRecoveryPoint -UseSecondaryRegion`, and `Restore-AzRecoveryServicesBackupItem -RestoreToSecondaryRegion`.
+* Added Cross Region Restore for Azure File Share backups through `Get-AzRecoveryServicesBackupItem -UseSecondaryRegion`, `Get-AzRecoveryServicesBackupRecoveryPoint -UseSecondaryRegion`, and `Restore-AzRecoveryServicesBackupItem -RestoreToSecondaryRegion`.
 * Refined soft delete behavior for Azure File Share backup items
-    - `Undo-AzRecoveryServicesBackupItemDeletion` now throws a clear error unless the item is in the soft-deleted (`ToBeDeleted`) state instead of sending an undelete request that cannot succeed.
-    - Corrected `DateOfPurge` to use the remaining deferred-delete window returned by the service instead of a fixed 14-day period.
+    - `Undo-AzRecoveryServicesBackupItemDeletion` now errors unless the item is soft-deleted (`ToBeDeleted`), avoiding an invalid undelete request.
+    - Corrected `DateOfPurge` to use the remaining deferred-delete window returned by the service instead of a fixed 14 days.
 
 ## Version 7.14.0
 * Added Cross Subscription Backup (CSB) support for Azure VM:

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -20,10 +20,10 @@
 
 ## Upcoming Release
 * Updated Policy cmdlets to use `2026-01-01` API
-* Added `Get-AzPolicyEnrollment`, `New-AzPolicyEnrollment`, `Remove-AzPolicyEnrollment`, and `Update-AzPolicyEnrollment` for Policy Enrollment resources.
-* Added a template deployment what-if notice for the generally available Deployment Stacks What-If, which removes noise from results.
-* Renamed `DenySettingsApplyToChildScope` to `DenySettingsApplyToChildScopes` for deployment stack WhatIfResult cmdlets, retaining the old name as an alias.
-* Added `ResourcesWithoutDeleteSupport` to deployment stack WhatIfResult cmdlets, and tag support to the cmdlets and output.
+* Added `Get-AzPolicyEnrollment`, `New-AzPolicyEnrollment`, `Remove-AzPolicyEnrollment`, and `Update-AzPolicyEnrollment` for Policy Enrollments.
+* Added a template deployment what-if notice for generally available Deployment Stacks What-If to reduce result noise.
+* Renamed `DenySettingsApplyToChildScope` to `DenySettingsApplyToChildScopes` for deployment stack WhatIfResult cmdlets, retaining an alias.
+* Added `ResourcesWithoutDeleteSupport` and tag support to deployment stack WhatIfResult cmdlets and output.
 
 ## Version 10.1.0
 * Added deployment stack WhatIfResult cmdlets for resource group, subscription, and management group scopes.

--- a/src/Security/Security/ChangeLog.md
+++ b/src/Security/Security/ChangeLog.md
@@ -19,10 +19,10 @@
 -->
 
 ## Upcoming Release
-* Added new cmdlets to support SQL Vulnerability Assessment (2026-04-01-preview) API:
-    - Added `Get-AzSecuritySqlVulnerabilityAssessmentSetting`, `New-AzSecuritySqlVulnerabilityAssessmentSetting`, `Update-AzSecuritySqlVulnerabilityAssessmentSetting`, and `Remove-AzSecuritySqlVulnerabilityAssessmentSetting`.
-    - Added `Get-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, `New-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, `Add-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, and `Remove-AzSecuritySqlVulnerabilityAssessmentBaselineRule`.
-    - Added `Get-AzSecuritySqlVulnerabilityAssessmentScan`, `Get-AzSecuritySqlVulnerabilityAssessmentScanRuleResult`, and `Invoke-AzSecurityInitiateSqlVulnerabilityAssessmentScan`. The per-rule result cmdlet name avoids a collision with the legacy `Get-AzSecuritySqlVulnerabilityAssessmentScanResult`.
+* Added SQL Vulnerability Assessment cmdlets for the 2026-04-01-preview API:
+    - `Get-AzSecuritySqlVulnerabilityAssessmentSetting`, `New-AzSecuritySqlVulnerabilityAssessmentSetting`, `Update-AzSecuritySqlVulnerabilityAssessmentSetting`, and `Remove-AzSecuritySqlVulnerabilityAssessmentSetting`.
+    - `Get-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, `New-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, `Add-AzSecuritySqlVulnerabilityAssessmentBaselineRule`, and `Remove-AzSecuritySqlVulnerabilityAssessmentBaselineRule`.
+    - `Get-AzSecuritySqlVulnerabilityAssessmentScan`, `Get-AzSecuritySqlVulnerabilityAssessmentScanRuleResult`, and `Invoke-AzSecurityInitiateSqlVulnerabilityAssessmentScan`. The per-rule name avoids a collision with legacy `Get-AzSecuritySqlVulnerabilityAssessmentScanResult`.
 
 ## Version 1.9.0
 * Added ChangeSafety Support

--- a/src/Sql/Sql/ChangeLog.md
+++ b/src/Sql/Sql/ChangeLog.md
@@ -18,8 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Added multi-database Managed Instance link support through `LinkMode` on `New-AzSqlInstanceLink` and database membership updates on `Update-AzSqlInstanceLink`.
-* Enhanced `Get-AzSqlDeletedServer` for subscription-level queries across all locations by making location optional and adding `ScheduledPurgeTime` and `Location` output properties.
+* Added multi-database Managed Instance links through `LinkMode` on `New-AzSqlInstanceLink` and database membership updates on `Update-AzSqlInstanceLink`.
+* Enhanced `Get-AzSqlDeletedServer` subscription-level queries by making location optional and adding `ScheduledPurgeTime` and `Location` output.
 
 ## Version 7.0.0
 * Added ChangeSafety Support

--- a/src/VMware/VMware/ChangeLog.md
+++ b/src/VMware/VMware/ChangeLog.md
@@ -18,7 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Fixed `New-AzVMwareVcf5LicenseObject` and the `-VcfLicense` parameter on `New-AzVMwarePrivateCloud` missing from the `0.9.1` package; both are now generated and exported.
+* Fixed missing `New-AzVMwareVcf5LicenseObject` and `-VcfLicense` on `New-AzVMwarePrivateCloud` in package `0.9.1`; both are now generated and exported.
 
 ## Version 0.9.1
 * Added `-VcfLicense` parameter to `New-AzVMwarePrivateCloud` to support setting a VMware Cloud Foundation (VCF) license during private cloud provisioning

--- a/src/Websites/Websites/ChangeLog.md
+++ b/src/Websites/Websites/ChangeLog.md
@@ -18,7 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-* Added support for creating and updating App Service Environment plans with Isolated v4 and memory-optimized Isolated v4 SKUs.
+* Added App Service Environment plan create and update support for Isolated v4 and memory-optimized Isolated v4 SKUs.
 
 ## Version 4.0.0
 * Added ChangeSafety Support


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ Pass |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Succeeded" summary="Pass" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Trim the September release notes after #30073 pushed the generated root changelog over the 10,000-character limit.

- Distributes wording reductions across 13 affected modules; the already-minimal `Az.Cdn` entry is unchanged.
- Preserves every release-note bullet and all cmdlet, parameter, property, API, and version identifiers.
- Reduces the generated `16.3.0` changelog section from 10,619 to 9,788 characters, leaving 212 characters of headroom.

## Validation

- `git diff --check`
- Verified no release-note bullets were added or removed.
- Verified no backtick-delimited identifiers were added or removed.
- Documentation-only change; no build or tests required.