### PR TITLE
[ArtifactSigning] Fix token audience resource

### DIFF
--- a/src/ArtifactSigning/ArtifactSigning.Test/ArtifactSigningServiceClientTests.cs
+++ b/src/ArtifactSigning/ArtifactSigning.Test/ArtifactSigningServiceClientTests.cs
@@ -1,0 +1,28 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.ArtifactSigning.Models;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.ArtifactSigning.Test
+{
+    public class ArtifactSigningServiceClientTests
+    {
+        [Fact]
+        public void ArtifactSigningResourceDoesNotHaveTrailingSlash()
+        {
+            Assert.Equal("https://codesigning.azure.net", ArtifactSigningServiceClient.ArtifactSigningResource);
+        }
+    }
+}

--- a/src/ArtifactSigning/ArtifactSigning/Models/ArtifactSigningServiceClient.cs
+++ b/src/ArtifactSigning/ArtifactSigning/Models/ArtifactSigningServiceClient.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Commands.ArtifactSigning.Models
 {
     internal class ArtifactSigningServiceClient : IArtifactSigningServiceClient
     {
+        internal const string ArtifactSigningResource = "https://codesigning.azure.net";
+
         /// <summary>
         /// Parameterless constructor for Mocking.
         /// </summary>
@@ -53,7 +55,7 @@ namespace Microsoft.Azure.Commands.ArtifactSigning.Models
 
         private void Initialize(IAuthenticationFactory authFactory, IAzureContext context)
         {
-            user_creds = new UserSuppliedCredential(new ArtifactSigningServiceCredential(authFactory, context, "https://codesigning.azure.net/"));
+            user_creds = new UserSuppliedCredential(new ArtifactSigningServiceCredential(authFactory, context, ArtifactSigningResource));
         }
 
         private void GetCertificateProfileClient(string endpoint)


### PR DESCRIPTION
<!-- act-bot:pr-validation:start -->
### 🤖 PR Validation — ⚠️ Review suggested

| Tests |
| :--: |
| ⚠️ 18/18 |

<!-- act-bot:section title="PRComment" category="test" label="Tests" status="Warning" summary="18/18" -->
<details>
<summary>️✔️Az.Accounts</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>
<details>
<summary>⚠️Az.ArtifactSigning</summary>

><details>
> <summary>️✔️Build</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Breaking Change Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️Signature Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzArtifactSigningAccount|Get-AzArtifactSigningAccount Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzArtifactSigningAccount|Get-AzArtifactSigningAccount changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzArtifactSigningCertificateProfile|Get-AzArtifactSigningCertificateProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzArtifactSigningCertificateProfile|Get-AzArtifactSigningCertificateProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️|Get-AzArtifactSigningAccount|Get-AzArtifactSigningAccount Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzArtifactSigningAccount|Get-AzArtifactSigningAccount changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>|⚠️|Get-AzArtifactSigningCertificateProfile|Get-AzArtifactSigningCertificateProfile Changes the ConfirmImpact but does not set the SupportsShouldProcess property to true in the cmdlet attribute.|Determine if the cmdlet should implement ShouldProcess and if so determine if it should implement Force / ShouldContinue|
>>|⚠️|Get-AzArtifactSigningCertificateProfile|Get-AzArtifactSigningCertificateProfile changes the confirm impact.  Please ensure that the change in ConfirmImpact is justified|Verify that ConfirmImpact is changed appropriately by the cmdlet. It is very rare for a cmdlet to change the ConfirmImpact.|
>>
>></details>
></details>
><details>
> <summary>️✔️Help File Existence Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>⚠️File Change Check</summary>
>
>><details>
>> <summary>⚠️PowerShell Core - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️||It is required to update ChangeLog.md if you want to release a new version for Az.ArtifactSigning.|Add a changelog record under Upcoming Release section with past tense.|
>>
>></details>
>><details>
>> <summary>⚠️Windows PowerShell - Windows</summary>
>>
>>|Type|Cmdlet|Description|Remediation|
>>|---|---|---|---|
>>|⚠️||It is required to update ChangeLog.md if you want to release a new version for Az.ArtifactSigning.|Add a changelog record under Upcoming Release section with past tense.|
>>
>></details>
></details>
><details>
> <summary>️✔️UX Metadata Check</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
><details>
> <summary>️✔️Test</summary>
>
>><details>
>> <summary>️✔️PowerShell Core - Linux</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - MacOS</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️PowerShell Core - Windows</summary>
>>
>>
>></details>
>><details>
>> <summary>️✔️Windows PowerShell - Windows</summary>
>>
>>
>></details>
></details>
</details>

<!-- act-bot:section-end -->

<!-- act-bot:pr-validation:end -->

## Description

`Az.ArtifactSigning` currently passes `https://codesigning.azure.net/` to `Az.Accounts` as the authentication resource. `Az.Accounts` converts resources to MSAL scopes by appending `/.default`, resulting in the malformed scope `https://codesigning.azure.net//.default` and a token whose audience includes the trailing slash. Artifact Signing endpoints configured with the canonical MISE audience reject that token with `401 Unauthorized` and `invalid_token`.

This change removes the trailing slash so the requested scope is `https://codesigning.azure.net/.default` and the resulting audience is `https://codesigning.azure.net`.

A focused unit test protects the canonical resource value from regressing.

## Testing

- Built the patched `Az.ArtifactSigning` module successfully with no warnings or errors.
- Imported the isolated local build in a fresh PowerShell process.
- `Get-AzArtifactSigningCustomerEku` against the CUS endpoint succeeded and returned the expected EKU; the unpatched 0.2.1 module returns `401 invalid_token` for the same account and profile.
- Added `ArtifactSigningServiceClientTests.ArtifactSigningResourceDoesNotHaveTrailingSlash`.