### PR TITLE
Fix Restore-AzSqlDatabase HA replica count default

### DIFF
--- a/src/Sql/Sql.Test/UnitTests/AzureSqlDatabaseBackupUnitTests.cs
+++ b/src/Sql/Sql.Test/UnitTests/AzureSqlDatabaseBackupUnitTests.cs
@@ -1,0 +1,41 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Sql.Backup.Cmdlet;
+using Microsoft.Azure.ServiceManagement.Common.Models;
+using Microsoft.WindowsAzure.Commands.ScenarioTest;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.Sql.Test.UnitTests
+{
+    public class AzureSqlDatabaseBackupUnitTests
+    {
+        [Theory]
+        [InlineData(false, 0, null)]
+        [InlineData(true, 0, 0)]
+        [InlineData(true, 1, 1)]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void ResolveHighAvailabilityReplicaCountPreservesParameterBinding(
+            bool isParameterBound,
+            int highAvailabilityReplicaCount,
+            int? expected)
+        {
+            Assert.Equal(
+                expected,
+                RestoreAzureRmSqlDatabase.ResolveHighAvailabilityReplicaCount(
+                    isParameterBound,
+                    highAvailabilityReplicaCount));
+        }
+    }
+}

--- a/src/Sql/Sql/ChangeLog.md
+++ b/src/Sql/Sql/ChangeLog.md
@@ -19,6 +19,7 @@
 -->
 ## Upcoming Release
 * Exposed the backup storage redundancy type in the output of `Get-AzSqlInstanceDatabaseLongTermRetentionBackup`.
+* Fixed `Restore-AzSqlDatabase` to omit the HA replica count when the parameter is not specified.
 
 ## Version 7.1.0
 * Added multi-database Managed Instance links through `LinkMode` on `New-AzSqlInstanceLink` and database membership updates on `Update-AzSqlInstanceLink`.

--- a/src/Sql/Sql/Database Backup/Cmdlet/RestoreAzureRMSqlDatabase.cs
+++ b/src/Sql/Sql/Database Backup/Cmdlet/RestoreAzureRMSqlDatabase.cs
@@ -418,7 +418,9 @@ namespace Microsoft.Azure.Commands.Sql.Backup.Cmdlet
                 RequestedBackupStorageRedundancy = BackupStorageRedundancy,
                 Tags = TagsConversionHelper.CreateTagDictionary(Tag, validate: true),
                 ZoneRedundant = this.IsParameterBound(p => p.ZoneRedundant) ? ZoneRedundant.ToBool() : (bool?)null,
-                HighAvailabilityReplicaCount = HAReplicaCount,
+                HighAvailabilityReplicaCount = ResolveHighAvailabilityReplicaCount(
+                    this.IsParameterBound(p => p.HAReplicaCount),
+                    HAReplicaCount),
                 Identity = DatabaseIdentityAndKeysHelper.GetDatabaseIdentity(this.AssignIdentity.IsPresent, this.UserAssignedIdentityId),
                 Keys = DatabaseIdentityAndKeysHelper.GetDatabaseKeysDictionary(this.KeyList),
                 EncryptionProtector = this.EncryptionProtector,
@@ -460,6 +462,11 @@ namespace Microsoft.Azure.Commands.Sql.Backup.Cmdlet
             }
 
             return ModelAdapter.RestoreDatabase(this.ResourceGroupName, restorePointInTime, ResourceId, model, isCrossSubscriptionRestore, auxAuthHeader);
+        }
+
+        internal static int? ResolveHighAvailabilityReplicaCount(bool isParameterBound, int highAvailabilityReplicaCount)
+        {
+            return isParameterBound ? highAvailabilityReplicaCount : (int?)null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

`Restore-AzSqlDatabase` previously assigned the non-nullable `HAReplicaCount` parameter directly to the nullable request model property. When `-HAReplicaCount` was omitted, PowerShell's default `Int32` value caused `highAvailabilityReplicaCount: 0` to be serialized instead of leaving the property unspecified.

This change:

- Sets `HighAvailabilityReplicaCount` only when `-HAReplicaCount` is explicitly bound.
- Preserves explicit values, including `-HAReplicaCount 0`.
- Adds unit coverage for omitted, zero, and nonzero values.

Validation:

- `dotnet test src/Sql/Sql.Test/Sql.Test.csproj --no-restore --filter "FullyQualifiedName~Microsoft.Azure.Commands.Sql.Test.UnitTests"` (58 total, 56 passed, 2 existing skips)
- `dotnet msbuild build.proj /p:Scope=Sql`
- `dotnet msbuild build.proj /t:StaticAnalysis /p:Scope=Sql`

## Mandatory Checklist

- Please choose the target release of Azure PowerShell. (⚠️**Target release** is a different concept from **API readiness**. Please click below links for details.)
  - [x] [General release](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Public preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Private preview](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] [Engineering build](../blob/main/CONTRIBUTING.md#target-release-types)
  - [ ] No need for a release

- [x] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * Update `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`.
        * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense.
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** adjust version of module manually in pull request