### PR TITLE
Expose backup storage redundancy for SQL MI LTR backups

### DIFF
--- a/src/Sql/Sql.Test/UnitTests/AzureSqlManagedDatabaseBackupAdapterTests.cs
+++ b/src/Sql/Sql.Test/UnitTests/AzureSqlManagedDatabaseBackupAdapterTests.cs
@@ -1,0 +1,42 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Sql.ManagedDatabaseBackup.Services;
+using Microsoft.Azure.Management.Sql.Models;
+using Microsoft.WindowsAzure.Commands.ScenarioTest;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.Sql.Test.UnitTests
+{
+    public class AzureSqlManagedDatabaseBackupAdapterTests
+    {
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void GetBackupModelMapsBackupStorageRedundancy()
+        {
+            const string resourceId = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Sql/locations/westcentralus/longTermRetentionManagedInstances/test-mi/longTermRetentionDatabases/test-db/longTermRetentionManagedInstanceBackups/test-backup";
+            var backup = new ManagedInstanceLongTermRetentionBackup(
+                id: resourceId,
+                name: "test-backup",
+                managedInstanceName: "test-mi",
+                databaseName: "test-db",
+                backupStorageRedundancy: "Geo");
+
+            var result = AzureSqlManagedDatabaseBackupAdapter.GetBackupModel(backup, "westcentralus");
+
+            Assert.Equal("Geo", result.BackupStorageRedundancy);
+            Assert.Equal("test-rg", result.ResourceGroupName);
+        }
+    }
+}

--- a/src/Sql/Sql/ChangeLog.md
+++ b/src/Sql/Sql/ChangeLog.md
@@ -18,6 +18,7 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+* Exposed the backup storage redundancy type in the output of `Get-AzSqlInstanceDatabaseLongTermRetentionBackup`.
 
 ## Version 7.1.0
 * Added multi-database Managed Instance links through `LinkMode` on `New-AzSqlInstanceLink` and database membership updates on `Update-AzSqlInstanceLink`.

--- a/src/Sql/Sql/ManagedDatabase Backup/Model/AzureSqlManagedDatabaseLongTermRetentionBackupModel.cs
+++ b/src/Sql/Sql/ManagedDatabase Backup/Model/AzureSqlManagedDatabaseLongTermRetentionBackupModel.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Azure.Commands.Sql.ManagedDatabaseBackup.Model
         public DateTime? BackupExpirationTime { get; set; }
 
         /// <summary>
+        /// Gets or sets the storage redundancy type of the backup, such as Geo, Local, Zone, or GeoZone.
+        /// </summary>
+        public string BackupStorageRedundancy { get; set; }
+
+        /// <summary>
         /// Gets or sets the backup name.
         /// </summary>
         public string BackupName { get; set; }

--- a/src/Sql/Sql/ManagedDatabase Backup/Services/AzureSqlManagedDatabaseBackupAdapter.cs
+++ b/src/Sql/Sql/ManagedDatabase Backup/Services/AzureSqlManagedDatabaseBackupAdapter.cs
@@ -271,12 +271,15 @@ namespace Microsoft.Azure.Commands.Sql.ManagedDatabaseBackup.Services
             };
         }
 
-        private AzureSqlManagedDatabaseLongTermRetentionBackupModel GetBackupModel(ManagedInstanceLongTermRetentionBackup backup, string locationName)
+        internal static AzureSqlManagedDatabaseLongTermRetentionBackupModel GetBackupModel(
+            ManagedInstanceLongTermRetentionBackup backup,
+            string locationName)
         {
             return new AzureSqlManagedDatabaseLongTermRetentionBackupModel()
             {
                 BackupExpirationTime = backup.BackupExpirationTime,
                 BackupName = backup.Name,
+                BackupStorageRedundancy = backup.BackupStorageRedundancy,
                 BackupTime = backup.BackupTime,
                 DatabaseDeletionTime = backup.DatabaseDeletionTime,
                 DatabaseName = backup.DatabaseName,
@@ -288,7 +291,7 @@ namespace Microsoft.Azure.Commands.Sql.ManagedDatabaseBackup.Services
             };
         }
 
-        private string GetResourceGroupNameFromResourceId(string resourceId)
+        private static string GetResourceGroupNameFromResourceId(string resourceId)
         {
             if (resourceId.Contains("/resourceGroups/"))
             {


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ️✔️ All clear

| Tests |
| :--: |
| ️✔️ 40/40 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Succeeded" summary="40/40" -->

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

Expose the backup storage redundancy type returned by `Get-AzSqlInstanceDatabaseLongTermRetentionBackup`.

The SQL REST API and generated .NET SDK already return `backupStorageRedundancy`, but the hand-written Managed Instance LTR PowerShell output model did not define the property and the adapter did not map it. This change adds the output property and maps the existing SDK value.

Related work item: https://msdata.visualstudio.com/Database%20Systems/_workitems/edit/5161960/

Validation performed:
- Confirmed the live REST response returns `backupStorageRedundancy` with value `Geo`.
- Added unit coverage for SDK-to-PowerShell model mapping.
- Editor diagnostics reported no errors.
- `git diff --check` passed.

Not run: module build or unit test execution, per the author's request to approve builds first.

## Mandatory Checklist

- Please choose the target release of Azure PowerShell.
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
* **SHOULD** regenerate markdown help files if there is cmdlet API change
* **SHOULD** have proper test coverage for changes in pull request
* **SHOULD NOT** adjust version of module manually in pull request