### PR TITLE
[Resources] Amend what-if noise notice to point to Deployment Stacks

### DIFF
--- a/src/Resources/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/Resources/ResourceManager/Properties/Resources.Designer.cs
@@ -1259,9 +1259,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Cmdlets.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Note: The result may contain false positive predictions (noise).
-        ///You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
-        ///NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA.
+        ///   Looks up a localized string similar to Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA).
         /// </summary>
         internal static string WhatIfNoiseNotice {
             get {

--- a/src/Resources/ResourceManager/Properties/Resources.resx
+++ b/src/Resources/ResourceManager/Properties/Resources.resx
@@ -494,9 +494,7 @@
     <value>Status Message: {0}</value>
   </data>
   <data name="WhatIfNoiseNotice" xml:space="preserve">
-    <value>Note: The result may contain false positive predictions (noise).
-You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
-NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA</value>
+    <value>Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)</value>
   </data>
   <data name="ConfirmDeploymentMessage" xml:space="preserve">
     <value>Are you sure you want to execute the deployment?</value>

--- a/src/Resources/Resources/ChangeLog.md
+++ b/src/Resources/Resources/ChangeLog.md
@@ -21,7 +21,7 @@
 ## Upcoming Release
 * Updated Policy cmdlets to use `2026-01-01` API
 * Added `Get-AzPolicyEnrollment`, `New-AzPolicyEnrollment`, `Remove-AzPolicyEnrollment`, and `Update-AzPolicyEnrollment` cmdlets to interact with new Policy Enrollments resources.
-* Added a notice to template deployment what-if output pointing users to Deployment Stacks What-If, which is now generally available and removes noise from results.
+* Amended the template deployment what-if noise notice to point users to Deployment Stacks what-if for noise reduction, replacing the previous issue-filing line.
 * Renamed `DenySettingsApplyToChildScope` to `DenySettingsApplyToChildScopes` for deployment stack WhatIfResult cmdlets while retaining the old name as an alias.
 * Added `ResourcesWithoutDeleteSupport` to deployment stack WhatIfResult cmdlets.
 * Added tag support to deployment stack WhatIfResult cmdlets and output.


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 44/44 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="44/44" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Blueprint</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|23.08%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.CosmosDB</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|72.49 %|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Last Coverage|Description|
>>|---|---|---|---|---|
>>|⚠️|Test Coverage Less Than 80%|72.49%|85.63%|Test coverage cannot be lower than the number of the last release.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.KeyVault</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.MachineLearning</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.ManagedServiceIdentity</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Monitor</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>️✔️Az.Network</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Resources</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyEnrollment|Get-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyEnrollment|Get-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzPolicyEnrollment|New-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|New-AzPolicyEnrollment|New-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Update-AzPolicyEnrollment|Update-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Update-AzPolicyEnrollment|Update-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADGroupOwner|Get-AzADGroupOwner changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzADServicePrincipalAppRoleAssignment|Get-AzADServicePrincipalAppRoleAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryScope|Get-AzDataBoundaryScope changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzDataBoundaryTenant|Get-AzDataBoundaryTenant changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyAssignment|Get-AzPolicyAssignment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyDefinition|Get-AzPolicyDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyEnrollment|Get-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyEnrollment|Get-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicyExemption|Get-AzPolicyExemption changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzPolicySetDefinition|Get-AzPolicySetDefinition changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|New-AzPolicyEnrollment|New-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|New-AzPolicyEnrollment|New-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Update-AzPolicyEnrollment|Update-AzPolicyEnrollment Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Update-AzPolicyEnrollment|Update-AzPolicyEnrollment changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️File Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️UX Metadata Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Get-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Remove-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Module|ResourceType|SubResourceType|Command|Description|
>>|---|---|---|---|---|---|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Get-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>|⚠️|Az.Resources|Microsoft.Resources|subscriptionsResourcegroups|Remove-AzResourceGroup|The path /subscriptions/{subscriptionId}/resourceGroups/{name} doesn't contains the right resource tpye: Microsoft.Resources|
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Description

Replaces #30048, which is now closed. This PR is branched from current `main` and implements @alex-frankel's review feedback from that PR.

### Review feedback being addressed

@alex-frankel, reviewing `Resources.resx` on #30048:

> This reads a bit too much like an ad..
>
> Can we only amend what is there:
>
> > Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)

**What changed as a result:**

- Dropped the separate `NOTICE! - Want to get What-if without noise? Move to ...` line, which was the part that read like an ad.
- Amended the existing `Note:` sentence in place instead of appending a new line, exactly as requested.
- Removed the `https://aka.ms/WhatIfIssues` issue-filing line, so the notice is a single sentence with one next step.
- Adopted the proposed wording **verbatim**, including the parenthesized bare URL and lowercase `what-if`.

Also addresses the automated review note on #30048 that the changelog entry itself still embedded the `aka.ms/WhatIfIssues` URL — the entry has been reworded so no URL remains.

Affected output: `New-AzDeploymentWhatIf` / `New-AzResourceGroupDeploymentWhatIf` and the equivalent subscription, management group, and tenant cmdlets, plus the what-if preview rendered by the deployment create cmdlets.

### Before (current `main`)

```
Note: The result may contain false positive predictions (noise).
You can help us improve the accuracy of the result by opening an issue here: https://aka.ms/WhatIfIssues.
NOTICE! - Want to get What-if without noise? Move to Deployment Stacks What-If https://aka.ms/stackswhatifGA
```

### After

```
Note: The result may contain false positive predictions (noise). For what-if with noise reduction, consider Deployment Stacks (https://aka.ms/stackswhatifGA)
```

### Changes

- `src/Resources/ResourceManager/Properties/Resources.resx` — updated the `WhatIfNoiseNotice` value to the single amended sentence.
- `src/Resources/ResourceManager/Properties/Resources.Designer.cs` — kept the generated doc comment in sync with the `.resx`. Comment only; the accessor is unchanged.
- `src/Resources/Resources/ChangeLog.md` — reworded the existing unreleased entry to describe the final behavior, with no embedded URL.

### Scope / risk

- `WhatIfNoiseNotice` is consumed only by `WhatIfOperationResultFormatter.FormatNoiseNotice()`, which formats `PSWhatIfOperationResult` for **template deployment** what-if.
- Deployment stacks what-if returns `PSDeploymentStackWhatIfResult` and is formatted separately, so it is not touched.
- `https://aka.ms/WhatIfIssues` now has no remaining references under `src/`.
- Tests in `src/Resources/Resources.Test/Formatters/WhatIfOperationResultFormatterTests.cs` assert with `Assert.Contains` / `Assert.EndsWith` against legend, change, stats, and diagnostic content. None include the noise notice, and the `Assert.EndsWith` case targets the trailing stats line while the notice is emitted at the top, so no test updates are required.
- The final string is byte-identical to the one in the companion Azure CLI PR.
