### PR TITLE
Document CFS NuGet restore workaround for Compute tests

### DIFF
--- a/.github/instructions/compute-test-debugging.instructions.md
+++ b/.github/instructions/compute-test-debugging.instructions.md
@@ -218,3 +218,9 @@ Keep entries concise — 1–2 sentences per field. The goal is to give future d
 ## Known Issues
 
 <!-- Entries are added automatically by Step 8 after successful debugging sessions. Do not remove existing entries. -->
+
+### NuGet restore fails because direct access to nuget.org is blocked
+- **Symptom**: `dotnet restore` or `dotnet build` fails with `NU1301: Unable to load the service index for source https://api.nuget.org/v3/index.json` on a Microsoft-managed developer device.
+- **Root cause**: The repository's `NuGet.Config` explicitly lists nuget.org, which takes precedence over the device's otherwise-unconfigured package-manager default. Device policy blocks direct public-registry access and requires public NuGet packages to be restored through the Central Feed Services (CFS) proxy.
+- **Fix**: Do not modify the repository's `NuGet.Config` and do not request a DIRE solely for this failure. Create a temporary NuGet config outside the repository containing the absolute path to `tools/LocalFeed`, the existing `azure-powershell` Azure Artifacts source, and `https://packagefeedproxy.microsoft.io/nuget/v3/index.json` in place of nuget.org. Restore with `dotnet restore src/Compute/Compute.sln --configfile <temp-config>`, then build with `dotnet build src/Compute/Compute.sln --no-restore`.
+- **Files involved**: NuGet.Config, src/Compute/Compute.sln, the temporary NuGet config outside the repository


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ 2/2 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Succeeded" summary="2/2" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Documents the verified workaround for Compute restore failures on Microsoft-managed developer devices where direct access to NuGet.org is blocked.

The new known-issue entry explains why the repository's explicit NuGet.org source bypasses the device's otherwise-unconfigured CFS default and directs developers to use a temporary NuGet configuration outside the repository with the sanctioned CFS proxy. It also preserves the repository configuration and avoids unnecessary DIRE requests.

Validation performed:
- Confirmed `https://packagefeedproxy.microsoft.io/nuget/v3/index.json` returns a valid NuGet v3 service index.
- Restored the complete Compute solution successfully using the temporary configuration.
- Built the Compute solution successfully with `--no-restore`.
- Confirmed the repository working tree remained clean before this documentation change.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell.
  - [ ] General release
  - [ ] Public preview
  - [ ] Private preview
  - [ ] Engineering build
  - [x] No need for a release

- [x] Check this box to confirm: **I have read the _Submitting Changes_ section of `CONTRIBUTING.md` and reviewed the checklist information.**

No changelog or generated help update is needed because this PR changes contributor troubleshooting instructions only.