### PR TITLE
[Mission] GA release of Az.Mission 1.0.0 module (Microsoft.Mission 2026-04-01)

### DIFF
--- a/src/Mission/Mission.Autorest/Properties/AssemblyInfo.cs
+++ b/src/Mission/Mission.Autorest/Properties/AssemblyInfo.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: System.Reflection.AssemblyCopyrightAttribute("Copyright © Microsoft")]
 [assembly: System.Reflection.AssemblyProductAttribute("Microsoft Azure PowerShell")]
 [assembly: System.Reflection.AssemblyTitleAttribute("Microsoft Azure PowerShell - Mission")]
-[assembly: System.Reflection.AssemblyFileVersionAttribute("0.1.0")]
-[assembly: System.Reflection.AssemblyVersionAttribute("0.1.0")]
+[assembly: System.Reflection.AssemblyFileVersionAttribute("1.0.0")]
+[assembly: System.Reflection.AssemblyVersionAttribute("1.0.0")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.CLSCompliantAttribute(false)]
 

--- a/src/Mission/Mission.Autorest/README.md
+++ b/src/Mission/Mission.Autorest/README.md
@@ -27,18 +27,18 @@ For information on how to develop for `Az.Mission`, see [how-to.md](how-to.md).
 > see https://aka.ms/autorest
 ``` yaml
 # pin the swagger version by using the commit id instead of branch name
-commit: 342124d3fe26c2499104206005a703695e471eb7
-tag: package-2026-03-01-preview
+commit: ae8bfcbd69fc161651b0509f4869f55376750f1a
+tag: package-2026-04-01
 require:
 # readme.azure.noprofile.md is the common configuration file
   - $(this-folder)/../../readme.azure.noprofile.md
 input-file:
 # You need to specify your swagger files here.
-  - $(repo)/specification/mission/resource-manager/Microsoft.Mission/Mission/preview/2026-03-01-preview/openapi.json
+  - $(repo)/specification/mission/resource-manager/Microsoft.Mission/Mission/stable/2026-04-01/openapi.json
 # Normally, title is the service name
 root-module-name: $(prefix).Mission
 title: Mission
-module-version: 0.1.0
+module-version: 1.0.0
 subject-prefix: Mission
 identity-correction-for-post: true
 

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/approvals.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/approvals.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "approvals",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-communityEndpoints.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-communityEndpoints.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "communities/communityEndpoints",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-dedicatedHubs.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-dedicatedHubs.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "communities/dedicatedHubs",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-transitHubs.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities-transitHubs.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "communities/transitHubs",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/communities.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "communities",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/enclaveConnections.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/enclaveConnections.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "enclaveConnections",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves-enclaveEndpoints.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves-enclaveEndpoints.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "virtualEnclaves/enclaveEndpoints",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves-workloads.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves-workloads.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "virtualEnclaves/workloads",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves.json
+++ b/src/Mission/Mission.Autorest/UX/Microsoft.Mission/virtualEnclaves.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "virtualEnclaves",
-  "apiVersion": "2026-03-01-preview",
+  "apiVersion": "2026-04-01",
   "learnMore": {
     "url": "https://learn.microsoft.com/powershell/module/az.mission"
   },

--- a/src/Mission/Mission.Autorest/test/Get-AzMissionCommunity.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/Get-AzMissionCommunity.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'Get-AzMissionCommunity'))
 }
 
 Describe 'Get-AzMissionCommunity' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'Get' -skip {
         {
             $community = Get-AzMissionCommunity -Name $env.communityName -ResourceGroupName $env.resourceGroup

--- a/src/Mission/Mission.Autorest/test/Get-AzMissionVirtualEnclave.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/Get-AzMissionVirtualEnclave.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'Get-AzMissionVirtualEnclave')
 }
 
 Describe 'Get-AzMissionVirtualEnclave' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'Get' -skip {
         {
             $enclave = Get-AzMissionVirtualEnclave -Name $env.enclaveName -ResourceGroupName $env.resourceGroup

--- a/src/Mission/Mission.Autorest/test/Get-AzMissionWorkload.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/Get-AzMissionWorkload.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'Get-AzMissionWorkload'))
 }
 
 Describe 'Get-AzMissionWorkload' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'Get' -skip {
         {
             $workload = Get-AzMissionWorkload -Name $env.workloadName -ResourceGroupName $env.resourceGroup -VirtualEnclaveName $env.enclaveName

--- a/src/Mission/Mission.Autorest/test/New-AzMissionCommunity.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/New-AzMissionCommunity.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'New-AzMissionCommunity'))
 }
 
 Describe 'New-AzMissionCommunity' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'CreateExpanded' -skip {
         {
             $community = New-AzMissionCommunity -Name $env.communityName -ResourceGroupName $env.resourceGroup -Location $env.location -AddressSpace '10.0.0.0/16'

--- a/src/Mission/Mission.Autorest/test/New-AzMissionVirtualEnclave.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/New-AzMissionVirtualEnclave.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'New-AzMissionVirtualEnclave')
 }
 
 Describe 'New-AzMissionVirtualEnclave' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'CreateExpanded' -skip {
         {
             $enclave = New-AzMissionVirtualEnclave -Name $env.enclaveName -ResourceGroupName $env.resourceGroup -Location $env.location -CommunityResourceId $env.communityResourceId -EnclaveVirtualNetworkName 'enclave-vnet' -EnclaveVirtualNetworkCustomCidrRange '10.0.1.0/24'

--- a/src/Mission/Mission.Autorest/test/New-AzMissionWorkload.Tests.ps1
+++ b/src/Mission/Mission.Autorest/test/New-AzMissionWorkload.Tests.ps1
@@ -15,7 +15,7 @@ if(($null -eq $TestName) -or ($TestName -contains 'New-AzMissionWorkload'))
 }
 
 Describe 'New-AzMissionWorkload' {
-    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission preview subscription.
+    # NOTE: Skipped until a Recording.json is captured against a live Microsoft.Mission subscription.
     It 'CreateExpanded' -skip {
         {
             $workload = New-AzMissionWorkload -Name $env.workloadName -ResourceGroupName $env.resourceGroup -VirtualEnclaveName $env.enclaveName -Location $env.location -ResourceGroupCollection @($env.workloadResourceGroupId)

--- a/src/Mission/Mission/Az.Mission.psd1
+++ b/src/Mission/Mission/Az.Mission.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '1.0.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Core', 'Desktop'
@@ -139,7 +139,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Initial preview release of the Az.Mission module for the Microsoft.Mission (Azure Virtual Enclaves) resource provider.'
+        ReleaseNotes = 'General availability release of the Az.Mission module for the Microsoft.Mission (Azure Virtual Enclaves) resource provider, targeting the stable API version 2026-04-01.'
 
         # Prerelease string of this module
         # Prerelease = ''

--- a/src/Mission/Mission/ChangeLog.md
+++ b/src/Mission/Mission/ChangeLog.md
@@ -19,6 +19,9 @@
 -->
 ## Upcoming Release
 
+## Version 1.0.0
+* General availability release for module Az.Mission targeting the stable Microsoft.Mission API version 2026-04-01
+
 ## Version 0.1.0
 * First preview release for module Az.Mission
 

--- a/src/Mission/Mission/ChangeLog.md
+++ b/src/Mission/Mission/ChangeLog.md
@@ -18,8 +18,6 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
-
-## Version 1.0.0
 * General availability release for module Az.Mission targeting the stable Microsoft.Mission API version 2026-04-01
 
 ## Version 0.1.0

--- a/src/Mission/Mission/Properties/AssemblyInfo.cs
+++ b/src/Mission/Mission/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 [assembly: Guid("5a9d44b1-9b7a-4dbe-a5bc-4e5ecbbfaa5a")]
-[assembly: AssemblyVersion("0.1.0")]
-[assembly: AssemblyFileVersion("0.1.0")]
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0")]


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 18/18 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="18/18" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.Mission</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzMissionApproval|Get-AzMissionApproval Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionApproval|Get-AzMissionApproval changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionCommunity|Get-AzMissionCommunity Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionCommunity|Get-AzMissionCommunity changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionCommunityEndpoint|Get-AzMissionCommunityEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionCommunityEndpoint|Get-AzMissionCommunityEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionDedicatedHub|Get-AzMissionDedicatedHub Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionDedicatedHub|Get-AzMissionDedicatedHub changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionEnclaveConnection|Get-AzMissionEnclaveConnection Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionEnclaveConnection|Get-AzMissionEnclaveConnection changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionEnclaveEndpoint|Get-AzMissionEnclaveEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionEnclaveEndpoint|Get-AzMissionEnclaveEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionTransitHub|Get-AzMissionTransitHub Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionTransitHub|Get-AzMissionTransitHub changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionVirtualEnclave|Get-AzMissionVirtualEnclave Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionVirtualEnclave|Get-AzMissionVirtualEnclave changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionWorkload|Get-AzMissionWorkload Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionWorkload|Get-AzMissionWorkload changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzMissionApproval|Get-AzMissionApproval Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionApproval|Get-AzMissionApproval changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionCommunity|Get-AzMissionCommunity Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionCommunity|Get-AzMissionCommunity changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionCommunityEndpoint|Get-AzMissionCommunityEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionCommunityEndpoint|Get-AzMissionCommunityEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionDedicatedHub|Get-AzMissionDedicatedHub Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionDedicatedHub|Get-AzMissionDedicatedHub changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionEnclaveConnection|Get-AzMissionEnclaveConnection Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionEnclaveConnection|Get-AzMissionEnclaveConnection changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionEnclaveEndpoint|Get-AzMissionEnclaveEndpoint Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionEnclaveEndpoint|Get-AzMissionEnclaveEndpoint changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionTransitHub|Get-AzMissionTransitHub Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionTransitHub|Get-AzMissionTransitHub changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionVirtualEnclave|Get-AzMissionVirtualEnclave Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionVirtualEnclave|Get-AzMissionVirtualEnclave changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzMissionWorkload|Get-AzMissionWorkload Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzMissionWorkload|Get-AzMissionWorkload changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️File Change Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️||AssemblyInfo.cs will be updated automatically. Please do not update it manually.|Revert AssemblyInfo.cs to its last version.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️||AssemblyInfo.cs will be updated automatically. Please do not update it manually.|Revert AssemblyInfo.cs to its last version.|
>>
>></details>
></details>
><details>
> <summary>️✔️UX Metadata Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Test</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Linux</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00 %|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - MacOS</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Title|Current Coverage|Description|
>>|---|---|---|---|
>>|⚠️|Test Coverage Less Than 50%|0.00%|Test coverage for the module cannot be lower than 50%.|
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

### Description

GA release of the **Az.Mission** PowerShell management module for the **Microsoft.Mission** resource provider (Azure Virtual Enclaves / AVE), promoting it from preview to the **stable** API version **2026-04-01**.

The stable `2026-04-01` surface is a byte-for-byte mirror of `2026-03-01-preview` (the preview shipped in #29844), so this is a pure GA promotion — no cmdlet, parameter, or output-type changes.

### What changed

- **AutoRest config repinned to the stable spec** (`Mission.Autorest/README.md`): `commit` -> `ae8bfcbd` (Azure/azure-rest-api-specs#45804 merge), `tag` -> `package-2026-04-01`, `input-file` -> `stable/2026-04-01/openapi.json`, `module-version` -> `1.0.0`.
- **ModuleVersion 0.1.0 -> 1.0.0** (`Az.Mission.psd1` + both `AssemblyInfo.cs`); GA `ReleaseNotes`.
- 9 UX `apiVersion` definitions -> `2026-04-01`; `ChangeLog.md` GA entry.

### Source

Stable API `2026-04-01` merged to `azure-rest-api-specs` main in Azure/azure-rest-api-specs#45804.

### Notes

- Cmdlet surface unchanged from preview: 55 cmdlets across 9 resources (Community, VirtualEnclave, Workload, TransitHub, DedicatedHub, EnclaveConnection, EnclaveEndpoint, CommunityEndpoint, Approval).
- AutoRest directives (variant pruning, `PropertiesAddressSpaces` -> `AddressSpaceList` rename) carried over unchanged.
- RequiredModules: Az.Accounts.